### PR TITLE
chore: removing config flag for Kind cluster on the tilt setup script

### DIFF
--- a/tilt/setup-tiltable-kind-cluster.sh
+++ b/tilt/setup-tiltable-kind-cluster.sh
@@ -1,4 +1,4 @@
-./kind create cluster --config=./test/fixtures/cluster-config.yaml --name=kind
+./kind create cluster --name=kind
 export KUBECONFIG=`./kind get kubeconfig-path`
 ./kubectl create namespace snyk-monitor
 ./kubectl create secret generic snyk-monitor -n snyk-monitor --from-literal=dockercfg.json="{}" --from-literal=integrationId="41214617-cb5d-4674-8d97-5b456952c360"


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

the Kind cluster-setup script is using a config file which no longer exists.
it was removed in e578eba319c85117355070ea31c8aa5dc2777e43 because its only purpose is setting up a docker socket, which we no longer use.
this is just a leftover.