### PR TITLE
fix: log workload name instead of random log ID

### DIFF
--- a/src/kube-scanner/index.ts
+++ b/src/kube-scanner/index.ts
@@ -13,28 +13,28 @@ import { constructHomebaseDeleteWorkloadPayload, constructHomebaseWorkloadPayloa
 import { IDepGraphPayload, IKubeImage, ILocalWorkloadLocator } from '../transmitter/types';
 
 export = class WorkloadWorker {
-  private readonly logId: string;
+  private readonly name: string;
 
-  constructor(logId: string) {
-    this.logId = logId;
+  constructor(name: string) {
+    this.name = name;
   }
 
   public async process(workloadMetadata: IKubeImage[]) {
-    const logId = this.logId;
+    const workloadName = this.name;
     const allImages = workloadMetadata.map((meta) => meta.imageName);
-    logger.info({logId, imageCount: allImages.length}, 'Queried workloads');
+    logger.info({workloadName, imageCount: allImages.length}, 'Queried workloads');
     const uniqueImages = [...new Set<string>(allImages)];
 
-    logger.info({logId, imageCount: uniqueImages.length}, 'Pulling unique images');
+    logger.info({workloadName, imageCount: uniqueImages.length}, 'Pulling unique images');
     const pulledImages = await pullImages(uniqueImages);
     if (pulledImages.length === 0) {
       logger.info({}, 'No images were pulled, halting scanner process.');
       return;
     }
 
-    logger.info({logId, imageCount: pulledImages.length}, 'Scanning pulled images');
+    logger.info({workloadName, imageCount: pulledImages.length}, 'Scanning pulled images');
     const scannedImages: ScanResult[] = await scanImages(pulledImages);
-    logger.info({logId, imageCount: scannedImages.length}, 'Successfully scanned images');
+    logger.info({workloadName, imageCount: scannedImages.length}, 'Successfully scanned images');
     if (scannedImages.length === 0) {
       logger.info({}, 'No images were scanned, halting scanner process.');
       return;
@@ -46,12 +46,12 @@ export = class WorkloadWorker {
     const pulledImageMetadata = workloadMetadata.filter((meta) =>
       pulledImages.includes(meta.imageName));
 
-    logger.info({logId, imageCount: pulledImageMetadata.length}, 'Processed images');
+    logger.info({workloadName, imageCount: pulledImageMetadata.length}, 'Processed images');
   }
 
   public async delete(localWorkloadLocator: ILocalWorkloadLocator) {
     const deletePayload = constructHomebaseDeleteWorkloadPayload(localWorkloadLocator);
-    logger.info({logId: this.logId, workload: localWorkloadLocator},
+    logger.info({workloadName: this.name, workload: localWorkloadLocator},
       'Removing workloads from homebase');
     await deleteHomebaseWorkload(deletePayload);
   }

--- a/src/kube-scanner/watchers/handlers/daemon-set.ts
+++ b/src/kube-scanner/watchers/handlers/daemon-set.ts
@@ -1,15 +1,13 @@
 import { V1DaemonSet } from '@kubernetes/client-node';
-import * as uuidv4 from 'uuid/v4';
 import { WatchEventType } from '../types';
 import { deleteWorkload } from './index';
 import { WorkloadKind } from '../../types';
+import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 
 export async function daemonSetWatchHandler(eventType: string, daemonSet: V1DaemonSet) {
   if (eventType !== WatchEventType.Deleted) {
     return;
   }
-
-  const logId = uuidv4().substring(0, 8);
 
   if (!daemonSet.metadata || !daemonSet.spec || !daemonSet.spec.template.metadata ||
       !daemonSet.spec.template.spec) {
@@ -17,11 +15,13 @@ export async function daemonSetWatchHandler(eventType: string, daemonSet: V1Daem
     return;
   }
 
+  const workloadName = daemonSet.metadata.name || FALSY_WORKLOAD_NAME_MARKER;
+
   await deleteWorkload({
     kind: WorkloadKind.DaemonSet,
     objectMeta: daemonSet.metadata,
     specMeta: daemonSet.spec.template.metadata,
     containers: daemonSet.spec.template.spec.containers,
     ownerRefs: daemonSet.metadata.ownerReferences,
-  }, logId);
+  }, workloadName);
 }

--- a/src/kube-scanner/watchers/handlers/deployment.ts
+++ b/src/kube-scanner/watchers/handlers/deployment.ts
@@ -1,15 +1,13 @@
 import { V1Deployment } from '@kubernetes/client-node';
-import * as uuidv4 from 'uuid/v4';
 import { WatchEventType } from '../types';
 import { deleteWorkload } from './index';
 import { WorkloadKind } from '../../types';
+import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 
 export async function deploymentWatchHandler(eventType: string, deployment: V1Deployment) {
   if (eventType !== WatchEventType.Deleted) {
     return;
   }
-
-  const logId = uuidv4().substring(0, 8);
 
   if (!deployment.metadata || !deployment.spec || !deployment.spec.template.metadata ||
       !deployment.spec.template.spec) {
@@ -17,11 +15,13 @@ export async function deploymentWatchHandler(eventType: string, deployment: V1De
     return;
   }
 
+  const workloadName = deployment.metadata.name || FALSY_WORKLOAD_NAME_MARKER;
+
   await deleteWorkload({
     kind: WorkloadKind.Deployment,
     objectMeta: deployment.metadata,
     specMeta: deployment.spec.template.metadata,
     containers: deployment.spec.template.spec.containers,
     ownerRefs: deployment.metadata.ownerReferences,
-  }, logId);
+  }, workloadName);
 }

--- a/src/kube-scanner/watchers/handlers/index.ts
+++ b/src/kube-scanner/watchers/handlers/index.ts
@@ -3,14 +3,14 @@ import WorkloadWorker = require('../../../kube-scanner');
 import { buildWorkloadMetadata } from '../../metadata-extractor';
 import { KubeObjectMetadata } from '../../types';
 
-export async function deleteWorkload(kubernetesMetadata: KubeObjectMetadata, logId: string) {
+export async function deleteWorkload(kubernetesMetadata: KubeObjectMetadata, workloadName: string) {
   try {
     if (kubernetesMetadata.ownerRefs !== undefined && kubernetesMetadata.ownerRefs.length > 0) {
       return;
     }
 
     const localWorkloadLocator = buildWorkloadMetadata(kubernetesMetadata);
-    const workloadWorker = new WorkloadWorker(logId);
+    const workloadWorker = new WorkloadWorker(workloadName);
     await workloadWorker.delete(localWorkloadLocator);
   } catch (error) {
     logger.error({error, resourceType: kubernetesMetadata.kind, resourceName: kubernetesMetadata.objectMeta.name},

--- a/src/kube-scanner/watchers/handlers/job.ts
+++ b/src/kube-scanner/watchers/handlers/job.ts
@@ -1,20 +1,20 @@
 import { V1Job } from '@kubernetes/client-node';
-import * as uuidv4 from 'uuid/v4';
 import { WatchEventType } from '../types';
 import { deleteWorkload } from './index';
 import { WorkloadKind } from '../../types';
+import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 
 export async function jobWatchHandler(eventType: string, job: V1Job) {
   if (eventType !== WatchEventType.Deleted) {
     return;
   }
 
-  const logId = uuidv4().substring(0, 8);
-
   if (!job.metadata || !job.spec || !job.spec.template.metadata || !job.spec.template.spec) {
     // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
+
+  const workloadName = job.metadata.name || FALSY_WORKLOAD_NAME_MARKER;
 
   await deleteWorkload({
     kind: WorkloadKind.Job,
@@ -22,5 +22,5 @@ export async function jobWatchHandler(eventType: string, job: V1Job) {
     specMeta: job.spec.template.metadata,
     containers: job.spec.template.spec.containers,
     ownerRefs: job.metadata.ownerReferences,
-  }, logId);
+  }, workloadName);
 }

--- a/src/kube-scanner/watchers/handlers/pod.ts
+++ b/src/kube-scanner/watchers/handlers/pod.ts
@@ -1,6 +1,5 @@
 import { V1Pod } from '@kubernetes/client-node';
 import async = require('async');
-import * as uuidv4 from 'uuid/v4';
 import config = require('../../../common/config');
 import logger = require('../../../common/logger');
 import WorkloadWorker = require('../../../kube-scanner');
@@ -8,6 +7,7 @@ import { IKubeImage } from '../../../transmitter/types';
 import { buildMetadataForWorkload } from '../../metadata-extractor';
 import { PodPhase, WatchEventType } from '../types';
 import state = require('../../../state');
+import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 
 async function queueWorker(task, callback) {
   const {workloadWorker, workloadMetadata, imageKeys} = task;
@@ -49,17 +49,18 @@ export async function podWatchHandler(eventType: string, pod: V1Pod) {
     return;
   }
 
-  const logId = uuidv4().substring(0, 8);
+  const podName = pod.metadata && pod.metadata.name ? pod.metadata.name : FALSY_WORKLOAD_NAME_MARKER;
 
   try {
     const workloadMetadata = await buildMetadataForWorkload(pod);
 
     if (workloadMetadata === undefined || workloadMetadata.length === 0) {
-      logger.warn({logId, podName: pod.metadata!.name}, 'Could not process Pod. The workload is possibly unsupported');
+      logger.warn({podName}, 'Could not process Pod. The workload is possibly unsupported');
       return;
     }
 
-    const workloadWorker = new WorkloadWorker(logId);
+    const workloadName = workloadMetadata[0].name;
+    const workloadWorker = new WorkloadWorker(workloadName);
 
     switch (eventType) {
       case WatchEventType.Added:
@@ -76,7 +77,7 @@ export async function podWatchHandler(eventType: string, pod: V1Pod) {
         break;
     }
   } catch (error) {
-    logger.error({error, logId, podName: pod.metadata!.name}, 'Could not build image metadata for pod');
+    logger.error({error, podName}, 'Could not build image metadata for pod');
   }
 }
 

--- a/src/kube-scanner/watchers/handlers/replication-controller.ts
+++ b/src/kube-scanner/watchers/handlers/replication-controller.ts
@@ -1,8 +1,8 @@
 import { V1ReplicationController } from '@kubernetes/client-node';
-import * as uuidv4 from 'uuid/v4';
 import { WatchEventType } from '../types';
 import { deleteWorkload } from './index';
 import { WorkloadKind } from '../../types';
+import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 
 export async function replicationControllerWatchHandler(
     eventType: string, replicationController: V1ReplicationController) {
@@ -10,13 +10,13 @@ export async function replicationControllerWatchHandler(
     return;
   }
 
-  const logId = uuidv4().substring(0, 8);
-
   if (!replicationController.metadata || !replicationController.spec || !replicationController.spec.template ||
       !replicationController.spec.template.metadata || !replicationController.spec.template.spec) {
     // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
+
+  const workloadName = replicationController.metadata.name || FALSY_WORKLOAD_NAME_MARKER;
 
   await deleteWorkload({
     kind: WorkloadKind.ReplicationController,
@@ -24,5 +24,5 @@ export async function replicationControllerWatchHandler(
     specMeta: replicationController.spec.template.metadata,
     containers: replicationController.spec.template.spec.containers,
     ownerRefs: replicationController.metadata.ownerReferences,
-  }, logId);
+  }, workloadName);
 }

--- a/src/kube-scanner/watchers/handlers/stateful-set.ts
+++ b/src/kube-scanner/watchers/handlers/stateful-set.ts
@@ -1,15 +1,13 @@
 import { V1StatefulSet } from '@kubernetes/client-node';
-import * as uuidv4 from 'uuid/v4';
 import { WatchEventType } from '../types';
 import { deleteWorkload } from './index';
 import { WorkloadKind } from '../../types';
+import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 
 export async function statefulSetWatchHandler(eventType: string, statefulSet: V1StatefulSet) {
   if (eventType !== WatchEventType.Deleted) {
     return;
   }
-
-  const logId = uuidv4().substring(0, 8);
 
   if (!statefulSet.metadata || !statefulSet.spec || !statefulSet.spec.template.metadata ||
       !statefulSet.spec.template.spec) {
@@ -17,11 +15,13 @@ export async function statefulSetWatchHandler(eventType: string, statefulSet: V1
     return;
   }
 
+  const workloadName = statefulSet.metadata.name || FALSY_WORKLOAD_NAME_MARKER;
+
   await deleteWorkload({
     kind: WorkloadKind.StatefulSet,
     objectMeta: statefulSet.metadata,
     specMeta: statefulSet.spec.template.metadata,
     containers: statefulSet.spec.template.spec.containers,
     ownerRefs: statefulSet.metadata.ownerReferences,
-  }, logId);
+  }, workloadName);
 }

--- a/src/kube-scanner/watchers/handlers/types.ts
+++ b/src/kube-scanner/watchers/handlers/types.ts
@@ -1,0 +1,1 @@
+export const FALSY_WORKLOAD_NAME_MARKER = 'falsy workload name';


### PR DESCRIPTION
Initially the idea of logging a random ID was to distinguish different workload processing flows as many of them ran concurrently and created log messages.
Sometimes it was difficult to follow for example where 3 of the same "Scanning pulled images" messages come from.

Logging a random ID actually doesn't give us any meaningful information; instead we can log the workload name, which is already unique as we opt to scan an image only once.
It should be much clearer to also figure out which workloads have been processed by the monitor and we can verify that they must appear in Snyk import UI.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
