### PR TITLE
fix: tone down image scans

### DIFF
--- a/src/lib/kube-scanner/watchers/handlers.ts
+++ b/src/lib/kube-scanner/watchers/handlers.ts
@@ -26,7 +26,7 @@ async function handleRemovedPod(
 
 export async function podWatchHandler(eventType: string, pod: V1Pod) {
   // This tones down the number of scans whenever a Pod is about to be scheduled by K8s
-  if (eventType === WatchEventType.Modified && !isPodReady(pod)) {
+  if (eventType !== WatchEventType.Deleted && !isPodReady(pod)) {
     return;
   }
 
@@ -73,6 +73,8 @@ export async function podWatchHandler(eventType: string, pod: V1Pod) {
   }
 }
 
-export function isPodReady(pod) {
-  return pod.status.phase === PodPhase.Running;
+export function isPodReady(pod: V1Pod) {
+  return pod.status.phase === PodPhase.Running &&
+    pod.status.containerStatuses.some((container) =>
+      container.state.running !== undefined || container.state.waiting !== undefined);
 }


### PR DESCRIPTION
Add a slightly more accurate way of deciding when to scan images in a Pod, reducing the number of extra scans by at least 1.

There is still one small caveat because of how Kubernetes fires events:
On deleting a Pod, Kubernetes first fires a MODIFIED event before firing a DELETED event.
We can't distinguish this MODIFIED event from a regular one so we don't know if a Pod is about to be deleted.
This results in an extra scan and then eventually deleting of the Pod. There is no fix for this (maybe we can do something smart about it in the future).

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### More information

- [Jira ticket RUN-353](https://snyksec.atlassian.net/browse/RUN-353)
