### PR TITLE
test: deleted workloads integration test

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -121,6 +121,12 @@ export async function applyK8sYaml(pathToYamlDeployment: string): Promise<void> 
   console.log(`Applied ${pathToYamlDeployment}!`);
 }
 
+export async function deleteDeployment(deploymentName: string, namespace: string) {
+  console.log(`Deleting deployment ${deploymentName} in namespace ${namespace}...`);
+  await exec(`./kubectl delete deployment ${deploymentName} -n ${namespace}`);
+  console.log(`Deleted deployment ${deploymentName}!`);
+}
+
 function createTestYamlDeployment(newYamlPath: string, integrationId: string): void {
   console.log('Creating test deployment...');
   const originalDeploymentYaml = readFileSync('./snyk-monitor-deployment.yaml', 'utf8');


### PR DESCRIPTION
Delete a deployment and validate that the snyk-monitor sends the data up to Homebase.
Changed validateHomebaseStoredData() so that it also accepts a relative URL, because the test needs only a different API endpoint.

- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

- [Jira ticket RUN-366](https://snyksec.atlassian.net/browse/RUN-366)
