### PR TITLE
chore: base branch for yaml files is master

### DIFF
--- a/scripts/publish-gh-pages.sh
+++ b/scripts/publish-gh-pages.sh
@@ -18,7 +18,7 @@ then
 fi
 
 echo overriding new yaml / chart files from master branch
-git checkout origin/chore/publish_gh_pages -- snyk-monitor snyk-monitor-cluster-permissions.yaml snyk-monitor-deployment.yaml snyk-monitor-namespaced-permissions.yaml
+git checkout origin/master -- snyk-monitor snyk-monitor-cluster-permissions.yaml snyk-monitor-deployment.yaml snyk-monitor-namespaced-permissions.yaml
 
 echo overriding tag placeholders with latest semantic version
 sed -i "s/{{IMAGE_TAG_OVERRIDE_WHEN_PUBLISHING}}/${NEW_TAG}/g" ./snyk-monitor/values.yaml


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

base branch for yaml files is master, not the non-existing chore/publish_gh_pages

### More information

https://snyksec.atlassian.net/browse/RUN-374
https://travis-ci.com/snyk/kubernetes-monitor/builds/126363589
