### PR TITLE
fix: ensure workload props have values

### DIFF
--- a/src/lib/kube-scanner/metadata-extractor.ts
+++ b/src/lib/kube-scanner/metadata-extractor.ts
@@ -5,7 +5,6 @@ import { currentClusterName } from './cluster';
 import { KubeObjectMetadata } from './types';
 import { getSupportedWorkload, getWorkloadReader } from './workload-reader';
 
-const podKindName = 'Pod';
 const loopingThreshold = 20;
 
 // Constructs the workload metadata based on a variety of k8s properties.
@@ -16,13 +15,13 @@ function buildImageMetadata(workloadMeta: KubeObjectMetadata): IKubeImage[] {
   const { name, namespace, labels, annotations, uid } = objectMeta;
   const images = containers.map(({ name: containerName, image }) => ({
       type: kind,
-      name,
+      name: name || 'unknown',
       namespace,
-      labels,
-      annotations,
+      labels: labels || {},
+      annotations: annotations || {},
       uid,
-      specLabels: specMeta.labels,
-      specAnnotations: specMeta.annotations,
+      specLabels: specMeta.labels || {},
+      specAnnotations: specMeta.annotations || {},
       containerName,
       imageName: image,
       cluster: currentClusterName,
@@ -65,7 +64,7 @@ export async function buildMetadataForWorkload(pod: V1Pod): Promise<IKubeImage[]
   // so just return the information directly.
   if (!isAssociatedWithParent) {
     return buildImageMetadata({
-      kind: podKindName, // Reading pod.kind is undefined, so use this
+      kind: 'Pod', // Reading pod.kind may be undefined, so use this
       objectMeta: pod.metadata,
       // Notice the pod.metadata repeats; this is because pods
       // do not have the "template" property.

--- a/src/lib/kube-scanner/workload-reader.ts
+++ b/src/lib/kube-scanner/workload-reader.ts
@@ -14,7 +14,7 @@ const deploymentReader: IWorkloadReaderFunc = async (workloadName, namespace) =>
   const deployment = deploymentResult.body;
 
   return {
-    kind: deployment.kind,
+    kind: 'Deployment',
     objectMeta: deployment.metadata,
     specMeta: deployment.spec.template.metadata,
     containers: deployment.spec.template.spec.containers,
@@ -28,7 +28,7 @@ const replicaSetReader: IWorkloadReaderFunc = async (workloadName, namespace) =>
   const replicaSet = replicaSetResult.body;
 
   return {
-    kind: replicaSet.kind,
+    kind: 'ReplicaSet',
     objectMeta: replicaSet.metadata,
     specMeta: replicaSet.spec.template.metadata,
     containers: replicaSet.spec.template.spec.containers,
@@ -42,7 +42,7 @@ const statefulSetReader: IWorkloadReaderFunc = async (workloadName, namespace) =
   const statefulSet = statefulSetResult.body;
 
   return {
-    kind: statefulSet.kind,
+    kind: 'StatefulSet',
     objectMeta: statefulSet.metadata,
     specMeta: statefulSet.spec.template.metadata,
     containers: statefulSet.spec.template.spec.containers,
@@ -56,7 +56,7 @@ const daemonSetReader: IWorkloadReaderFunc = async (workloadName, namespace) => 
   const daemonSet = daemonSetResult.body;
 
   return {
-    kind: daemonSet.kind,
+    kind: 'DaemonSet',
     objectMeta: daemonSet.metadata,
     specMeta: daemonSet.spec.template.metadata,
     containers: daemonSet.spec.template.spec.containers,
@@ -70,7 +70,7 @@ const jobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
   const job = jobResult.body;
 
   return {
-    kind: job.kind,
+    kind: 'Job',
     objectMeta: job.metadata,
     specMeta: job.spec.template.metadata,
     containers: job.spec.template.spec.containers,
@@ -87,7 +87,7 @@ const cronJobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
   const cronJob = cronJobResult.body;
 
   return {
-    kind: cronJob.kind,
+    kind: 'CronJob',
     objectMeta: cronJob.metadata,
     specMeta: cronJob.spec.jobTemplate.metadata,
     containers: cronJob.spec.jobTemplate.spec.template.spec.containers,
@@ -101,7 +101,7 @@ const replicationControllerReader: IWorkloadReaderFunc = async (workloadName, na
   const replicationController = replicationControllerResult.body;
 
   return {
-    kind: replicationController.kind,
+    kind: 'ReplicationController',
     objectMeta: replicationController.metadata,
     specMeta: replicationController.spec.template.metadata,
     containers: replicationController.spec.template.spec.containers,


### PR DESCRIPTION
According to the k8s docs, some properties of a workload have optional values.
The changes here ensure that we give default values to properties that may be missing.

We explicitly store the `kind` when reading a k8s object and we ensure optional values have at least empty defaults.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### More information

- [Jira ticket RUN-333](https://snyksec.atlassian.net/browse/RUN-333)
