### PR TITLE
chore: instruct containers to sleep when creating a deployment from an image

### DIFF
--- a/test/helpers/kubectl.ts
+++ b/test/helpers/kubectl.ts
@@ -56,7 +56,7 @@ export async function applyK8sYaml(pathToYamlDeployment: string): Promise<void> 
 
 export async function createDeploymentFromImage(name: string, image: string, namespace: string) {
   console.log(`Letting Kubernetes decide how to manage image ${image} with name ${name}`);
-  await exec(`./kubectl run ${name} --image=${image} -n ${namespace}`);
+  await exec(`./kubectl run ${name} --image=${image} -n ${namespace} -- sleep 999999999`);
   console.log(`Done Letting Kubernetes decide how to manage image ${image} with name ${name}`);
 }
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

right now the containers will use their default command, usually resulting in nothing or a loop of crashing.
this creates race conditions in the Kubernetes Monitor and adds some sporadic behaviours to our tests.
for the consistent tests, let's make the behaviour of the containers consistent - just instructing them to sleep.