### PR TITLE
fix: redundant log line

### DIFF
--- a/src/kube-scanner/watchers/handlers/pod.ts
+++ b/src/kube-scanner/watchers/handlers/pod.ts
@@ -71,7 +71,6 @@ export async function podWatchHandler(eventType: string, pod: V1Pod) {
       case WatchEventType.Bookmark:
         break;
       case WatchEventType.Deleted:
-        logger.info({logId, podName: pod.metadata!.name}, 'DELETED event occurred for the Pod, skipping scanning');
         break;
       default:
         break;


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

we don't care events where pods are deleted, no point logging them.
