### PR TITLE
feat: add environment variable to override default homebase url

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -7,8 +7,6 @@
     "INITIAL_REFRESH_MS": 1000
   },
   "INTEGRATION_ID": "203210a3-1de0-4ed3-b6a6-3acd24b71639",
-  "HOMEBASE": {
-    "url": "https://homebase.dev.snyk.io"
-  },
+  "HOMEBASE_URL": "https://homebase.snyk.io",
   "NAMESPACE": ""
 }

--- a/snyk-monitor-cluster-permissions.yaml
+++ b/snyk-monitor-cluster-permissions.yaml
@@ -72,4 +72,5 @@ metadata:
   namespace: snyk-monitor
 data:
   namespace: ""
+  homebaseUrl: ""
 ---

--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -38,6 +38,12 @@ spec:
                 name: snyk-monitor
                 key: namespace
                 optional: true
+          - name: SNYK_HOMEBASE_URL
+            valueFrom:
+              configMapKeyRef:
+                name: snyk-monitor
+                key: homebaseUrl
+                optional: true
       securityContext: {}
       volumes:
       - name: docker-socket-mount

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
                 key: integrationId
           - name: SNYK_NAMESPACE
             value: {{ include "snyk-monitor.scope" . }}
+          - name: SNYK_HOMEBASE_URL
+            value: {{ .Values.homebaseUrl }}
       volumes:
         - name: docker-socket-mount
           hostPath:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -11,6 +11,9 @@ monitorSecrets: snyk-monitor
 # Namespaced - creates a Role and RoleBinding with the ServiceAccount
 scope: Cluster
 
+# The endpoint that being used to transmit monitored information
+homebaseUrl: ""
+
 # The registry from which to pull the snyk-monitor image.
 image:
   repository: snyk/kubernetes-monitor

--- a/src/transmitter/index.ts
+++ b/src/transmitter/index.ts
@@ -9,7 +9,7 @@ function isSuccessStatusCode(statusCode: number | undefined): boolean {
 export async function sendDepGraph(...payloads: IDepGraphPayload[]) {
   for (const payload of payloads) {
     try {
-      const result = await needle('post', `${config.HOMEBASE.url}/api/v1/dependency-graph`, payload, {
+      const result = await needle('post', `${config.HOMEBASE_URL}/api/v1/dependency-graph`, payload, {
           json: true,
           compressed: true,
         },
@@ -29,7 +29,7 @@ export async function sendDepGraph(...payloads: IDepGraphPayload[]) {
 export async function deleteHomebaseWorkload(payloads: IDeleteImagePayload[]) {
   for (const payload of payloads) {
     try {
-      const result = await needle('delete', `${config.HOMEBASE.url}/api/v1/image`, payload, {
+      const result = await needle('delete', `${config.HOMEBASE_URL}/api/v1/image`, payload, {
           json: true,
           compressed: true,
         },

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -141,6 +141,12 @@ function createTestYamlDeployment(newYamlPath: string, integrationId: string): v
     value: integrationId,
   };
 
+  // Inject the baseUrl of homebase that snyk-monitor container use to send metadata
+  deployment.spec.template.spec.containers[0].env[2] = {
+    name: 'SNYK_HOMEBASE_URL',
+    value: 'https://homebase.dev.snyk.io',
+  };
+
   writeFileSync(newYamlPath, stringify(deployment));
   console.log('Created test deployment!');
 }


### PR DESCRIPTION
Currently, kubernetes-monitor sends monitored metadata to dev homebase only. 
The goal of this PR is to provide additional env variable (SNYK_HOMEBASE_URL) which will override the default homebase url (production). 