### PR TITLE
feat: use dumb-init to wrap the main process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV NODE_ENV production
 
 RUN apk update
 RUN apk upgrade
-RUN apk --no-cache add db
+RUN apk --no-cache add db dumb-init
 
 RUN addgroup -S -g 10001 snyk
 RUN adduser -S -G snyk -h /srv/app -u 10001 snyk
@@ -56,4 +56,4 @@ ADD --chown=snyk:snyk . .
 # Complete any `prepare` tasks (e.g. typescript), as this step ran automatically prior to app being copied
 RUN npm run prepare
 
-ENTRYPOINT ["bin/start"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "bin/start"]


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

PID 1 in Linux has special treatment, and won't react as most processes do to certain signals (kill, int, term...).
this means when the Kubernetes-Monitor gets an interrupt from Kubernetes, it probably will ignore it and later on be killed forcefully without a graceful attempt at shutting down.

this is probably insignificant for now, but may be more significant as time goes by when we split to worker/manager pattern and maybe attempt some caching or syncing between adding/deleting workloads.

detailed article here https://engineeringblog.yelp.com/2016/01/dumb-init-an-init-for-docker.html

### More information

https://snyksec.atlassian.net/browse/RUN-511

### Screenshots

![image](https://user-images.githubusercontent.com/1255387/69056146-05249d80-0a18-11ea-8eec-567630631b0e.png)

