### PR TITLE
feat: use the go-rpmdb tool for RPM scanning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3041,9 +3041,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.32.1.tgz",
-      "integrity": "sha512-mL/xIVQyFW5ga6VADpmex1kTQP9fVma4McFP2bX65foNaJVqLZoIue6pjyFhdXx/imJOjwwnf/Qmsrx9CFuRJQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.33.0.tgz",
+      "integrity": "sha512-wlE1KKyco0vvQ/Lzztv2le7qr4xEcXT3AI0a9wBV8lqyTBaadss/khYjsxTeamALT60kZbNwcARkiW3ZAeqF6A==",
       "requires": {
         "debug": "^4.1.1",
         "dockerfile-ast": "0.0.16",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "needle": "^2.4.0",
     "response-time": "^2.3.2",
     "snyk-config": "^2.2.0",
-    "snyk-docker-plugin": "^1.32.1",
+    "snyk-docker-plugin": "^1.33.0",
     "source-map-support": "^0.5.9",
     "tslib": "^1.9.3",
     "ws": "^7.0.0",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Bump the snyk-docker-plugin to the version that integrates RPM DB analysis. This requires building the go-rpmdb tool and embedding it in the image: this is done as a separate build stage.

### More information

- [Jira ticket RUN-468](https://snyksec.atlassian.net/browse/RUN-468)
