### PR TITLE
chore: release to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ node_js:
 before_install:
   - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 install:
+  - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+  - git fetch --unshallow --tags
   - npm install
 jobs:
   include:
@@ -65,7 +67,8 @@ jobs:
               ./scripts/slack-notify-push.sh ${IMAGE_NAME_PUBLISHED} &&
               docker tag ${IMAGE_NAME_APPROVED} snyk/kubernetes-monitor:latest &&
               docker push snyk/kubernetes-monitor:latest &&
-              ./scripts/slack-notify-push.sh snyk/kubernetes-monitor:latest ||
+              ./scripts/slack-notify-push.sh snyk/kubernetes-monitor:latest &&
+              ./scripts/publish-gh-pages.sh ${LATEST_TAG} ||
               ( ./scripts/slack-notify-failure.sh master && false )
       name: publish the kubernetes-monitor (npm, container, helm)
 branches:

--- a/scripts/publish-gh-pages.sh
+++ b/scripts/publish-gh-pages.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+set -e
+
+NEW_TAG=$1
+echo About to update the gh-pages branch with new tag ${NEW_TAG}
+
+echo configuring git
+git config --global user.email "egg@snyk.io"
+git config --global user.name "Runtime CI & CD"
+git remote add origin-pages https://${GH_TOKEN}@github.com/snyk/kubernetes-monitor.git > /dev/null 2>&1
+git checkout -f gh-pages
+
+if grep -Fxq "  tag: ${NEW_TAG}" ./snyk-monitor/values.yaml
+then
+  echo not publishing a new gh-pages commit since this version is already published
+  ./scripts/slack-notify-success-no-publish.sh
+  exit 0
+fi
+
+echo overriding new yaml / chart files from master branch
+git checkout origin/chore/publish_gh_pages -- snyk-monitor snyk-monitor-cluster-permissions.yaml snyk-monitor-deployment.yaml snyk-monitor-namespaced-permissions.yaml
+
+echo overriding tag placeholders with latest semantic version
+sed -i "s/{{IMAGE_TAG_OVERRIDE_WHEN_PUBLISHING}}/${NEW_TAG}/g" ./snyk-monitor/values.yaml
+sed -i "s/{{IMAGE_TAG_OVERRIDE_WHEN_PUBLISHING}}/${NEW_TAG}/g" ./snyk-monitor-deployment.yaml
+
+echo building new helm release
+./helm init --client-only
+./helm package snyk-monitor --version ${NEW_TAG}
+./helm repo index .
+
+echo publishing to gh-pages
+git add index.yaml
+git add snyk-monitor-${NEW_TAG}.tgz
+git add ./snyk-monitor/values.yaml
+git add ./snyk-monitor-deployment.yaml
+COMMIT_MESSAGE='fix: :egg: Automatic Publish '${NEW_TAG}' :egg:'
+git commit -m "${COMMIT_MESSAGE}"
+git push --quiet --set-upstream origin-pages gh-pages
+./scripts/slack-notify-push.sh "gh-pages"

--- a/scripts/slack-notify-success-no-publish.sh
+++ b/scripts/slack-notify-success-no-publish.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "warning", "fallback": "Build Notification: $TRAVIS_BUILD_WEB_URL", "title": "Kubernetes-Monitor Publish Notification", "text": ":egg_fancy: Successful `master` merge, but no `gh-pages` release occurring :egg_fancy:"}]}' $SLACK_WEBHOOK

--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app.kubernetes.io/name: snyk-monitor
     spec:
       containers:
-      - image: snyk/kubernetes-monitor:latest
+      - image: snyk/kubernetes-monitor:{{IMAGE_TAG_OVERRIDE_WHEN_PUBLISHING}}
         imagePullPolicy: Always
         name: snyk-monitor
         terminationMessagePath: /dev/termination-log

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -17,7 +17,7 @@ integrationApi: ""
 # The registry from which to pull the snyk-monitor image.
 image:
   repository: snyk/kubernetes-monitor
-  tag: latest
+  tag: {{IMAGE_TAG_OVERRIDE_WHEN_PUBLISHING}}
   pullPolicy: Always
 
 # The snyk-monitor requires knowing the cluster name so that it can organise


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

1. our yaml files that specify which image tag to use are now "templated".
2. "template" is replaced in "publish-gh-pages.sh" which runs when "master" is merged, by the latest tag, if it hasn't been published yet.
3. gh-pages branch is updated with all the artifacts required.

### More information

https://snyksec.atlassian.net/browse/RUN-374
https://github.com/snyk/kubernetes-monitor/commit/35af9417580283f2f2034aa7cc24756216f1d723

### Screenshots

![image](https://user-images.githubusercontent.com/1255387/64355465-f4b07980-d009-11e9-8fa5-5d4b0887d995.png)

