### PR TITLE
fix: prevent grep with no matches from failing the build

### DIFF
--- a/scripts/publish-gh-pages.sh
+++ b/scripts/publish-gh-pages.sh
@@ -46,7 +46,9 @@ echo waiting for the new release to appear in github
 attempts=60
 sleep_time=10
 for (( i=0; i<${attempts}; i++ )); do
-  count=$(curl -s https://snyk.github.io/kubernetes-monitor/snyk-monitor/values.yaml | grep --line-buffered -c "tag: ${NEW_TAG}")
+  # Notice we must use "|| :" at the end of grep because when it doesn't find a match
+  # it returns an exit code 1, which trips this script (it has "set -e").
+  count=$(curl -s https://snyk.github.io/kubernetes-monitor/snyk-monitor/values.yaml | grep --line-buffered -c "tag: ${NEW_TAG}" || :)
   if [[ "$count" == "1" ]]; then
     attempts=${i}
     break


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

`grep` returns exit code 1 when it doesn't match, resulting in the build failing (because of `set -e` in the script).
