### PR TITLE
chore: unset PR-related env variables on "merge to staging" flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,10 @@ jobs:
           command: |
             npm install &&
             docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} &&
+            unset CIRCLE_PULL_REQUEST &&
+            unset CI_PULL_REQUEST &&
+            unset CI_PULL_REQUESTS &&
+            unset CIRCLE_PULL_REQUESTS &&
             npx semantic-release &&
             NEW_VERSION=`cat ./package.json | jq -r '.version'` &&
             ./scripts/approve-image.sh $NEW_VERSION ||


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

unset PR-related env variables on "merge to staging" flow
CIRCLE_PULL_REQUEST, CIRCLE_PULL_REQUESTS, CI_PULL_REQUEST, CI_PULL_REQUESTS
if these env variables are set, semantic release will mistaken the run as a pull request and refuse to release.
they may be set because of how CircleCI interacts with PRs - it doesn't respond to PRs opening and trigger builds, instead, it starts running when pushes are made to any branch, and adds the PR variables if it detects a PR exists.

### More information

https://snyksec.atlassian.net/browse/RUN-423
https://circleci.com/gh/snyk/kubernetes-monitor/60
https://snyk.slack.com/archives/CDSMEJ29E/p1568287889294300