### PR TITLE
chore: send a slack message when a PR to master opens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
       name: build the kubernetes-monitor image
       # TODO: run integration tests with the image we just built, then mark it as test-passed
     - stage: pre-publish
-      if: branch = master AND type = pull_request
+      if: branch = master AND type = pull_request AND head_branch = staging
       script: "curl -X POST -H \"Content-Type:application/json\" -d \"{\\\"attachments\\\": [{\\\"color\\\": \\\"warning\\\", \\\"fallback\\\": \\\"Build Notification: $TRAVIS_BUILD_WEB_URL\\\", \\\"title\\\": \\\"Kubernetes-Monitor Publish Notification\\\", \\\"text\\\": \\\":egg: A new version is about to be published! :egg:\nhttps://github.com/$TRAVIS_PULL_REQUEST_SLUG/pull/$TRAVIS_PULL_REQUEST\nbranch of origin is $TRAVIS_PULL_REQUEST_BRANCH\\\"}]}\" $SLACK_WEBHOOK"
       name: pre-publish notification
     - stage: Publish


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

sends a slack message on PRs to the master branch, to notify the team a release may take place soon.
use an insane backspacing for all these quotation marks, otherwise it doesn't work.

also allow merging to ```master``` only from ```staging```
this is achieved by not running the job if the "source" branch (```head_branch```) is not ```staging```, meaning Travis will never send the success for the PR event, not allowing us to merge it.

### More information

https://snyksec.atlassian.net/browse/RUN-373
https://docs.travis-ci.com/user/conditions-v1#integration

### Screenshots

from #runtime-deployment
![image](https://user-images.githubusercontent.com/1255387/62005841-bf2e8b80-b141-11e9-8791-daa2461cfdd5.png)

