### PR TITLE
chore: attempt to notify in slack after pushing new images to dockerhub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,16 @@ jobs:
     - stage: Build
       if: branch = staging AND type = push
       # we will need to change the tag to test-candidate, then use the image, then re-tag to test-approved
-      script: docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} && docker build -t snyk/kubernetes-monitor:test-approved --no-cache . && docker push snyk/kubernetes-monitor:test-approved
+      script: docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} && docker build -t snyk/kubernetes-monitor:test-approved --no-cache . && docker push snyk/kubernetes-monitor:test-approved && ./scripts/slack-notify-push.sh test-approved
       name: build the kubernetes-monitor image
       # TODO: run integration tests with the image we just built, then mark it as test-passed
     - stage: pre-publish
       if: branch = master AND type = pull_request AND head_branch = staging
-      script: "curl -X POST -H \"Content-Type:application/json\" -d \"{\\\"attachments\\\": [{\\\"color\\\": \\\"warning\\\", \\\"fallback\\\": \\\"Build Notification: $TRAVIS_BUILD_WEB_URL\\\", \\\"title\\\": \\\"Kubernetes-Monitor Publish Notification\\\", \\\"text\\\": \\\":egg: A new version is about to be published! :egg:\nhttps://github.com/$TRAVIS_PULL_REQUEST_SLUG/pull/$TRAVIS_PULL_REQUEST\nbranch of origin is $TRAVIS_PULL_REQUEST_BRANCH\\\"}]}\" $SLACK_WEBHOOK"
+      script: ./scripts/slack-notify-pr.sh
       name: pre-publish notification
     - stage: Publish
       if: branch = master AND type = push
-      script: docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} && docker pull snyk/kubernetes-monitor:test-approved && docker tag snyk/kubernetes-monitor:test-approved snyk/kubernetes-monitor:latest && docker push snyk/kubernetes-monitor:latest
+      script: docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} && docker pull snyk/kubernetes-monitor:test-approved && docker tag snyk/kubernetes-monitor:test-approved snyk/kubernetes-monitor:latest && docker push snyk/kubernetes-monitor:latest && ./scripts/slack-notify-push.sh latest
       name: publish the kubernetes-monitor (npm, container, helm)
 branches:
   only:

--- a/scripts/slack-notify-pr.sh
+++ b/scripts/slack-notify-pr.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "warning", "fallback": "Build Notification: $TRAVIS_BUILD_WEB_URL", "title": "Kubernetes-Monitor Publish Notification", "text": ":egg: A new version is about to be published! :egg:\nhttps://github.com/$TRAVIS_PULL_REQUEST_SLUG/pull/$TRAVIS_PULL_REQUEST\nbranch of origin is $TRAVIS_PULL_REQUEST_BRANCH"}]}' $SLACK_WEBHOOK

--- a/scripts/slack-notify-push.sh
+++ b/scripts/slack-notify-push.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "warning", "fallback": "Build Notification: $TRAVIS_BUILD_WEB_URL", "title": "Kubernetes-Monitor Publish Notification", "text": ":egg_fancy: Published Kubernetes-Monitor with tag: '$1' :egg_fancy:"}]}' $SLACK_WEBHOOK


### PR DESCRIPTION
send a slack notification whenever we push an image to dockerhub.
happens when we merge to ```staging``` (with ```test-approved```) or ```master``` (with ```latest```)