### PR TITLE
test: move our integration tests to /api/v2/workloads/...

### DIFF
--- a/test/integration/kubernetes.test.ts
+++ b/test/integration/kubernetes.test.ts
@@ -96,18 +96,17 @@ tap.test('snyk-monitor sends data to homebase', async (t) => {
 
   const validatorFn: WorkloadLocatorValidator = (workloads) => {
     return workloads !== undefined && workloads.length === 3 &&
-      workloads.every((workload) => workload.userLocator === integrationId) &&
-      workloads.every((workload) => workload.cluster.indexOf('Default cluster') !== -1) &&
-      workloads.find((workload) => workload.name === 'alpine' && workload.type === WorkloadKind.Pod
-      && workload.namespace === 'services') !== undefined &&
-      workloads.find((workload) => workload.name === 'nginx' && workload.type === WorkloadKind.ReplicationController
-      && workload.namespace === 'services') !== undefined &&
-      workloads.find((workload) => workload.name === 'redis' && workload.type === WorkloadKind.Deployment
-      && workload.namespace === 'services') !== undefined;
+      workloads.find((workload) => workload.name === 'alpine' &&
+        workload.type === WorkloadKind.Pod) !== undefined &&
+      workloads.find((workload) => workload.name === 'nginx' &&
+        workload.type === WorkloadKind.ReplicationController) !== undefined &&
+      workloads.find((workload) => workload.name === 'redis' &&
+        workload.type === WorkloadKind.Deployment) !== undefined;
   };
 
   // We don't want to spam Homebase with requests; do it infrequently
-  const homebaseTestResult = await validateHomebaseStoredData(validatorFn, `api/v1/workloads/${integrationId}`);
+  const homebaseTestResult = await validateHomebaseStoredData(
+    validatorFn, `api/v2/workloads/${integrationId}/Default cluster/services`);
   t.ok(homebaseTestResult, 'snyk-monitor sent expected data to homebase in the expected timeframe');
 });
 
@@ -119,11 +118,12 @@ tap.test('snyk-monitor sends correct data to homebase after adding another deplo
 
   const validatorFn: WorkloadLocatorValidator = (workloads) => {
     return workloads !== undefined &&
-      workloads.find((workload) => workload.name === 'nginx-deployment' && workload.type === WorkloadKind.Deployment
-      && workload.namespace === 'services') !== undefined;
+      workloads.find((workload) => workload.name === 'nginx-deployment' &&
+        workload.type === WorkloadKind.Deployment) !== undefined;
   };
 
-  const homebaseTestResult = await validateHomebaseStoredData(validatorFn, `api/v1/workloads/${integrationId}`);
+  const homebaseTestResult = await validateHomebaseStoredData(
+    validatorFn, `api/v2/workloads/${integrationId}/Default cluster/services`);
   t.ok(homebaseTestResult, 'snyk-monitor sent expected data to homebase in the expected timeframe');
 });
 
@@ -131,12 +131,12 @@ tap.test('snyk-monitor sends deleted workload to homebase', async (t) => {
   // First ensure the deployment exists from the previous test
   const deploymentValidatorFn: WorkloadLocatorValidator = (workloads) => {
     return workloads !== undefined &&
-      workloads.find((workload) => workload.name === 'nginx-deployment' && workload.type === WorkloadKind.Deployment
-      && workload.namespace === 'services') !== undefined;
+      workloads.find((workload) => workload.name === 'nginx-deployment' &&
+        workload.type === WorkloadKind.Deployment) !== undefined;
   };
 
   const homebaseTestResult = await validateHomebaseStoredData(deploymentValidatorFn,
-    `api/v1/workloads/${integrationId}`);
+    `api/v2/workloads/${integrationId}/Default cluster/services`);
   t.ok(homebaseTestResult, 'snyk-monitor sent expected data to homebase in the expected timeframe');
 
   const deploymentName = 'nginx-deployment';


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Homebase's /api/v1/workloads/:userID is deprecated and should no longer be in use. it was used by the non-projects-at-scale API (/apps) from kubernets-agent, but /apps has been removed.
this will allow us to remove /api/v1/workloads from Homebase and delete more unused code.