### PR TITLE
test: add an RPM-based deployment to the tests

### DIFF
--- a/test/fixtures/centos-deployment.yaml
+++ b/test/fixtures/centos-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: centos
+  namespace: services
+  labels:
+    app.kubernetes.io/name: centos
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: centos
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: centos
+    spec:
+      containers:
+      - image: centos:7
+        imagePullPolicy: Always
+        name: centos
+      securityContext: {}

--- a/test/integration/kubernetes.test.ts
+++ b/test/integration/kubernetes.test.ts
@@ -119,7 +119,7 @@ tap.test('snyk-monitor sends data to homebase', async (t) => {
   console.log(`Begin polling Homebase for the expected workloads with integration ID ${integrationId}...`);
 
   const validatorFn: WorkloadLocatorValidator = (workloads) => {
-    return workloads !== undefined && workloads.length === 4 &&
+    return workloads !== undefined && workloads.length === 5 &&
       workloads.find((workload) => workload.name === 'alpine' &&
         workload.type === WorkloadKind.Pod) !== undefined &&
       workloads.find((workload) => workload.name === 'nginx' &&
@@ -127,6 +127,8 @@ tap.test('snyk-monitor sends data to homebase', async (t) => {
       workloads.find((workload) => workload.name === 'redis' &&
         workload.type === WorkloadKind.Deployment) !== undefined &&
       workloads.find((workload) => workload.name === 'alpine-from-sha' &&
+        workload.type === WorkloadKind.Deployment) !== undefined &&
+      workloads.find((workload) => workload.name === 'centos' &&
         workload.type === WorkloadKind.Deployment) !== undefined;
   };
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -289,6 +289,7 @@ Test.prototype.deployMonitor = async (staticAnalysis: boolean): Promise<string> 
   await applyK8sYaml('./test/fixtures/alpine-pod.yaml');
   await applyK8sYaml('./test/fixtures/nginx-replicationcontroller.yaml');
   await applyK8sYaml('./test/fixtures/redis-deployment.yaml');
+  await applyK8sYaml('./test/fixtures/centos-deployment.yaml');
   const someImageWithSha = 'alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a';
   await createDeploymentFromImage('alpine-from-sha', someImageWithSha, servicesNamespace);
 


### PR DESCRIPTION
Ensure that we can also scan a workload with RPM as the package manager in our integration tests.

- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)