### PR TITLE
fix: docker-ignore the tilt dir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,6 +34,7 @@ tests_output/
 
 README.md
 Tiltfile
+tilt
 scripts
 tap
 snyk-monitor


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

tilt is used for debugging our container locally, these files don't belong inside the container