### PR TITLE
chore: when approving images, first pull that image

### DIFF
--- a/scripts/approve-image.sh
+++ b/scripts/approve-image.sh
@@ -9,6 +9,7 @@ else
   IMAGE_NAME_CANDIDATE=snyk/kubernetes-monitor:staging-candidate
   IMAGE_NAME_APPROVED=snyk/kubernetes-monitor:${1}-approved
 
+  docker pull ${IMAGE_NAME_CANDIDATE}
   docker tag ${IMAGE_NAME_CANDIDATE} ${IMAGE_NAME_APPROVED}
   docker push ${IMAGE_NAME_APPROVED}
   ./scripts/slack-notify-push.sh ${IMAGE_NAME_APPROVED}


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

"tag and push" stage of "merge to staging" jobs are run on a separate VM than the one that built the candidate image, so we need to pull that image before retagging it.