### PR TITLE
fix: supply env variable to override default value

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -7,6 +7,6 @@
     "INITIAL_REFRESH_MS": 1000
   },
   "INTEGRATION_ID": "203210a3-1de0-4ed3-b6a6-3acd24b71639",
-  "HOMEBASE_URL": "https://homebase.snyk.io",
+  "DEFAULT_HOMEBASE_URL": "https://homebase.snyk.io",
   "NAMESPACE": ""
 }

--- a/snyk-monitor-cluster-permissions.yaml
+++ b/snyk-monitor-cluster-permissions.yaml
@@ -72,5 +72,5 @@ metadata:
   namespace: snyk-monitor
 data:
   namespace: ""
-  homebaseUrl: ""
+  integrationApi: ""
 ---

--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -38,11 +38,11 @@ spec:
                 name: snyk-monitor
                 key: namespace
                 optional: true
-          - name: SNYK_HOMEBASE_URL
+          - name: SNYK_INTEGRATION_API
             valueFrom:
               configMapKeyRef:
                 name: snyk-monitor
-                key: homebaseUrl
+                key: integrationApi
                 optional: true
       securityContext: {}
       volumes:

--- a/snyk-monitor-namespaced-permissions.yaml
+++ b/snyk-monitor-namespaced-permissions.yaml
@@ -65,4 +65,5 @@ metadata:
   namespace: snyk-monitor
 data:
   namespace: snyk-monitor
+  integrationApi: ""
 ---

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -40,8 +40,8 @@ spec:
                 key: integrationId
           - name: SNYK_NAMESPACE
             value: {{ include "snyk-monitor.scope" . }}
-          - name: SNYK_HOMEBASE_URL
-            value: {{ .Values.homebaseUrl }}
+          - name: SNYK_INTEGRATION_API
+            value: {{ .Values.integrationApi }}
       volumes:
         - name: docker-socket-mount
           hostPath:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -12,7 +12,7 @@ monitorSecrets: snyk-monitor
 scope: Cluster
 
 # The endpoint that being used to transmit monitored information
-homebaseUrl: ""
+integrationApi: ""
 
 # The registry from which to pull the snyk-monitor image.
 image:

--- a/src/transmitter/index.ts
+++ b/src/transmitter/index.ts
@@ -2,6 +2,8 @@ import needle = require('needle');
 import * as config from '../common/config';
 import { IDeleteImagePayload, IDepGraphPayload } from './types';
 
+const homebaseUrl = config.INTEGRATION_API || config.DEFAULT_HOMEBASE_URL;
+
 function isSuccessStatusCode(statusCode: number | undefined): boolean {
   return statusCode !== undefined && statusCode > 100 && statusCode < 400;
 }
@@ -9,7 +11,7 @@ function isSuccessStatusCode(statusCode: number | undefined): boolean {
 export async function sendDepGraph(...payloads: IDepGraphPayload[]) {
   for (const payload of payloads) {
     try {
-      const result = await needle('post', `${config.HOMEBASE_URL}/api/v1/dependency-graph`, payload, {
+      const result = await needle('post', `${homebaseUrl}/api/v1/dependency-graph`, payload, {
           json: true,
           compressed: true,
         },
@@ -29,7 +31,7 @@ export async function sendDepGraph(...payloads: IDepGraphPayload[]) {
 export async function deleteHomebaseWorkload(payloads: IDeleteImagePayload[]) {
   for (const payload of payloads) {
     try {
-      const result = await needle('delete', `${config.HOMEBASE_URL}/api/v1/image`, payload, {
+      const result = await needle('delete', `${homebaseUrl}/api/v1/image`, payload, {
           json: true,
           compressed: true,
         },

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -143,7 +143,7 @@ function createTestYamlDeployment(newYamlPath: string, integrationId: string): v
 
   // Inject the baseUrl of homebase that snyk-monitor container use to send metadata
   deployment.spec.template.spec.containers[0].env[2] = {
-    name: 'SNYK_HOMEBASE_URL',
+    name: 'SNYK_INTEGRATION_API',
     value: 'https://homebase.dev.snyk.io',
   };
 


### PR DESCRIPTION
homebaseUrl environment variable value was set to an empty string which forced us to type the exact URL in the kubernetes-monitor installation.
The PR solves it by setting a new env variable while depending on the default value set in the config JSON file
