### PR TITLE
chore: eslint rule to enforce semicolons

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
     "prettier/@typescript-eslint"
   ],
   "rules": {
+    "@typescript-eslint/semi": "error",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/interface-name-prefix": "off",
     "@typescript-eslint/await-thenable": "error",

--- a/src/state.ts
+++ b/src/state.ts
@@ -9,7 +9,7 @@ const lruCacheOptions = {
   // eventually we will report again for that image, if it's still relevant
   maxAge: config.IMAGES_SCANNED_CACHE.MAX_AGE_MS,
   updateAgeOnGet: false,
-}
+};
 
 const state = {
   imagesAlreadyScanned: new lruCache<string, string>(lruCacheOptions),

--- a/src/transmitter/index.ts
+++ b/src/transmitter/index.ts
@@ -17,7 +17,7 @@ export async function sendDepGraph(...payloads: IDepGraphPayload[]): Promise<voi
       if (!isSuccessStatusCode(response.statusCode)) {
         throw new Error(`${response.statusCode} ${response.statusMessage}`);
       } else {
-        logger.info({payload: payloadWithoutDepGraph, attempt}, 'dependency graph sent upstream successfully')
+        logger.info({payload: payloadWithoutDepGraph, attempt}, 'dependency graph sent upstream successfully');
       }
     } catch (error) {
       logger.error({error, payload: payloadWithoutDepGraph}, 'could not send the dependency scan result to Homebase');
@@ -27,13 +27,13 @@ export async function sendDepGraph(...payloads: IDepGraphPayload[]): Promise<voi
 
 export async function sendWorkloadMetadata(payload: IWorkloadMetadataPayload): Promise<void> {
     try {
-      logger.info({workloadLocator: payload.workloadLocator}, 'attempting to send workload metadata upstream')
+      logger.info({workloadLocator: payload.workloadLocator}, 'attempting to send workload metadata upstream');
 
       const {response, attempt} = await retryRequest('post', `${upstreamUrl}/api/v1/workload`, payload);
       if (!isSuccessStatusCode(response.statusCode)) {
         throw new Error(`${response.statusCode} ${response.statusMessage}`);
       } else {
-        logger.info({workloadLocator: payload.workloadLocator, attempt}, 'workload metadata sent upstream successfully')
+        logger.info({workloadLocator: payload.workloadLocator, attempt}, 'workload metadata sent upstream successfully');
       }
     } catch (error) {
       logger.error({error, workloadLocator: payload.workloadLocator}, 'could not send workload metadata to Homebase');
@@ -51,7 +51,7 @@ export async function deleteHomebaseWorkload(payload: IDeleteWorkloadPayload): P
     if (!isSuccessStatusCode(response.statusCode)) {
       throw new Error(`${response.statusCode} ${response.statusMessage}`);
     } else {
-      logger.info({workloadLocator: payload.workloadLocator, attempt}, 'workload deleted successfully')
+      logger.info({workloadLocator: payload.workloadLocator, attempt}, 'workload deleted successfully');
     }
   } catch (error) {
     logger.error({error, payload}, 'could not send workload to delete to Homebase');
@@ -66,7 +66,7 @@ async function retryRequest(verb: NeedleHttpVerbs, url: string, payload: object)
   const retry = {
     attempts: 3,
     intervalSeconds: 2,
-  }
+  };
   const options = {
     json: true,
     compressed: true,

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -11,6 +11,7 @@
     "prettier/@typescript-eslint"
   ],
   "rules": {
+    "@typescript-eslint/semi": "error",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-non-null-assertion": "off",

--- a/test/integration/kubernetes.test.ts
+++ b/test/integration/kubernetes.test.ts
@@ -27,7 +27,7 @@ tap.test('start with clean environment', async () => {
   } catch (error) {
     console.log(`could not start with a clean environment: ${error.message}`);
   }
-})
+});
 
 // Make sure this runs first -- deploying the monitor for the next tests
 tap.test('deploy snyk-monitor', async (t) => {

--- a/test/setup/platforms/index.ts
+++ b/test/setup/platforms/index.ts
@@ -20,9 +20,9 @@ const eksSetup: IPlatformSetup = {
   create: eks.createCluster,
   delete: eks.deleteCluster,
   config: eks.exportKubeConfig,
-}
+};
 
 export default {
   kind: kindSetup,
   eks: eksSetup,
-}
+};

--- a/test/unit/metadata-extractor.test.ts
+++ b/test/unit/metadata-extractor.test.ts
@@ -70,7 +70,7 @@ tap.test('buildImageMetadata', async (t) => {
     specMeta: deploymentObject.spec!.template.metadata!,
     ownerRefs: deploymentObject.metadata!.ownerReferences,
     podSpec: deploymentObject.spec!.template.spec!,
-  }
+  };
 
   const imageMetadataResult = metadataExtractor.buildImageMetadata(
     deploymentWeirdWrapper,


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

eslint rule to enforce semicolons.
also fixing all the places it's missing.