### PR TITLE
feat: watch all workloads for DELETED events

### DIFF
--- a/snyk-monitor-cluster-permissions.yaml
+++ b/snyk-monitor-cluster-permissions.yaml
@@ -25,6 +25,7 @@ rules:
   - replicationcontrollers
   verbs:
   - get
+  - watch
 - apiGroups:
   - batch
   resources:
@@ -32,6 +33,7 @@ rules:
   - jobs
   verbs:
   - get
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -41,6 +43,7 @@ rules:
   - statefulsets
   verbs:
   - get
+  - watch
 ---
 kind: ServiceAccount
 apiVersion: v1

--- a/snyk-monitor-namespaced-permissions.yaml
+++ b/snyk-monitor-namespaced-permissions.yaml
@@ -12,12 +12,14 @@ rules:
   - pods
   verbs:
   - list
+  - watch
 - apiGroups:
   - ""
   resources:
   - replicationcontrollers
   verbs:
   - get
+  - watch
 - apiGroups:
   - batch
   resources:
@@ -25,6 +27,7 @@ rules:
   - jobs
   verbs:
   - get
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -34,6 +37,7 @@ rules:
   - statefulsets
   verbs:
   - get
+  - watch
 ---
 kind: ServiceAccount
 apiVersion: v1

--- a/snyk-monitor/templates/clusterrole.yaml
+++ b/snyk-monitor/templates/clusterrole.yaml
@@ -22,6 +22,7 @@ rules:
   - replicationcontrollers
   verbs:
   - get
+  - watch
 - apiGroups:
   - batch
   resources:
@@ -29,6 +30,7 @@ rules:
   - jobs
   verbs:
   - get
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -38,4 +40,5 @@ rules:
   - statefulsets
   verbs:
   - get
+  - watch
 {{- end }}

--- a/snyk-monitor/templates/role.yaml
+++ b/snyk-monitor/templates/role.yaml
@@ -22,6 +22,7 @@ rules:
   - replicationcontrollers
   verbs:
   - get
+  - watch
 - apiGroups:
   - batch
   resources:
@@ -29,6 +30,7 @@ rules:
   - jobs
   verbs:
   - get
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -38,4 +40,5 @@ rules:
   - statefulsets
   verbs:
   - get
+  - watch
 {{- end }}

--- a/src/lib/kube-scanner/metadata-extractor.ts
+++ b/src/lib/kube-scanner/metadata-extractor.ts
@@ -8,7 +8,7 @@ const loopingThreshold = 20;
 
 // Constructs the workload metadata based on a variety of k8s properties.
 // https://www.notion.so/snyk/Kubernetes-workload-fields-we-should-collect-c60c8f0395f241978282173f4c133a34
