### PR TITLE
Chore/ci fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ jobs:
               IMAGE_NAME_APPROVED=snyk/kubernetes-monitor:${NEW_VERSION}-approved &&
               docker tag ${IMAGE_NAME_CANDIDATE} ${IMAGE_NAME_APPROVED} &&
               docker push ${IMAGE_NAME_APPROVED} &&
-              ./scripts/slack-notify-push.sh ${IMAGE_NAME_APPROVED}
+              ./scripts/slack-notify-push.sh ${IMAGE_NAME_APPROVED} ||
+              ./scripts/slack-notify-failure.sh staging
       name: Test and Build
 ######################## PR TO MASTER ########################
     - stage: pre-publish
@@ -63,7 +64,8 @@ jobs:
               ./scripts/slack-notify-push.sh ${IMAGE_NAME_PUBLISHED} &&
               docker tag ${IMAGE_NAME_APPROVED} snyk/kubernetes-monitor:latest &&
               docker push ${IMAGE_NAME_PUBLISHED} &&
-              ./scripts/slack-notify-push.sh snyk/kubernetes-monitor:latest
+              ./scripts/slack-notify-push.sh snyk/kubernetes-monitor:latest ||
+              ./scripts/slack-notify-failure.sh master
       name: publish the kubernetes-monitor (npm, container, helm)
 branches:
   only:

--- a/scripts/slack-notify-failure.sh
+++ b/scripts/slack-notify-failure.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "warning", "fallback": "Build Notification: $TRAVIS_BUILD_WEB_URL", "title": ":warning: Kubernetes-Monitor Merge Failure :warning:", "text": ":egg_broken_1: Kubernetes-Monitor broken branch: `'$1'` :egg_broken_1:"}]}' $SLACK_WEBHOOK


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

1. fix re-tagging that happens in "merge to master" builds, as it looked for ```v1.2.3``` instead of ```1.2.3``` for retagging the image.
2. notify on slack when a "merge to staging" or "merge to master" build fails