### PR TITLE
Chore/circleci fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,12 @@ workflows:
     jobs:
       - test_and_build:
           <<: *staging_branch_only_filter
+      - package_manager_test_apk:
+          <<: *staging_branch_only_filter
+      - package_manager_test_apt:
+          <<: *staging_branch_only_filter
+      - package_manager_test_rpm:
+          <<: *staging_branch_only_filter
       - tag_and_push:
           requires:
             - test_and_build
@@ -211,12 +217,6 @@ workflows:
       - deploy_dev:
           requires:
             - tag_and_push
-          <<: *staging_branch_only_filter
-      - package_manager_test_apk:
-          <<: *staging_branch_only_filter
-      - package_manager_test_apt:
-          <<: *staging_branch_only_filter
-      - package_manager_test_rpm:
           <<: *staging_branch_only_filter
 
   MERGE_TO_MASTER:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

tag_and_push to require package manager tests:

the tag_and_push phase should run only when we have asserted our candidate product is good-to-go.
right now it only waits for the test_and_build phase, which means we don't wait for the package managers tests to succeed or fail before claiming the image is tested.

### More information

https://snyk.slack.com/archives/CDSMEJ29E/p1573997682011900