### PR TITLE
feat: swap homebase for kubernetes-upstream

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -9,6 +9,6 @@
   },
   "WORKLOADS_TO_SCAN_QUEUE_WORKER_COUNT": 10,
   "INTEGRATION_ID": "203210a3-1de0-4ed3-b6a6-3acd24b71639",
-  "DEFAULT_HOMEBASE_URL": "https://homebase.snyk.io",
+  "DEFAULT_KUBERNETES_UPSTREAM_URL": "https://kubernetes-upstream.snyk.io",
   "NAMESPACE": ""
 }

--- a/src/transmitter/index.ts
+++ b/src/transmitter/index.ts
@@ -3,7 +3,7 @@ import * as config from '../common/config';
 import logger = require('../common/logger');
 import { IDeleteWorkloadPayload, IDepGraphPayload, IWorkloadMetadataPayload } from './types';
 
-const homebaseUrl = config.INTEGRATION_API || config.DEFAULT_HOMEBASE_URL;
+const homebaseUrl = config.INTEGRATION_API || config.DEFAULT_KUBERNETES_UPSTREAM_URL;
 
 function isSuccessStatusCode(statusCode: number | undefined): boolean {
   return statusCode !== undefined && statusCode > 100 && statusCode < 400;

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -168,7 +168,7 @@ function createTestYamlDeployment(
   // Inject the baseUrl of homebase that snyk-monitor container use to send metadata
   deployment.spec.template.spec.containers[0].env[2] = {
     name: 'SNYK_INTEGRATION_API',
-    value: 'https://homebase.dev.snyk.io',
+    value: 'https://kubernetes-upstream.dev.snyk.io',
   };
 
   writeFileSync(newYamlPath, stringify(deployment));


### PR DESCRIPTION
Following the domain name changes, use kubernetes-upstream from now on.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
