### PR TITLE
fix: add namespaced deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Container to monitor Kubernetes clusters' security
 
 The Snyk monitor (`kubernetes-monitor`) requires some minimal configuration items in order to work correctly.
 
-As with any k8s deployment, a namespace must be provisioned first.
-You can run the following command to create the namespace:
+As with any k8s deployment, the `kubernetes-monitor` runs within a single namespace.
+If you do not already have access to a namespace where you want to deploy the monitor, you can run the following command to create one:
 ```shell
 kubectl create namespace snyk-monitor
 ```
@@ -34,7 +34,8 @@ Both of these items must be provided by a k8s secret. The secret must be called 
 }
 ```
 
-2. Locate your Snyk Integration ID from the Snyk Integrations page (navigate to https://app.snyk.io/org/YOUR-ORGANIZATION-NAME/manage/integrations/kubernetes) and copy it. The Snyk Integration ID looks similar to the following:
+2. Locate your Snyk Integration ID from the Snyk Integrations page (navigate to https://app.snyk.io/org/YOUR-ORGANIZATION-NAME/manage/integrations/kubernetes) and copy it.
+The Snyk Integration ID looks similar to the following:
 ```
 abcd1234-abcd-1234-abcd-1234abcd1234
 ```
@@ -48,10 +49,22 @@ kubectl create secret generic snyk-monitor -n snyk-monitor --from-file=./dockerc
 Note that the secret _must_ be namespaced, and the namespace (which we configured earlier) is called _snyk-monitor_.
 
 
-Next, you can create the necessary `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` required for the monitor's deployment. These objects ensure the monitor has the right (limited) level of access to resources in the cluster. The command is as follows:
+The `kubernetes-monitor` can run in one of two modes: constrained to a single namespace, or with access to the whole cluster.
+In other words, the monitor can scan containers in the namespace, or it can scan all containers in your cluster.
+The choice of which deployment to use depends on the permissions you have on your cluster.
+
+For _cluster_-scoped deployment you can create the necessary `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` required for the monitor's deployment.
+These objects ensure the monitor has the right (limited) level of access to resources in the cluster. The command is as follows:
 ```shell
-kubectl apply -f snyk-monitor-permissions.yaml
+kubectl apply -f snyk-monitor-cluster-permissions.yaml
 ```
+Note that even though the monitor operates in the whole cluster, the `ClusterRole` ensures it can only _read_ or _watch_ resources; the monitor can never modify your objects!
+
+For a _namespaced_ deployment you can create the necessary `ServiceAccount`, `Role`, and `RoleBinding` required for the monitor's deployment:
+```shell
+kubectl apply -f snyk-monitor-namespaced-permissions.yaml
+```
+Similarly to the cluster-scoped deployment, this `Role` ensures the monitor can only _read_ or _watch_ resources, never to modify them!
 
 
 Finally, to launch the Snyk monitor in your cluster, run the following:

--- a/snyk-monitor-cluster-permissions.yaml
+++ b/snyk-monitor-cluster-permissions.yaml
@@ -1,0 +1,75 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: snyk-monitor
+  labels:
+    app.kubernetes.io/name: snyk-monitor
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - daemonsets
+  - deployments
+  - statefulsets
+  verbs:
+  - get
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: snyk-monitor
+  namespace: snyk-monitor
+  labels:
+    app.kubernetes.io/name: snyk-monitor
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snyk-monitor
+  labels:
+    app.kubernetes.io/name: snyk-monitor
+subjects:
+- kind: ServiceAccount
+  name: snyk-monitor
+  namespace: snyk-monitor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: snyk-monitor
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snyk-monitor
+  namespace: snyk-monitor
+data:
+  namespace: ""
+---

--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -32,6 +32,12 @@ spec:
               secretKeyRef:
                 name: snyk-monitor
                 key: integrationId
+          - name: SNYK_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: snyk-monitor
+                key: namespace
+                optional: true
       securityContext: {}
       volumes:
       - name: docker-socket-mount

--- a/snyk-monitor-namespaced-permissions.yaml
+++ b/snyk-monitor-namespaced-permissions.yaml
@@ -1,5 +1,5 @@
 ---
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: snyk-monitor
@@ -12,13 +12,6 @@ rules:
   - pods
   verbs:
   - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - watch
 - apiGroups:
   - ""
   resources:
@@ -50,7 +43,7 @@ metadata:
   labels:
     app.kubernetes.io/name: snyk-monitor
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: snyk-monitor
@@ -62,6 +55,14 @@ subjects:
   namespace: snyk-monitor
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: snyk-monitor
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snyk-monitor
+  namespace: snyk-monitor
+data:
+  namespace: snyk-monitor
 ---

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -237,7 +237,7 @@ Test.prototype.deployMonitor = async (): Promise<string> => {
   const testYaml = 'snyk-monitor-test-deployment.yaml';
   createTestYamlDeployment(testYaml, integrationId);
 
-  await applyK8sYaml('./snyk-monitor-permissions.yaml');
+  await applyK8sYaml('./snyk-monitor-cluster-permissions.yaml');
   await applyK8sYaml('./snyk-monitor-test-deployment.yaml');
 
   try {


### PR DESCRIPTION
Currently the monitor can be deployed using kubectl and the YAML files in the whole cluster.
This may not work for every customer, as it requires permissions/access to the whole cluster.
This works well only if running in KinD or in Minikube, but folks will run into problems when they have access only to a single namespace.

Adding a namespaced deployment file and updated the README to reflect the change.
Some customers will be limited to a single namespace only, which means they can now deploy the monitor within that namespace!

- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### More information

- [Jira ticket RUN-307](https://snyksec.atlassian.net/browse/RUN-307)
