### PR TITLE
chore: move creation of secret not used by the Monitor

### DIFF
--- a/test/setup/index.ts
+++ b/test/setup/index.ts
@@ -72,22 +72,8 @@ export async function removeMonitor(): Promise<void> {
 }
 
 async function createEnvironment(imageNameAndTag: string): Promise<void> {
-  await platforms.kind.create(imageNameAndTag);
   await kubectl.downloadKubectl();
-}
-
-async function installKubernetesMonitor(imageNameAndTag: string): Promise<string> {
-  const namespace = 'snyk-monitor';
-  await kubectl.createNamespace(namespace);
-
-  const secretName = 'snyk-monitor';
-  const integrationId = getIntegrationId();
-  const gcrDockercfg = getEnvVariableOrDefault('GCR_IO_DOCKERCFG', '{}');
-  await kubectl.createSecret(secretName, namespace, {
-    'dockercfg.json': gcrDockercfg,
-    integrationId,
-  });
-
+  await platforms.kind.create(imageNameAndTag);
   const servicesNamespace = 'services';
   await kubectl.createNamespace(servicesNamespace);
   // Small hack to prevent timing problems in CircleCI...
@@ -111,6 +97,19 @@ async function installKubernetesMonitor(imageNameAndTag: string): Promise<string
     gcrKubectlSecretsKeyPrefix,
     gcrSecretType,
   );
+}
+
+async function installKubernetesMonitor(imageNameAndTag: string): Promise<string> {
+  const namespace = 'snyk-monitor';
+  await kubectl.createNamespace(namespace);
+
+  const secretName = 'snyk-monitor';
+  const integrationId = getIntegrationId();
+  const gcrDockercfg = getEnvVariableOrDefault('GCR_IO_DOCKERCFG', '{}');
+  await kubectl.createSecret(secretName, namespace, {
+    'dockercfg.json': gcrDockercfg,
+    integrationId,
+  });
 
   const testYaml = 'snyk-monitor-test-deployment.yaml';
   createTestYamlDeployment(testYaml, integrationId, imageNameAndTag);


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

introduced in https://github.com/snyk/kubernetes-monitor/commit/60644d950c78af1d57459e2f01b012edc7bc185e, part of our setup involves creating a secret so KinD is able to pull images from private registries.
this secret and its creation are not part of the Kubernetes-Monitor's behaviour, but of the environment where it runs.
moving its creation to a slightly more appropriate place.

the next step will be understanding if this config is required strictly for KinD, or if all other platforms would need it as well. the answer will dictate the place this secret creation belongs to.

### Notes for the reviewer

the git diff here is a bit misleading - I recommend looking at the actual implementation of ```createEnvironment``` and ```installKubernetesMonitor``` before and after the change