### PR TITLE
fix: increase temporary storage to 50Gi

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,6 @@ kubectl apply -f snyk-monitor-deployment.yaml
 ## Enabling static analysis ##
 
 Static analysis works with any container runtime and does not rely on Docker to scan the images in your cluster.
-It works by pulling the image, unpacking it and inspecting the files directly. For this process it needs temporary storage, so the Snyk monitor uses 20 GB of storage in the form of [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir).
+It works by pulling the image, unpacking it and inspecting the files directly. For this process it needs temporary storage, so the Snyk monitor uses 50 GB of storage in the form of [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir).
 
 To enable static analysis, modify one of the permissions files (`snyk-monitor-namespaced-permissions.yaml` for the Namespaced deployment or `snyk-monitor-cluster-permissions.yaml` for the Cluster-scoped deployment) and set the string value of `staticAnalysis` to `"true"`.

--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -79,5 +79,5 @@ spec:
               path: config.json
       - name: temporary-storage
         emptyDir:
-          sizeLimit: 20Gi
+          sizeLimit: 50Gi
       serviceAccountName: snyk-monitor

--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -74,7 +74,7 @@ helm upgrade --generate-name --install snyk-monitor snyk-charts/snyk-monitor --n
 ## Enabling static analysis ##
 
 Static analysis works with any container runtime and does not rely on Docker to scan the images in your cluster.
-It works by pulling the image, unpacking it and inspecting the files directly. For this process it needs temporary storage, so the Snyk monitor uses 20 GB of storage in the form of [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir).
+It works by pulling the image, unpacking it and inspecting the files directly. For this process it needs temporary storage, so the Snyk monitor uses 50 GB of storage in the form of [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir).
 The Docker socket is _not_ mounted when static analysis is enabled.
 
 To enable static analysis, set the `featureFlags.staticAnalysis` value to `true`:

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -74,5 +74,5 @@ spec:
         {{- if eq .Values.featureFlags.staticAnalysis true }}
         - name: temporary-storage
           emptyDir:
-            sizeLimit: 20Gi
+            sizeLimit: {{ .Values.temporaryStorageSize }}
         {{- end }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -30,3 +30,7 @@ dockerSocketHostPath: "/var/run/docker.sock"
 
 featureFlags:
   staticAnalysis: false
+
+# The snyk-monitor requires disk storage to temporarily pull container images and to scan them for vulnerabilities.
+# This value controls how much disk storage _at most_ may be allocated for the snyk-monitor. The snyk-monitor mounts an emptyDir for storage.
+temporaryStorageSize: 50Gi


### PR DESCRIPTION
To be on the safe side, increase storage from 20Gi to 50Gi in case there are multiple large images running in a cluster.
For Helm, the value is now adjustable in case even more storage is needed.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

After some consideration we would like to increase the static analysis temporary disk size from 20 GB to 50 GB to avoid potential issues if customers are running very large containers.
For Helm the value can now be adjusted in case even _more_ storage is necessary.

### More information

- [Slack conversation](https://snyk.slack.com/archives/CMTRGQY73/p1571140008004900?thread_ts=1570780478.002800&cid=CMTRGQY73)
