### PR TITLE
fix: use enum for workload kind

### DIFF
--- a/src/kube-scanner/types.ts
+++ b/src/kube-scanner/types.ts
@@ -1,6 +1,17 @@
 import { AppsV1Api, BatchV1Api, BatchV1beta1Api, CoreV1Api, KubeConfig,
   V1Container, V1ObjectMeta, V1OwnerReference } from '@kubernetes/client-node';
 
+export enum WorkloadKind {
+  Deployment = 'Deployment',
+  ReplicaSet = 'ReplicaSet',
+  StatefulSet = 'StatefulSet',
+  DaemonSet = 'DaemonSet',
+  Job = 'Job',
+  CronJob = 'CronJob',
+  ReplicationController = 'ReplicationController',
+  Pod = 'Pod',
+}
+
 export interface KubeObjectMetadata {
   kind: string;
   objectMeta: V1ObjectMeta;

--- a/src/kube-scanner/watchers/handlers/cron-job.ts
+++ b/src/kube-scanner/watchers/handlers/cron-job.ts
@@ -2,6 +2,7 @@ import { V1beta1CronJob } from '@kubernetes/client-node';
 import * as uuidv4 from 'uuid/v4';
 import { WatchEventType } from '../types';
 import { deleteWorkload } from './index';
+import { WorkloadKind } from '../../types';
 
 export async function cronJobWatchHandler(eventType: string, cronJob: V1beta1CronJob) {
   if (eventType !== WatchEventType.Deleted) {
@@ -17,7 +18,7 @@ export async function cronJobWatchHandler(eventType: string, cronJob: V1beta1Cro
   }
 
   await deleteWorkload({
-    kind: 'CronJob',
+    kind: WorkloadKind.CronJob,
     objectMeta: cronJob.metadata,
     specMeta: cronJob.spec.jobTemplate.metadata,
     containers: cronJob.spec.jobTemplate.spec.template.spec.containers,

--- a/src/kube-scanner/watchers/handlers/daemon-set.ts
+++ b/src/kube-scanner/watchers/handlers/daemon-set.ts
@@ -2,6 +2,7 @@ import { V1DaemonSet } from '@kubernetes/client-node';
 import * as uuidv4 from 'uuid/v4';
 import { WatchEventType } from '../types';
 import { deleteWorkload } from './index';
+import { WorkloadKind } from '../../types';
 
 export async function daemonSetWatchHandler(eventType: string, daemonSet: V1DaemonSet) {
   if (eventType !== WatchEventType.Deleted) {
@@ -17,7 +18,7 @@ export async function daemonSetWatchHandler(eventType: string, daemonSet: V1Daem
   }
 
   await deleteWorkload({
-    kind: 'DaemonSet',
+    kind: WorkloadKind.DaemonSet,
     objectMeta: daemonSet.metadata,
     specMeta: daemonSet.spec.template.metadata,
     containers: daemonSet.spec.template.spec.containers,

--- a/src/kube-scanner/watchers/handlers/deployment.ts
+++ b/src/kube-scanner/watchers/handlers/deployment.ts
@@ -2,6 +2,7 @@ import { V1Deployment } from '@kubernetes/client-node';
 import * as uuidv4 from 'uuid/v4';
 import { WatchEventType } from '../types';
 import { deleteWorkload } from './index';
+import { WorkloadKind } from '../../types';
 
 export async function deploymentWatchHandler(eventType: string, deployment: V1Deployment) {
   if (eventType !== WatchEventType.Deleted) {
@@ -17,7 +18,7 @@ export async function deploymentWatchHandler(eventType: string, deployment: V1De
   }
 
   await deleteWorkload({
-    kind: 'Deployment',
+    kind: WorkloadKind.Deployment,
     objectMeta: deployment.metadata,
     specMeta: deployment.spec.template.metadata,
     containers: deployment.spec.template.spec.containers,

--- a/src/kube-scanner/watchers/handlers/job.ts
+++ b/src/kube-scanner/watchers/handlers/job.ts
@@ -2,6 +2,7 @@ import { V1Job } from '@kubernetes/client-node';
 import * as uuidv4 from 'uuid/v4';
 import { WatchEventType } from '../types';
 import { deleteWorkload } from './index';
+import { WorkloadKind } from '../../types';
 
 export async function jobWatchHandler(eventType: string, job: V1Job) {
   if (eventType !== WatchEventType.Deleted) {
@@ -16,7 +17,7 @@ export async function jobWatchHandler(eventType: string, job: V1Job) {
   }
 
   await deleteWorkload({
-    kind: 'Job',
+    kind: WorkloadKind.Job,
     objectMeta: job.metadata,
     specMeta: job.spec.template.metadata,
     containers: job.spec.template.spec.containers,

--- a/src/kube-scanner/watchers/handlers/replica-set.ts
+++ b/src/kube-scanner/watchers/handlers/replica-set.ts
@@ -2,6 +2,7 @@ import { V1ReplicaSet } from '@kubernetes/client-node';
 import * as uuidv4 from 'uuid/v4';
 import { WatchEventType } from '../types';
 import { deleteWorkload } from './index';
+import { WorkloadKind } from '../../types';
 
 export async function replicaSetWatchHandler(eventType: string, replicaSet: V1ReplicaSet) {
   if (eventType !== WatchEventType.Deleted) {
@@ -17,7 +18,7 @@ export async function replicaSetWatchHandler(eventType: string, replicaSet: V1Re
   }
 
   await deleteWorkload({
-    kind: 'ReplicaSet',
+    kind: WorkloadKind.ReplicaSet,
     objectMeta: replicaSet.metadata,
     specMeta: replicaSet.spec.template.metadata,
     containers: replicaSet.spec.template.spec.containers,

--- a/src/kube-scanner/watchers/handlers/replication-controller.ts
+++ b/src/kube-scanner/watchers/handlers/replication-controller.ts
@@ -2,6 +2,7 @@ import { V1ReplicationController } from '@kubernetes/client-node';
 import * as uuidv4 from 'uuid/v4';
 import { WatchEventType } from '../types';
 import { deleteWorkload } from './index';
+import { WorkloadKind } from '../../types';
 
 export async function replicationControllerWatchHandler(
     eventType: string, replicationController: V1ReplicationController) {
@@ -18,7 +19,7 @@ export async function replicationControllerWatchHandler(
   }
 
   await deleteWorkload({
-    kind: 'ReplicationController',
+    kind: WorkloadKind.ReplicationController,
     objectMeta: replicationController.metadata,
     specMeta: replicationController.spec.template.metadata,
     containers: replicationController.spec.template.spec.containers,

--- a/src/kube-scanner/watchers/handlers/stateful-set.ts
+++ b/src/kube-scanner/watchers/handlers/stateful-set.ts
@@ -2,6 +2,7 @@ import { V1StatefulSet } from '@kubernetes/client-node';
 import * as uuidv4 from 'uuid/v4';
 import { WatchEventType } from '../types';
 import { deleteWorkload } from './index';
+import { WorkloadKind } from '../../types';
 
 export async function statefulSetWatchHandler(eventType: string, statefulSet: V1StatefulSet) {
   if (eventType !== WatchEventType.Deleted) {
@@ -17,7 +18,7 @@ export async function statefulSetWatchHandler(eventType: string, statefulSet: V1
   }
 
   await deleteWorkload({
-    kind: 'StatefulSet',
+    kind: WorkloadKind.StatefulSet,
     objectMeta: statefulSet.metadata,
     specMeta: statefulSet.spec.template.metadata,
     containers: statefulSet.spec.template.spec.containers,

--- a/src/kube-scanner/watchers/namespaces.ts
+++ b/src/kube-scanner/watchers/namespaces.ts
@@ -12,6 +12,7 @@ import { replicaSetWatchHandler } from './handlers/replica-set';
 import { replicationControllerWatchHandler } from './handlers/replication-controller';
 import { statefulSetWatchHandler } from './handlers/stateful-set';
 import { ILooseObject, WatchEventType } from './types';
+import { WorkloadKind } from '../types';
 
 const watches = {
 };
@@ -36,21 +37,21 @@ function setupWatchesForNamespace(namespace: string) {
   const queryOptions = {};
   watches[namespace] = [
     k8sWatch.watch(`/api/v1/namespaces/${namespace}/pods`,
-      queryOptions, podWatchHandler, watchEndHandler(namespace, 'pods')),
+      queryOptions, podWatchHandler, watchEndHandler(namespace, WorkloadKind.Pod)),
     k8sWatch.watch(`/apis/apps/v1/watch/namespaces/${namespace}/deployments`,
-      queryOptions, deploymentWatchHandler, watchEndHandler(namespace, 'deployments')),
+      queryOptions, deploymentWatchHandler, watchEndHandler(namespace, WorkloadKind.Deployment)),
     k8sWatch.watch(`/apis/apps/v1/watch/namespaces/${namespace}/replicasets`,
-      queryOptions, replicaSetWatchHandler, watchEndHandler(namespace, 'replicasets')),
+      queryOptions, replicaSetWatchHandler, watchEndHandler(namespace, WorkloadKind.ReplicaSet)),
     k8sWatch.watch(`/apis/apps/v1/watch/namespaces/${namespace}/daemonsets`,
-      queryOptions, daemonSetWatchHandler, watchEndHandler(namespace, 'daemonsets')),
+      queryOptions, daemonSetWatchHandler, watchEndHandler(namespace, WorkloadKind.DaemonSet)),
     k8sWatch.watch(`/apis/apps/v1/watch/namespaces/${namespace}/statefulsets`,
-      queryOptions, statefulSetWatchHandler, watchEndHandler(namespace, 'statefulsets')),
+      queryOptions, statefulSetWatchHandler, watchEndHandler(namespace, WorkloadKind.StatefulSet)),
     k8sWatch.watch(`/apis/batch/v1beta1/watch/namespaces/${namespace}/cronjobs`,
-      queryOptions, cronJobWatchHandler, watchEndHandler(namespace, 'cronjobs')),
+      queryOptions, cronJobWatchHandler, watchEndHandler(namespace, WorkloadKind.CronJob)),
     k8sWatch.watch(`/apis/batch/v1/watch/namespaces/${namespace}/jobs`,
-      queryOptions, jobWatchHandler, watchEndHandler(namespace, 'jobs')),
+      queryOptions, jobWatchHandler, watchEndHandler(namespace, WorkloadKind.Job)),
     k8sWatch.watch(`/api/v1/watch/namespaces/${namespace}/replicationcontrollers`,
-      queryOptions, replicationControllerWatchHandler, watchEndHandler(namespace, 'replicationcontrollers')),
+      queryOptions, replicationControllerWatchHandler, watchEndHandler(namespace, WorkloadKind.ReplicationController)),
   ];
 }
 

--- a/src/kube-scanner/workload-reader.ts
+++ b/src/kube-scanner/workload-reader.ts
@@ -1,6 +1,6 @@
 import { V1OwnerReference } from '@kubernetes/client-node';
 import { k8sApi } from './cluster';
-import { KubeObjectMetadata } from './types';
+import { KubeObjectMetadata, WorkloadKind } from './types';
 
 type IWorkloadReaderFunc = (
   workloadName: string,
@@ -19,7 +19,7 @@ const deploymentReader: IWorkloadReaderFunc = async (workloadName, namespace) =>
   }
 
   return {
-    kind: 'Deployment',
+    kind: WorkloadKind.Deployment,
     objectMeta: deployment.metadata,
     specMeta: deployment.spec.template.metadata,
     containers: deployment.spec.template.spec.containers,
@@ -39,7 +39,7 @@ const replicaSetReader: IWorkloadReaderFunc = async (workloadName, namespace) =>
   }
 
   return {
-    kind: 'ReplicaSet',
+    kind: WorkloadKind.ReplicaSet,
     objectMeta: replicaSet.metadata,
     specMeta: replicaSet.spec.template.metadata,
     containers: replicaSet.spec.template.spec.containers,
@@ -59,7 +59,7 @@ const statefulSetReader: IWorkloadReaderFunc = async (workloadName, namespace) =
   }
 
   return {
-    kind: 'StatefulSet',
+    kind: WorkloadKind.StatefulSet,
     objectMeta: statefulSet.metadata,
     specMeta: statefulSet.spec.template.metadata,
     containers: statefulSet.spec.template.spec.containers,
@@ -79,7 +79,7 @@ const daemonSetReader: IWorkloadReaderFunc = async (workloadName, namespace) => 
   }
 
   return {
-    kind: 'DaemonSet',
+    kind: WorkloadKind.DaemonSet,
     objectMeta: daemonSet.metadata,
     specMeta: daemonSet.spec.template.metadata,
     containers: daemonSet.spec.template.spec.containers,
@@ -98,7 +98,7 @@ const jobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
   }
 
   return {
-    kind: 'Job',
+    kind: WorkloadKind.Job,
     objectMeta: job.metadata,
     specMeta: job.spec.template.metadata,
     containers: job.spec.template.spec.containers,
@@ -121,7 +121,7 @@ const cronJobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
   }
 
   return {
-    kind: 'CronJob',
+    kind: WorkloadKind.CronJob,
     objectMeta: cronJob.metadata,
     specMeta: cronJob.spec.jobTemplate.metadata,
     containers: cronJob.spec.jobTemplate.spec.template.spec.containers,
@@ -141,7 +141,7 @@ const replicationControllerReader: IWorkloadReaderFunc = async (workloadName, na
   }
 
   return {
-    kind: 'ReplicationController',
+    kind: WorkloadKind.ReplicationController,
     objectMeta: replicationController.metadata,
     specMeta: replicationController.spec.template.metadata,
     containers: replicationController.spec.template.spec.containers,
@@ -153,13 +153,13 @@ const replicationControllerReader: IWorkloadReaderFunc = async (workloadName, na
 // This gives us a quick look up table where we can abstract away the internal implementation of reading a resource
 // and just grab a generic handler/reader that does that for us (based on the "kind").
 const workloadReader = {
-  Deployment: deploymentReader,
-  ReplicaSet: replicaSetReader,
-  StatefulSet: statefulSetReader,
-  DaemonSet: daemonSetReader,
-  Job: jobReader,
-  CronJob: cronJobReader,
-  ReplicationController: replicationControllerReader,
+  [WorkloadKind.Deployment]: deploymentReader,
+  [WorkloadKind.ReplicaSet]: replicaSetReader,
+  [WorkloadKind.StatefulSet]: statefulSetReader,
+  [WorkloadKind.DaemonSet]: daemonSetReader,
+  [WorkloadKind.Job]: jobReader,
+  [WorkloadKind.CronJob]: cronJobReader,
+  [WorkloadKind.ReplicationController]: replicationControllerReader,
 };
 
 export const SupportedWorkloadTypes = Object.keys(workloadReader);

--- a/test/integration/kubernetes.test.ts
+++ b/test/integration/kubernetes.test.ts
@@ -7,6 +7,7 @@ import * as tap from 'tap';
 import * as config from '../../src/common/config';
 import { IWorkloadLocator } from '../../src/transmitter/types';
 import { getKindConfigPath } from '../helpers/kind';
+import { WorkloadKind } from '../../src/kube-scanner/types';
 
 let integrationId: string;
 const toneDownFactor = 5;
@@ -97,11 +98,11 @@ tap.test('snyk-monitor sends data to homebase', async (t) => {
     return workloads !== undefined && workloads.length === 3 &&
       workloads.every((workload) => workload.userLocator === integrationId) &&
       workloads.every((workload) => workload.cluster.indexOf('Default cluster') !== -1) &&
-      workloads.find((workload) => workload.name === 'alpine' && workload.type === 'Pod'
+      workloads.find((workload) => workload.name === 'alpine' && workload.type === WorkloadKind.Pod
       && workload.namespace === 'services') !== undefined &&
-      workloads.find((workload) => workload.name === 'nginx' && workload.type === 'ReplicationController'
+      workloads.find((workload) => workload.name === 'nginx' && workload.type === WorkloadKind.ReplicationController
       && workload.namespace === 'services') !== undefined &&
-      workloads.find((workload) => workload.name === 'redis' && workload.type === 'Deployment'
+      workloads.find((workload) => workload.name === 'redis' && workload.type === WorkloadKind.Deployment
       && workload.namespace === 'services') !== undefined;
   };
 
@@ -118,7 +119,7 @@ tap.test('snyk-monitor sends correct data to homebase after adding another deplo
 
   const validatorFn: WorkloadLocatorValidator = (workloads) => {
     return workloads !== undefined &&
-      workloads.find((workload) => workload.name === 'nginx-deployment' && workload.type === 'Deployment'
+      workloads.find((workload) => workload.name === 'nginx-deployment' && workload.type === WorkloadKind.Deployment
       && workload.namespace === 'services') !== undefined;
   };
 
@@ -130,7 +131,7 @@ tap.test('snyk-monitor sends deleted workload to homebase', async (t) => {
   // First ensure the deployment exists from the previous test
   const deploymentValidatorFn: WorkloadLocatorValidator = (workloads) => {
     return workloads !== undefined &&
-      workloads.find((workload) => workload.name === 'nginx-deployment' && workload.type === 'Deployment'
+      workloads.find((workload) => workload.name === 'nginx-deployment' && workload.type === WorkloadKind.Deployment
       && workload.namespace === 'services') !== undefined;
   };
 


### PR DESCRIPTION
The names of the workloads (e.g. 'Deployment', 'CronJob') are starting to repeat a few times now so gather them in an enum.
This is a "fix" instead of a "chore" because it also affects our log messages (e.g. 'replicasets' becomes 'ReplicaSet').

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
