### PR TITLE
chore: remove a TODO from June

### DIFF
--- a/src/kube-scanner/cluster.ts
+++ b/src/kube-scanner/cluster.ts
@@ -4,13 +4,6 @@ import { IK8sClients, K8sClients } from './types';
 
 function getKubeConfig(): KubeConfig {
   const kc = new KubeConfig();
-  // TODO(ivanstanev): We may need to change this to loadFromClusterAndUser()
-  // and pass the cluster and user from somewhere (e.g. env vars).
-  // By default, these would be (as taken from the k8s client source):
-  // { name: 'cluster', server: 'http://localhost:8080' } as Cluster,
-  // { name: 'user' } as User
-  // We need to identify what the implications of this are, and whether
-  // our customers would want to configure this. Keep an eye on this!
   kc.loadFromDefault();
   return kc;
 }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

removes a comment.

it appears that loadFromDefault is working pretty well for us, and seems very standard.
if we find users intent on injecting the KubeConfig some other way, we'll handle that.