### PR TITLE
fix: pass the monitor version as an environment variable

### DIFF
--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -50,6 +50,8 @@ spec:
                 name: snyk-monitor
                 key: clusterName
                 optional: true
+          - name: SNYK_MONITOR_VERSION
+            value: IMAGE_TAG_OVERRIDE_WHEN_PUBLISHING
         resources:
           requests:
             cpu: '250m'

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
             value: {{ .Values.integrationApi }}
           - name: SNYK_CLUSTER_NAME
             value: {{ .Values.clusterName }}
+          - name: SNYK_MONITOR_VERSION
+            value: {{ .Values.image.tag }}
           resources:
             requests:
               cpu: '250m'


### PR DESCRIPTION
Read the value from the deployment files and pass it as an environment variable for the snyk-monitor to use. This allows us to notify the upstream of the running version of the snyk-monitor.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
