### PR TITLE
fix: scan workloads that are controllers

### DIFF
--- a/src/kube-scanner/workload-reader.ts
+++ b/src/kube-scanner/workload-reader.ts
@@ -176,6 +176,10 @@ export function getWorkloadReader(workloadType: string): IWorkloadReaderFunc {
 
 export function getSupportedWorkload(ownerRefs: V1OwnerReference[] | undefined): V1OwnerReference | undefined {
   return ownerRefs !== undefined
-    ? ownerRefs.find((owner) => SupportedWorkloadTypes.includes(owner.kind))
+    ? ownerRefs.find(
+        (owner) =>
+          SupportedWorkloadTypes.includes(owner.kind) &&
+          owner.controller === true,
+      )
     : undefined;
 }

--- a/test/unit/workload-reader.test.ts
+++ b/test/unit/workload-reader.test.ts
@@ -1,6 +1,7 @@
 import * as tap from 'tap';
 
-import { SupportedWorkloadTypes } from '../../src/kube-scanner/workload-reader';
+import { SupportedWorkloadTypes, getSupportedWorkload } from '../../src/kube-scanner/workload-reader';
+import { V1OwnerReference } from '@kubernetes/client-node';
 
 tap.test('SupportedWorkloadTypes', async (t) => {
   t.ok(SupportedWorkloadTypes.indexOf('Deployment') > -1, 'Deployment is a supported workload');
@@ -10,4 +11,46 @@ tap.test('SupportedWorkloadTypes', async (t) => {
   t.ok(SupportedWorkloadTypes.indexOf('Job') > -1, 'Job is a supported workload');
   t.ok(SupportedWorkloadTypes.indexOf('CronJob') > -1, 'CronJob is a supported workload');
   t.ok(SupportedWorkloadTypes.indexOf('ReplicationController') > -1, 'ReplicationController is a supported workload');
+});
+
+tap.test('getSupportedWorkload()', async (t) => {
+  t.same(getSupportedWorkload(undefined), undefined, 'returns undefined on receiving undefined');
+  t.same(getSupportedWorkload([]), undefined, 'returns undefined on empty list');
+
+  const unsupportedOwnerRefs = [
+    { kind: 'B7', controller: true },
+    { kind: ':egg:', controller: true },
+  ];
+  t.same(
+    getSupportedWorkload(unsupportedOwnerRefs as V1OwnerReference[]),
+    undefined,
+    'returns undefined when there is no match in a list',
+  );
+
+  const noController = [{ kind: 'ReplicaSet' }, { kind: 'Deployment' }];
+  t.same(
+    getSupportedWorkload(noController as V1OwnerReference[]),
+    undefined,
+    'returns undefined when no OwnerReference is a controller',
+  );
+
+  const oneController = [
+    { kind: 'ReplicaSet' },
+    { kind: 'Deployment', controller: true },
+  ];
+  t.same(
+    getSupportedWorkload(oneController as V1OwnerReference[]),
+    { kind: 'Deployment', controller: true },
+    'returns the only controller in a list',
+  );
+
+  const twoControllers = [
+    { kind: 'ReplicaSet', controller: true },
+    { kind: 'Deployment', controller: true },
+  ];
+  t.same(
+    getSupportedWorkload(twoControllers as V1OwnerReference[]),
+    { kind: 'ReplicaSet', controller: true },
+    'returns the first controller in a list',
+  );
 });


### PR DESCRIPTION
In order to be accurate when looking for a supported workload, we need to look both at the ownerReferences and to ensure that the owner is a controller. This fix ensures both and adds tests to verify this.

- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### More information

- [Jira ticket RUN-399](https://snyksec.atlassian.net/browse/RUN-399)
