### PR TITLE
chore: ScanResult-->IScanResult

### DIFF
--- a/src/kube-scanner/image-scanner.ts
+++ b/src/kube-scanner/image-scanner.ts
@@ -1,7 +1,7 @@
 import * as plugin from 'snyk-docker-plugin';
 import logger = require('../common/logger');
 
-export interface ScanResult {
+export interface IScanResult {
   image: string;
   imageWithTag: string;
   pluginResult: any;
@@ -20,8 +20,8 @@ function getImageTag(imageWithTag: string): string {
   return '';
 }
 
-export async function scanImages(images: string[]): Promise<ScanResult[]> {
-  const scannedImages: ScanResult[] = [];
+export async function scanImages(images: string[]): Promise<IScanResult[]> {
+  const scannedImages: IScanResult[] = [];
 
   for (const image of images) {
     try {

--- a/src/kube-scanner/index.ts
+++ b/src/kube-scanner/index.ts
@@ -7,7 +7,7 @@
  */
 import logger = require('../common/logger');
 import { pullImages } from '../images';
-import { scanImages, ScanResult } from './image-scanner';
+import { scanImages, IScanResult } from './image-scanner';
 import { deleteHomebaseWorkload, sendDepGraph } from '../transmitter';
 import { constructHomebaseDeleteWorkloadPayload, constructHomebaseWorkloadPayloads } from '../transmitter/payload';
 import { IDepGraphPayload, IKubeImage, ILocalWorkloadLocator } from '../transmitter/types';
@@ -33,7 +33,7 @@ export = class WorkloadWorker {
     }
 
     logger.info({workloadName, imageCount: pulledImages.length}, 'Scanning pulled images');
-    const scannedImages: ScanResult[] = await scanImages(pulledImages);
+    const scannedImages: IScanResult[] = await scanImages(pulledImages);
     logger.info({workloadName, imageCount: scannedImages.length}, 'Successfully scanned images');
     if (scannedImages.length === 0) {
       logger.info({}, 'No images were scanned, halting scanner process.');

--- a/src/transmitter/payload.ts
+++ b/src/transmitter/payload.ts
@@ -1,10 +1,10 @@
 import config = require('../common/config');
 import { currentClusterName } from '../kube-scanner/cluster';
-import { ScanResult } from '../kube-scanner/image-scanner';
+import { IScanResult } from '../kube-scanner/image-scanner';
 import { IDeleteWorkloadPayload, IDepGraphPayload, IKubeImage, ILocalWorkloadLocator, IImageLocator } from './types';
 
 export function constructHomebaseWorkloadPayloads(
-    scannedImages: ScanResult[],
+    scannedImages: IScanResult[],
     workloadMetadata: IKubeImage[],
 ): IDepGraphPayload[] {
   const results = scannedImages.map((scannedImage) => {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

```ScanResult```-->```IScanResult```
to fit our "interfaces start with a capital I" convention
