### PR TITLE
chore: when publishing images, stop publishing as latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,9 +165,6 @@ jobs:
             docker tag ${IMAGE_NAME_APPROVED} ${IMAGE_NAME_PUBLISHED} &&
             docker push ${IMAGE_NAME_PUBLISHED} &&
             ./scripts/slack-notify-push.sh ${IMAGE_NAME_PUBLISHED} &&
-            docker tag ${IMAGE_NAME_APPROVED} snyk/kubernetes-monitor:latest &&
-            docker push snyk/kubernetes-monitor:latest &&
-            ./scripts/slack-notify-push.sh snyk/kubernetes-monitor:latest &&
             ./scripts/publish-gh-pages.sh ${LATEST_TAG} ||
             ( ./scripts/slack-notify-failure.sh master && false )
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

today we publish both with a fixed version, and with the "latest" tag.
guidelines usually point towards ignoring the "latest" tag and using proper versions instead, so now that we have semantic releases versioning our product, we can stop using the "latest" tag.

https://medium.com/@mccode/the-misunderstood-docker-tag-latest-af3babfd6375
https://vsupalov.com/docker-latest-tag/