### PR TITLE
chore: set @snyk/runtime as the owning team for all the files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+* @snyk/runtime


### PR DESCRIPTION
### What this does

introduce ```CODEOWNERS``` file to set @snyk/runtime as this repository's owners