### PR TITLE
feat: limit how many workloads are being scanned concurrently

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -6,6 +6,7 @@
   "MONITOR": {
     "INITIAL_REFRESH_MS": 1000
   },
+  "WORKLOADS_TO_SCAN_QUEUE_WORKER_COUNT": 10,
   "INTEGRATION_ID": "203210a3-1de0-4ed3-b6a6-3acd24b71639",
   "HOMEBASE_URL": "https://homebase.snyk.io",
   "NAMESPACE": ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -217,6 +217,11 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/async": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.0.1.tgz",
+      "integrity": "sha512-fBq+1+btw/4CPGCpp3B05vUsslyikLUSUoZmFEjjHrUEPOisIVxUzGJFg1k43iWq9y0lC2UDqWAlg5ynUCwwSA=="
+    },
     "@types/body-parser": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
@@ -465,6 +470,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
     },
     "async-limiter": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "private": true,
   "dependencies": {
     "@kubernetes/client-node": "^0.8.2",
+    "@types/async": "^3.0.1",
     "@types/body-parser": "^1.17.0",
     "@types/child-process-promise": "^2.2.1",
     "@types/compression": "0.0.36",
@@ -29,6 +30,7 @@
     "@types/raven": "^2.5.1",
     "@types/request": "^2.48.1",
     "@types/response-time": "^2.3.3",
+    "async": "^2.6.2",
     "body-parser": "^1.18.3",
     "child-process-promise": "^2.2.1",
     "compression": "^1.7.3",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

whenever we receive an event from k8s-api about pod changes, we begin processing it.
this means we start pulling all the images involved, then scanning them, then constructing payloads, which we then send to Homebase, without limiting the count of pod changes we handle concurrently.
this causes the memory consumption to explode, because we (should) release memory only after sending data to Homebase, which happens very late in the process.

this commit attempts to alleviate the memory consumption by limiting the number of pod changes that we handle concurrently.
only after sending results to Homebase will we have the capacity of starting to handle new pod changes.

an important note is that while we're limiting the number of pods, we're not limiting the number of images, which may vary from pod to pod.

### Notes for the reviewer

easiest way to check locally I could find:
1. tune the number of concurrent tasks to something lower (maybe even 1 or 2)
2. let our integration tests set up a Kind cluster (for example breakpoint on the beginning of one of the tests, and start a ```Tap current file```.
3. set the ```KUBECONFIG``` env var so ```kubectl``` may be used, for example ```KUBECONFIG=/Users/amir/.kube/kind-config-kind```
4. use ```kubectl``` to look at the monitor's logs, which may be enhanced before-hand to give more visibility to the amount of concurrent things being processed.

### More information

https://snyksec.atlassian.net/browse/RUN-387