### PR TITLE
fix: extract namespace name from namespace object

### DIFF
--- a/test/unit/watchers.test.ts
+++ b/test/unit/watchers.test.ts
@@ -1,0 +1,26 @@
+import * as tap from 'tap';
+import { V1Namespace } from '@kubernetes/client-node';
+
+import namespaces = require('../../src/kube-scanner/watchers/namespaces');
+
+tap.test('SupportedWorkloadTypes', async (t) => {
+  const namespaceEmpty = {} as V1Namespace;
+  t.throws(() => namespaces.extractNamespaceName(namespaceEmpty),
+    'extractNamespaceName throws on empty input');
+
+  const namespaceMetadataEmpty = {metadata: {}} as V1Namespace;
+  t.throws(() => namespaces.extractNamespaceName(namespaceMetadataEmpty),
+    'extractNamespaceName throws on empty metadata');
+
+  const namespaceNameUndefined = {metadata: {name: undefined}} as V1Namespace;
+  t.throws(() => namespaces.extractNamespaceName(namespaceNameUndefined),
+    'extractNamespaceName throws on undefined name');
+
+  const namespaceNameFalsy = {metadata: {name: ''}} as V1Namespace;
+  t.throws(() => namespaces.extractNamespaceName(namespaceNameFalsy),
+    'extractNamespaceName throws on empty name');
+
+  const namespaceNameExists = {metadata: {name: 'literally anything else'}} as V1Namespace;
+  t.equals(namespaces.extractNamespaceName(namespaceNameExists), 'literally anything else',
+    'extractNamespaceName returns namespace.metadata.name');
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

- use a safer way to extract the name
- log with more information on unexpected (and expected) errors when watching namespace changes

### More information

https://snyk.slack.com/archives/CDSMEJ29E/p1565186857135400