### PR TITLE
chore: moving our image to snyk org in dockerhub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
     - stage: Build
       if: branch = staging AND type = push
       # we will need to change the tag to test-candidate, then use the image, then re-tag to test-approved
-      script: docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} && docker build -t sheseksnyk/kubernetes-monitor:test-approved --no-cache . && docker push sheseksnyk/kubernetes-monitor:test-approved
+      script: docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} && docker build -t snyk/kubernetes-monitor:test-approved --no-cache . && docker push snyk/kubernetes-monitor:test-approved
       name: build the kubernetes-monitor image
       # TODO: run integration tests with the image we just built, then mark it as test-passed
     - stage: pre-publish
@@ -42,7 +42,7 @@ jobs:
       name: pre-publish notification
     - stage: Publish
       if: branch = master AND type = push
-      script: docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} && docker pull sheseksnyk/kubernetes-monitor:test-approved && docker tag sheseksnyk/kubernetes-monitor:test-approved sheseksnyk/kubernetes-monitor:latest && docker push sheseksnyk/kubernetes-monitor:latest
+      script: docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} && docker pull snyk/kubernetes-monitor:test-approved && docker tag snyk/kubernetes-monitor:test-approved snyk/kubernetes-monitor:latest && docker push snyk/kubernetes-monitor:latest
       name: publish the kubernetes-monitor (npm, container, helm)
 branches:
   only:

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,4 +1,4 @@
-docker_build("sheseksnyk/kubernetes-monitor", ".",
+docker_build("snyk/kubernetes-monitor", ".",
   live_update=[
     fall_back_on(["package.json", "package-lock.json"]),
     sync('.', '/src'),

--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app.kubernetes.io/name: snyk-monitor
     spec:
       containers:
-      - image: sheseksnyk/kubernetes-monitor:latest
+      - image: snyk/kubernetes-monitor:latest
         imagePullPolicy: Always
         name: snyk-monitor
         terminationMessagePath: /dev/termination-log

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -13,7 +13,7 @@ scope: Cluster
 
 # The registry from which to pull the snyk-monitor image.
 image:
-  repository: sheseksnyk/kubernetes-monitor
+  repository: snyk/kubernetes-monitor
   tag: latest
   pullPolicy: Always
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

move the org we use to host our images from ```sheseksnyk``` to ```snyk```.
same repo name (kubernetes-monitor), just a different org.

part of prod-readiness.