### PR TITLE
fix: pull images to uniquely-named files

### DIFF
--- a/src/images/index.ts
+++ b/src/images/index.ts
@@ -3,39 +3,56 @@ import { pull as dockerPull } from './docker';
 import { pull as skopeoCopy, getDestinationForImage } from './skopeo';
 import { unlink } from 'fs';
 import { isStaticAnalysisEnabled } from '../common/features';
+import { IPullableImage } from './types';
 
-export { getDestinationForImage };
-
-export async function pullImages(images: string[]): Promise<string[]> {
-  const pulledImages: string[] = [];
+export async function pullImages(images: IPullableImage[]): Promise<IPullableImage[]> {
+  const pulledImages: IPullableImage[] = [];
 
   for (const image of images) {
+    const {imageName, fileSystemPath} = image;
     try {
       if (isStaticAnalysisEnabled()) {
-        await skopeoCopy(image);
+        if (!fileSystemPath) {
+          throw new Error('Missing required parameter fileSystemPath for static analysis');
+        }
+        await skopeoCopy(imageName, fileSystemPath);
       } else {
-        await dockerPull(image);
+        await dockerPull(imageName);
       }
       pulledImages.push(image);
     } catch (error) {
-      logger.error({error, image}, 'failed to pull image');
+      logger.error({error, image: imageName}, 'failed to pull image');
     }
   }
 
   return pulledImages;
 }
 
-export async function removePulledImages(images: string[]) {
+/**
+ * TODO: For Docker (dynamic scanning) it returns the image but with an empty file system path
+ * (because Docker does not pull images to a temporary directory). This will no longer be true
+ * when static analysis becomes the only option, but worth nothing it here to avoid confusion!
+ * @param images a list of images for which to generate a file system path
+ */
+export function getImagesWithFileSystemPath(images: string[]): IPullableImage[] {
+  return isStaticAnalysisEnabled()
+    ? images.map((image) => ({ imageName: image, fileSystemPath: getDestinationForImage(image) }))
+    : images.map((image) => ({ imageName: image }));
+}
+
+export async function removePulledImages(images: IPullableImage[]) {
   if (!isStaticAnalysisEnabled()) {
     return;
   }
 
-  for (const image of images) {
+  for (const {imageName, fileSystemPath} of images) {
     try {
-      const destination = getDestinationForImage(image);
-      await new Promise((resolve) => unlink(destination, resolve));
+      if (!fileSystemPath) {
+        throw new Error('Missing required parameter fileSystemPath for static analysis');
+      }
+      await new Promise((resolve) => unlink(fileSystemPath, resolve));
     } catch (error) {
-      logger.warn({error, image}, 'failed to delete pulled image');
+      logger.warn({error, image: imageName}, 'failed to delete pulled image');
     }
   }
 }

--- a/src/images/types.ts
+++ b/src/images/types.ts
@@ -1,0 +1,4 @@
+export interface IPullableImage {
+  imageName: string;
+  fileSystemPath?: string;
+}

--- a/test/unit/images.test.ts
+++ b/test/unit/images.test.ts
@@ -1,0 +1,71 @@
+import * as tap from 'tap';
+import { getImagesWithFileSystemPath, pullImages } from '../../src/images';
+const config = require('../../src/common/config');
+
+tap.test('getImagesWithFileSystemPath()', async (t) => {
+  const noImages: string[] = [];
+  const noImagesResult = getImagesWithFileSystemPath(noImages);
+  t.same(noImagesResult, [], 'correctly maps an empty array');
+
+  // Cache the last value of STATIC_ANALYSIS, we return it back to normal once the test completes
+  const lastStaticAnalysisValue = config.STATIC_ANALYSIS;
+
+  // First try without static analysis set
+  config.STATIC_ANALYSIS = false;
+  const imageWithoutStaticAnalysis = ['redis:latest'];
+  const imageWithoutStaticAnalysisResult = getImagesWithFileSystemPath(imageWithoutStaticAnalysis);
+  t.same(
+    imageWithoutStaticAnalysisResult,
+    [{ imageName: 'redis:latest' }],
+    'correctly returns an image without a file system path',
+  );
+
+  // Next try with static analysis set
+  config.STATIC_ANALYSIS = true;
+  const imageWithStaticAnalysis = ['nginx:latest'];
+  const imageWithStaticAnalysisResult = getImagesWithFileSystemPath(imageWithStaticAnalysis);
+  t.same(imageWithStaticAnalysisResult.length, 1, 'expected 1 item');
+
+  const resultWithExpectedPath = imageWithStaticAnalysisResult[0];
+  t.same(
+    resultWithExpectedPath.imageName,
+    'nginx:latest',
+    'correctly returns an image without a file system path',
+  );
+  const fileSystemPath = resultWithExpectedPath.fileSystemPath!;
+  t.ok(fileSystemPath, 'file system path exists on the result');
+  t.ok(fileSystemPath.endsWith('.tar'), 'file system path ends in .tar');
+
+  const expectedPattern = fileSystemPath.indexOf(`${config.IMAGE_STORAGE_ROOT}/nginx_latest_`) !== -1;
+  t.ok(expectedPattern, 'the file system path starts with an expected pattern');
+
+  // Finally ensure that two consecutive calls do not return the same file system path
+  config.STATIC_ANALYSIS = true;
+  const someImage = ['centos:latest'];
+  const firstCallResult = getImagesWithFileSystemPath(someImage)[0];
+  const secondCallResult = getImagesWithFileSystemPath(someImage)[0];
+  t.ok(
+    firstCallResult.fileSystemPath !== secondCallResult.fileSystemPath,
+    'consecutive calls to the function with the same data return different file system paths',
+  );
+
+  // Restore the old value
+  config.STATIC_ANALYSIS = lastStaticAnalysisValue;
+});
+
+tap.test('pullImages() skips on missing file system path in static analysis', async (t) => {
+  // Cache the last value of STATIC_ANALYSIS, we return it back to normal once the test completes
+  const lastStaticAnalysisValue = config.STATIC_ANALYSIS;
+
+  config.STATIC_ANALYSIS = true;
+  const badStaticAnalysisImage = [
+    {
+      imageName: 'nginx:latest',
+    },
+  ];
+  const result = await pullImages(badStaticAnalysisImage);
+  t.same(result, [], 'expect to skip images on static analysis set but missing file system path');
+
+  // Restore the old value
+  config.STATIC_ANALYSIS = lastStaticAnalysisValue;
+});


### PR DESCRIPTION
Currently there is a bug that happens rarely but once it does it crashes the Node.js process.
It occurs when two workloads which contain an identical image are pulled at the same time.
The images are pulled to the same filesystem name and the two processes react poorly with each other, resulting in a crash.

This fix adds a unique identifier to every file system name so that clashes do not occur.

- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
