### PR TITLE
Fix/docs empty dockercfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Both of these items must be provided from a Kubernetes secret. The secret must b
 }
 ```
 
+If access to private registries is not needed, the `dockercfg.json` file contents should look like this:
+
+```json
+{}
+```
+
 2. Locate your Snyk Integration ID from the Snyk Integrations page (navigate to https://app.snyk.io/org/YOUR-ORGANIZATION-NAME/manage/integrations/kubernetes) and copy it.
 The Snyk Integration ID is a UUID and looks similar to the following:
 ```

--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -33,6 +33,12 @@ Both of these items must be provided by a Kubernetes secret. The secret must be 
 }
 ```
 
+If access to private registries is not needed, the `dockercfg.json` file contents should look like this:
+
+```json
+{}
+```
+
 2. Locate your Snyk Integration ID from the Snyk Integrations page (navigate to https://app.snyk.io/org/YOUR-ORGANIZATION-NAME/manage/integrations/kubernetes) and copy it. The Snyk Integration ID looks similar to the following:
 ```
 abcd1234-abcd-1234-abcd-1234abcd1234


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Small docs fixes:
- Add an additional example how the dockercfg file could look like if access to private registries is not required. This was raised as a question before so adding this to help customers not have to figure out everything on their own.
- Note that storage is required on the node and how its used.