### PR TITLE
chore: specify imagelocator attributes

### DIFF
--- a/src/transmitter/payload.ts
+++ b/src/transmitter/payload.ts
@@ -1,21 +1,24 @@
 import config = require('../common/config');
 import { currentClusterName } from '../kube-scanner/cluster';
 import { ScanResult } from '../kube-scanner/image-scanner';
-import { IDeleteWorkloadPayload, IDepGraphPayload, IKubeImage, ILocalWorkloadLocator } from './types';
+import { IDeleteWorkloadPayload, IDepGraphPayload, IKubeImage, ILocalWorkloadLocator, IImageLocator } from './types';
 
 export function constructHomebaseWorkloadPayloads(
     scannedImages: ScanResult[],
-    imageMetadata: IKubeImage[],
+    workloadMetadata: IKubeImage[],
 ): IDepGraphPayload[] {
   const results = scannedImages.map((scannedImage) => {
-    const metadata = imageMetadata.find((meta) => meta.imageName === scannedImage.imageWithTag)!;
+    const kubeImage: IKubeImage = workloadMetadata.find((meta) => meta.imageName === scannedImage.imageWithTag)!;
 
-    const { imageName: image, ...workloadLocator } = metadata;
+    const { cluster, namespace, type, name } = kubeImage;
 
-    const imageLocator = {
-      ...workloadLocator,
+    const imageLocator: IImageLocator = {
       userLocator: config.INTEGRATION_ID,
       imageId: scannedImage.image,
+      cluster,
+      namespace,
+      type,
+      name,
     };
 
     return {

--- a/src/transmitter/types.ts
+++ b/src/transmitter/types.ts
@@ -17,7 +17,7 @@ export interface IWorkloadMetadata extends IWorkloadLocator {
   uid: string;
 }
 
-export interface IImageLocator extends IWorkloadMetadata {
+export interface IImageLocator extends IWorkloadLocator {
   imageId: string;
 }
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
imageLocator object includes 5 mandatory attributes: userLocator, cluster, namespace, type and name. Unfortunately, in our code we overuse spread operator on the metadata object and send information to homebase that has nothing to do with `locating` the image. this PR solve it by specifying the correct attributes