-function buildImageMetadata(workloadMeta: KubeObjectMetadata): IKubeImage[] {
+export function buildImageMetadata(workloadMeta: KubeObjectMetadata): IKubeImage[] {
   const { kind, objectMeta, specMeta, containers } = workloadMeta;
 
   const { name, namespace, labels, annotations, uid } = objectMeta;

--- a/src/lib/kube-scanner/watchers/handlers/cron-job.ts
+++ b/src/lib/kube-scanner/watchers/handlers/cron-job.ts
@@ -1,0 +1,20 @@
+import { V1beta1CronJob } from '@kubernetes/client-node';
+import * as uuidv4 from 'uuid/v4';
+import { WatchEventType } from '../types';
+import { deleteWorkload } from './index';
+
+export async function cronJobWatchHandler(eventType: string, cronJob: V1beta1CronJob) {
+  if (eventType !== WatchEventType.Deleted) {
+    return;
+  }
+
+  const logId = uuidv4().substring(0, 8);
+
+  await deleteWorkload({
+    kind: 'CronJob',
+    objectMeta: cronJob.metadata,
+    specMeta: cronJob.spec.jobTemplate.metadata,
+    containers: cronJob.spec.jobTemplate.spec.template.spec.containers,
+    ownerRefs: cronJob.metadata.ownerReferences,
+  }, logId);
+}

--- a/src/lib/kube-scanner/watchers/handlers/daemon-set.ts
+++ b/src/lib/kube-scanner/watchers/handlers/daemon-set.ts
@@ -1,0 +1,20 @@
+import { V1DaemonSet } from '@kubernetes/client-node';
+import * as uuidv4 from 'uuid/v4';
+import { WatchEventType } from '../types';
+import { deleteWorkload } from './index';
+
+export async function daemonSetWatchHandler(eventType: string, daemonSet: V1DaemonSet) {
+  if (eventType !== WatchEventType.Deleted) {
+    return;
+  }
+
+  const logId = uuidv4().substring(0, 8);
+
+  await deleteWorkload({
+    kind: 'DaemonSet',
+    objectMeta: daemonSet.metadata,
+    specMeta: daemonSet.spec.template.metadata,
+    containers: daemonSet.spec.template.spec.containers,
+    ownerRefs: daemonSet.metadata.ownerReferences,
+  }, logId);
+}

--- a/src/lib/kube-scanner/watchers/handlers/deployment.ts
+++ b/src/lib/kube-scanner/watchers/handlers/deployment.ts
@@ -1,0 +1,20 @@
+import { V1Deployment } from '@kubernetes/client-node';
+import * as uuidv4 from 'uuid/v4';
+import { WatchEventType } from '../types';
+import { deleteWorkload } from './index';
+
+export async function deploymentWatchHandler(eventType: string, deployment: V1Deployment) {
+  if (eventType !== WatchEventType.Deleted) {
+    return;
+  }
+
+  const logId = uuidv4().substring(0, 8);
+
+  await deleteWorkload({
+    kind: 'Deployment',
+    objectMeta: deployment.metadata,
+    specMeta: deployment.spec.template.metadata,
+    containers: deployment.spec.template.spec.containers,
+    ownerRefs: deployment.metadata.ownerReferences,
+  }, logId);
+}

--- a/src/lib/kube-scanner/watchers/handlers/index.ts
+++ b/src/lib/kube-scanner/watchers/handlers/index.ts
@@ -1,0 +1,19 @@
+import WorkloadWorker = require('../../../kube-scanner');
+import { buildImageMetadata } from '../../metadata-extractor';
+import { KubeObjectMetadata } from '../../types';
+
+export async function deleteWorkload(kubernetesMetadata: KubeObjectMetadata, logId: string) {
+  try {
+    if (kubernetesMetadata.ownerRefs !== undefined && kubernetesMetadata.ownerRefs.length > 0) {
+      return;
+    }
+
+    const workloadMetadata = buildImageMetadata(kubernetesMetadata);
+    const workloadWorker = new WorkloadWorker(logId);
+    await workloadWorker.delete(workloadMetadata);
+    console.log(`${logId}: Removed the following images: ${workloadMetadata.map((workload) => workload.imageName)}`);
+  } catch (error) {
+    console.log(`${logId}: Could not delete the ${kubernetesMetadata.kind} ${kubernetesMetadata.objectMeta.name}: ` +
+      JSON.stringify(error));
+  }
+}

--- a/src/lib/kube-scanner/watchers/handlers/job.ts
+++ b/src/lib/kube-scanner/watchers/handlers/job.ts
@@ -1,0 +1,20 @@
+import { V1Job } from '@kubernetes/client-node';
+import * as uuidv4 from 'uuid/v4';
+import { WatchEventType } from '../types';
+import { deleteWorkload } from './index';
+
+export async function jobWatchHandler(eventType: string, job: V1Job) {
+  if (eventType !== WatchEventType.Deleted) {
+    return;
+  }
+
+  const logId = uuidv4().substring(0, 8);
+
+  await deleteWorkload({
+    kind: 'Job',
+    objectMeta: job.metadata,
+    specMeta: job.spec.template.metadata,
+    containers: job.spec.template.spec.containers,
+    ownerRefs: job.metadata.ownerReferences,
+  }, logId);
+}

--- a/src/lib/kube-scanner/watchers/handlers/replica-set.ts
+++ b/src/lib/kube-scanner/watchers/handlers/replica-set.ts
@@ -1,0 +1,20 @@
+import { V1ReplicaSet } from '@kubernetes/client-node';
+import * as uuidv4 from 'uuid/v4';
+import { WatchEventType } from '../types';
+import { deleteWorkload } from './index';
+
+export async function replicaSetWatchHandler(eventType: string, replicaSet: V1ReplicaSet) {
+  if (eventType !== WatchEventType.Deleted) {
+    return;
+  }
+
+  const logId = uuidv4().substring(0, 8);
+
+  await deleteWorkload({
+    kind: 'ReplicaSet',
+    objectMeta: replicaSet.metadata,
+    specMeta: replicaSet.spec.template.metadata,
+    containers: replicaSet.spec.template.spec.containers,
+    ownerRefs: replicaSet.metadata.ownerReferences,
+  }, logId);
+}

--- a/src/lib/kube-scanner/watchers/handlers/replication-controller.ts
+++ b/src/lib/kube-scanner/watchers/handlers/replication-controller.ts
@@ -1,0 +1,21 @@
+import { V1ReplicationController } from '@kubernetes/client-node';
+import * as uuidv4 from 'uuid/v4';
+import { WatchEventType } from '../types';
+import { deleteWorkload } from './index';
+
+export async function replicationControllerWatchHandler(
+    eventType: string, replicationController: V1ReplicationController) {
+  if (eventType !== WatchEventType.Deleted) {
+    return;
+  }
+
+  const logId = uuidv4().substring(0, 8);
+
+  await deleteWorkload({
+    kind: 'ReplicationController',
+    objectMeta: replicationController.metadata,
+    specMeta: replicationController.spec.template.metadata,
+    containers: replicationController.spec.template.spec.containers,
+    ownerRefs: replicationController.metadata.ownerReferences,
+  }, logId);
+}

--- a/src/lib/kube-scanner/watchers/handlers/stateful-set.ts
+++ b/src/lib/kube-scanner/watchers/handlers/stateful-set.ts
@@ -1,0 +1,20 @@
+import { V1StatefulSet } from '@kubernetes/client-node';
+import * as uuidv4 from 'uuid/v4';
+import { WatchEventType } from '../types';
+import { deleteWorkload } from './index';
+
+export async function statefulSetWatchHandler(eventType: string, statefulSet: V1StatefulSet) {
+  if (eventType !== WatchEventType.Deleted) {
+    return;
+  }
+
+  const logId = uuidv4().substring(0, 8);
+
+  await deleteWorkload({
+    kind: 'StatefulSet',
+    objectMeta: statefulSet.metadata,
+    specMeta: statefulSet.spec.template.metadata,
+    containers: statefulSet.spec.template.spec.containers,
+    ownerRefs: statefulSet.metadata.ownerReferences,
+  }, logId);
+}

--- a/src/lib/kube-scanner/watchers/namespaces.ts
+++ b/src/lib/kube-scanner/watchers/namespaces.ts
@@ -2,7 +2,14 @@ import * as k8s from '@kubernetes/client-node';
 import { V1Namespace } from '@kubernetes/client-node';
 import config = require('../../../common/config');
 import { kubeConfig } from '../cluster';
-import { podWatchHandler } from './handlers';
+import { cronJobWatchHandler } from './handlers/cron-job';
+import { daemonSetWatchHandler } from './handlers/daemon-set';
+import { deploymentWatchHandler } from './handlers/deployment';
+import { jobWatchHandler } from './handlers/job';
+import { podWatchHandler } from './handlers/pod';
+import { replicaSetWatchHandler } from './handlers/replica-set';
+import { replicationControllerWatchHandler } from './handlers/replication-controller';
+import { statefulSetWatchHandler } from './handlers/stateful-set';
 import { WatchEventType } from './types';
 
 const watches = {
@@ -10,12 +17,17 @@ const watches = {
 
 const k8sWatch = new k8s.Watch(kubeConfig);
 
+function genericErrorHandler(error) {
+  const errorMessage = error.message ? error.message : error;
+  console.log(`An error occurred during Pod watch: ${errorMessage}`);
+}
+
 function deleteWatchesForNamespace(namespace: string) {
   console.log(`Stopping watching for changes to namespace ${namespace}`);
 
   if (watches[namespace] !== undefined) {
     try {
-      watches[namespace].abort();
+      watches[namespace].forEach((watch) => watch.abort());
       delete watches[namespace];
     } catch (error) {
       console.log(`Error: could not stop watch for namespace ${namespace}`);
@@ -26,11 +38,24 @@ function deleteWatchesForNamespace(namespace: string) {
 function setupWatchesForNamespace(namespace: string) {
   console.log(`Attempting to watch for changes to namespace ${namespace}...`);
   const queryOptions = {};
-  watches[namespace] = k8sWatch.watch(`/api/v1/namespaces/${namespace}/pods`,
-    queryOptions, podWatchHandler, (error) => {
-      const errorMessage = error.message ? error.message : error;
-      console.log(`An error occurred during Pod watch: ${errorMessage}`);
-    });
+  watches[namespace] = [
+    k8sWatch.watch(`/api/v1/namespaces/${namespace}/pods`,
+      queryOptions, podWatchHandler, genericErrorHandler),
+    k8sWatch.watch(`/apis/apps/v1/watch/namespaces/${namespace}/deployments`,
+      queryOptions, deploymentWatchHandler, genericErrorHandler),
+    k8sWatch.watch(`/apis/apps/v1/watch/namespaces/${namespace}/replicasets`,
+      queryOptions, replicaSetWatchHandler, genericErrorHandler),
+    k8sWatch.watch(`/apis/apps/v1/watch/namespaces/${namespace}/daemonsets`,
+      queryOptions, daemonSetWatchHandler, genericErrorHandler),
+    k8sWatch.watch(`/apis/apps/v1/watch/namespaces/${namespace}/statefulsets`,
+      queryOptions, statefulSetWatchHandler, genericErrorHandler),
+    k8sWatch.watch(`/apis/batch/v1beta1/watch/namespaces/${namespace}/cronjobs`,
+      queryOptions, cronJobWatchHandler, genericErrorHandler),
+    k8sWatch.watch(`/apis/batch/v1/watch/namespaces/${namespace}/jobs`,
+      queryOptions, jobWatchHandler, genericErrorHandler),
+    k8sWatch.watch(`/api/v1/watch/namespaces/${namespace}/replicationcontrollers`,
+      queryOptions, replicationControllerWatchHandler, genericErrorHandler),
+  ];
   console.log(`Watching for changes to namespace ${namespace}`);
 }
 


### PR DESCRIPTION
When a workload is deleted, we need to notify Homebase so that it has an updated view of what can be imported.

The current approach of just listening for Pod changes doesn't work, because Kubernetes doesn't notify a Pod when its parent owner is killed (e.g. when the Deployment is deleted).

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### More information

- [Jira ticket RUN-366](https://snyksec.atlassian.net/browse/RUN-366)
