### PR TITLE
chore: merge-to-master should push latest tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
               docker push ${IMAGE_NAME_PUBLISHED} &&
               ./scripts/slack-notify-push.sh ${IMAGE_NAME_PUBLISHED} &&
               docker tag ${IMAGE_NAME_APPROVED} snyk/kubernetes-monitor:latest &&
-              docker push ${IMAGE_NAME_PUBLISHED} &&
+              docker push snyk/kubernetes-monitor:latest &&
               ./scripts/slack-notify-push.sh snyk/kubernetes-monitor:latest ||
               ( ./scripts/slack-notify-failure.sh master && false )
       name: publish the kubernetes-monitor (npm, container, helm)


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

fixing a minor bug in the "merge to master" event where we push the same tagged (```1.2.3```) image twice instead of pushing ```latest```