### PR TITLE
fix: send only parent workloads

### DIFF
--- a/src/lib/kube-scanner/types.ts
+++ b/src/lib/kube-scanner/types.ts
@@ -1,4 +1,13 @@
-import { Apps_v1Api, Batch_v1Api, Batch_v1beta1Api, Core_v1Api, KubeConfig } from '@kubernetes/client-node';
+import { Apps_v1Api, Batch_v1Api, Batch_v1beta1Api, Core_v1Api, KubeConfig,
+  V1Container, V1ObjectMeta, V1OwnerReference } from '@kubernetes/client-node';
+
+export interface KubeObjectMetadata {
+  kind: string;
+  objectMeta: V1ObjectMeta;
+  specMeta: V1ObjectMeta;
+  containers: V1Container[];
+  ownerRefs: V1OwnerReference[];
+}
 
 export interface IK8sClients {
   readonly appsClient: Apps_v1Api;
@@ -11,7 +20,7 @@ export class K8sClients implements IK8sClients {
   public readonly appsClient: Apps_v1Api;
   public readonly coreClient: Core_v1Api;
   public readonly batchClient: Batch_v1Api;
-  // Keep an eye on this! We need v1beta1 API for CronJobs.
+  // TODO: Keep an eye on this! We need v1beta1 API for CronJobs.
   // https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning
   // CronJobs will appear in v2 API, but for now there' only v2alpha1, so it's a bad idea to use it.
   public readonly batchUnstableClient: Batch_v1beta1Api;

--- a/src/lib/kube-scanner/workload-reader.ts
+++ b/src/lib/kube-scanner/workload-reader.ts
@@ -1,0 +1,135 @@
+import { V1OwnerReference } from '@kubernetes/client-node';
+import { keys } from 'lodash';
+import { k8sApi } from './cluster';
+import { KubeObjectMetadata } from './types';
+
+type IWorkloadReaderFunc = (
+  workloadName: string,
+  namespace: string,
+) => Promise<KubeObjectMetadata>;
+
+const deploymentReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
+  const deploymentResult = await k8sApi.appsClient.readNamespacedDeployment(
+    workloadName, namespace);
+  const deployment = deploymentResult.body;
+
+  return {
+    kind: deployment.kind,
+    objectMeta: deployment.metadata,
+    specMeta: deployment.spec.template.metadata,
+    containers: deployment.spec.template.spec.containers,
+    ownerRefs: deployment.metadata.ownerReferences,
+  };
+};
+
+const replicaSetReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
+  const replicaSetResult = await k8sApi.appsClient.readNamespacedReplicaSet(
+    workloadName, namespace);
+  const replicaSet = replicaSetResult.body;
+
+  return {
+    kind: replicaSet.kind,
+    objectMeta: replicaSet.metadata,
+    specMeta: replicaSet.spec.template.metadata,
+    containers: replicaSet.spec.template.spec.containers,
+    ownerRefs: replicaSet.metadata.ownerReferences,
+  };
+};
+
+const statefulSetReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
+  const statefulSetResult = await k8sApi.appsClient.readNamespacedStatefulSet(
+    workloadName, namespace);
+  const statefulSet = statefulSetResult.body;
+
+  return {
+    kind: statefulSet.kind,
+    objectMeta: statefulSet.metadata,
+    specMeta: statefulSet.spec.template.metadata,
+    containers: statefulSet.spec.template.spec.containers,
+    ownerRefs: statefulSet.metadata.ownerReferences,
+  };
+};
+
+const daemonSetReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
+  const daemonSetResult = await k8sApi.appsClient.readNamespacedDaemonSet(
+    workloadName, namespace);
+  const daemonSet = daemonSetResult.body;
+
+  return {
+    kind: daemonSet.kind,
+    objectMeta: daemonSet.metadata,
+    specMeta: daemonSet.spec.template.metadata,
+    containers: daemonSet.spec.template.spec.containers,
+    ownerRefs: daemonSet.metadata.ownerReferences,
+  };
+};
+
+const jobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
+  const jobResult = await k8sApi.batchClient.readNamespacedJob(
+    workloadName, namespace);
+  const job = jobResult.body;
+
+  return {
+    kind: job.kind,
+    objectMeta: job.metadata,
+    specMeta: job.spec.template.metadata,
+    containers: job.spec.template.spec.containers,
+    ownerRefs: job.metadata.ownerReferences,
+  };
+};
+
+// Keep an eye on this! We need v1beta1 API for CronJobs.
+// https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning
+// CronJobs will appear in v2 API, but for now there' only v2alpha1, so it's a bad idea to use it.
+const cronJobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
+  const cronJobResult = await k8sApi.batchUnstableClient.readNamespacedCronJob(
+    workloadName, namespace);
+  const cronJob = cronJobResult.body;
+
+  return {
+    kind: cronJob.kind,
+    objectMeta: cronJob.metadata,
+    specMeta: cronJob.spec.jobTemplate.metadata,
+    containers: cronJob.spec.jobTemplate.spec.template.spec.containers,
+    ownerRefs: cronJob.metadata.ownerReferences,
+  };
+};
+
+const replicationControllerReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
+  const replicationControllerResult = await k8sApi.coreClient.readNamespacedReplicationController(
+    workloadName, namespace);
+  const replicationController = replicationControllerResult.body;
+
+  return {
+    kind: replicationController.kind,
+    objectMeta: replicationController.metadata,
+    specMeta: replicationController.spec.template.metadata,
+    containers: replicationController.spec.template.spec.containers,
+    ownerRefs: replicationController.metadata.ownerReferences,
+  };
+};
+
+// Here we are using the "kind" property of a k8s object as a key to map it to a reader.
+// This gives us a quick look up table where we can abstract away the internal implementation of reading a resource
+// and just grab a generic handler/reader that does that for us (based on the "kind").
+const workloadReader = {
+  Deployment: deploymentReader,
+  ReplicaSet: replicaSetReader,
+  StatefulSet: statefulSetReader,
+  DaemonSet: daemonSetReader,
+  Job: jobReader,
+  CronJob: cronJobReader,
+  ReplicationController: replicationControllerReader,
+};
+
+export const SupportedWorkloadTypes = keys(workloadReader);
+
+export function getWorkloadReader(workloadType: string): IWorkloadReaderFunc {
+  return workloadReader[workloadType];
+}
+
+export function getSupportedWorkload(ownerRefs: V1OwnerReference[] | undefined): V1OwnerReference | undefined {
+  return ownerRefs !== undefined
+    ? ownerRefs.find((owner) => SupportedWorkloadTypes.includes(owner.kind))
+    : undefined;
+}


### PR DESCRIPTION
The monitor was initially written to send every workload that is a direct parent of a pod.
However, this is not the correct approach, and it results uploading loads of temporary objects (temporary in the sense that they are tied to a larger object, like a deployment, so a re-deployment effectively erases the object).

For example, if we had this structure:
Deployment -> 2x ReplicaSet -> Pods
We would be sending the 2x ReplicaSets. Instead, we want the Deployment!

This change attempts to recursively scan up until it finds the topmost workload -- and this is the one that gets sent to homebase.
The lookup stops whenever there are no more parents, or whenever it finds an unsupported workload.

For example:
Deployment -> UnsupportedWorkload -> ReplicaSet -> Pod
If we start from the Pod and look up, we will stop at the UnsupportedWorkload and consider the ReplicaSet the workload that can be inspected.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### More information

- [Jira ticket RUN-244](https://snyksec.atlassian.net/browse/RUN-244)

