### PR TITLE
Fix/k8s internal namespaces

### DIFF
--- a/src/kube-scanner/watchers/namespaces.ts
+++ b/src/kube-scanner/watchers/namespaces.ts
@@ -67,7 +67,9 @@ export function beginWatchingWorkloads() {
     (eventType: string, namespace: V1Namespace) => {
       try {
         const namespaceName = extractNamespaceName(namespace);
-        if (namespaceName.startsWith('kube')) {
+        if (isKubernetesInternalNamespace(namespaceName)) {
+          // disregard namespaces internal to kubernetes
+          logger.info({namespaceName}, 'ignoring blacklisted namespace');
           return;
         }
 
@@ -102,4 +104,14 @@ export function extractNamespaceName(namespace: V1Namespace): string {
     return namespace.metadata.name;
   }
   throw new Error('Namespace missing metadata.name');
+}
+
+export function isKubernetesInternalNamespace(namespace: string): boolean {
+  const kubernetesInternalNamespaces = [
+    'kube-node-lease',
+    'kube-public',
+    'kube-system',
+  ];
+
+  return kubernetesInternalNamespaces.includes(namespace);
 }

--- a/test/unit/watchers.test.ts
+++ b/test/unit/watchers.test.ts
@@ -24,3 +24,24 @@ tap.test('extractNamespaceName', async (t) => {
   t.equals(namespaces.extractNamespaceName(namespaceNameExists), 'literally anything else',
     'extractNamespaceName returns namespace.metadata.name');
 });
+
+tap.test('isKubernetesInternalNamespace', async (t) => {
+  t.ok(namespaces.isKubernetesInternalNamespace('kube-node-lease'),
+    'kube-node-lease is a k8s internal namespace');
+  t.ok(namespaces.isKubernetesInternalNamespace('kube-public'),
+    'kube-public is a k8s internal namespace');
+  t.ok(namespaces.isKubernetesInternalNamespace('kube-system'),
+    'kube-system is a k8s internal namespace');
+  t.notOk(namespaces.isKubernetesInternalNamespace('kube-node-lease-'),
+    'kube-node-lease- is not a k8s internal namespace');
+  t.notOk(namespaces.isKubernetesInternalNamespace('node-lease'),
+    'kubenode-lease is not a k8s internal namespace');
+  t.notOk(namespaces.isKubernetesInternalNamespace('snyk-monitor'),
+    'snyk-monitor is not a k8s internal namespace');
+  t.notOk(namespaces.isKubernetesInternalNamespace('egg'),
+    'egg is not a k8s internal namespace');
+  t.notOk(namespaces.isKubernetesInternalNamespace(''),
+    'empty string is not a k8s internal namespace');
+  t.notOk(namespaces.isKubernetesInternalNamespace(undefined as unknown as string),
+    'undefined is not a k8s internal namespace');
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

instead of ignoring all namespaces starting with ```kube```,
ignore just ```kube-node-lease```, ```kube-public```,```kube-system```.