### PR TITLE
feat: add support for developing with Tilt

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,12 @@ logfile
 
 selenium-debug.log
 tests_output/
+
+README.md
+Tiltfile
+bin
+scripts
+tap
+snyk-monitor
+*-deployment.yaml
+*-permissions.yaml

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,9 @@
+docker_build("gcr.io/snyk-main/kubernetes-monitor", ".",
+  live_update=[
+    fall_back_on(["package.json", "package-lock.json"]),
+    sync('.', '/src'),
+  ]
+)
+
+k8s_yaml(local("helm template snyk-monitor"))
+watch_file("snyk-monitor")


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

[Tilt](https://tilt.dev/) is a handy development tool for Kubernetes
projects.

What the current configuration supports when you run `tilt up` is:

* Building the Docker image locally
* Running the Helm chart, but swapping out the image reference for the
local one Tilt just build
* Presenting a handy browser and CLI UI which streams the log output
from the pods

More interestingly, Tilt will watch for any changes and reload the
updated parts of the application. For instance:

* If the Dockerfile or application code changes it will rebuild the
image and update the running deployment
* If the Helm Chart configuration changes it will redeploy the updated
resources

### Notes for the reviewer

The following relies on the Helm chart work, but I left in a separate
commit to make the proposed change clear. Happy to chat through, demo
how this works, and then discard or merge as we see fit.

If you'd like to try out before then, install Tilt, grab the changes from #10 and then run `tilt up`.  

### More information

- [Tilt](https://tilt.dev/)
