### PR TITLE
chore: "set -e" instead of && all over the place

### DIFF
--- a/scripts/approve-image.sh
+++ b/scripts/approve-image.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+set -e
 
 # $1 is the version from package.json
 # if semantic release chooses not to release (only chores for example)
@@ -10,8 +11,8 @@ else
   IMAGE_NAME_CANDIDATE=snyk/kubernetes-monitor:staging-candidate
   IMAGE_NAME_APPROVED=snyk/kubernetes-monitor:${1}-approved
 
-  docker pull ${IMAGE_NAME_CANDIDATE} &&
-  docker tag ${IMAGE_NAME_CANDIDATE} ${IMAGE_NAME_APPROVED} &&
-  docker push ${IMAGE_NAME_APPROVED} &&
+  docker pull ${IMAGE_NAME_CANDIDATE}
+  docker tag ${IMAGE_NAME_CANDIDATE} ${IMAGE_NAME_APPROVED}
+  docker push ${IMAGE_NAME_APPROVED}
   ./scripts/slack-notify-push.sh ${IMAGE_NAME_APPROVED}
 fi


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

"set -e" means the shell will stop executing the script if a command fails, instead of moving to the next one.
this means we don't need to concatenate commands with &&.