### PR TITLE
fix: remove reference to docker.sock in Helm values

### DIFF
--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -25,9 +25,6 @@ image:
 # Set the name of the cluster, otherwise the snyk-monitor will set this to a default value.
 clusterName: ""
 
-# The path of the docker socket on the node. For PKS: /var/vcap/data/sys/run/docker/docker.sock
-dockerSocketHostPath: "/var/run/docker.sock"
-
 # The snyk-monitor requires disk storage to temporarily pull container images and to scan them for vulnerabilities.
 # This value controls how much disk storage _at most_ may be allocated for the snyk-monitor. The snyk-monitor mounts an emptyDir for storage.
 temporaryStorageSize: 50Gi


### PR DESCRIPTION
It is no longer used; we forgot to remove it when stripping out all references to Docker (dynamic scanning).

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
