### PR TITLE
chore: cleanup unused ci&cd notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,16 +214,6 @@ jobs:
           command: ./scripts/slack-notify-failure.sh "deploy-dev"
           when: on_fail
 
-######################## PR TO MASTER ########################
-  prepublish:
-    <<: *default_container_config
-    steps:
-      - checkout
-      - run:
-          name: PREPUBLISH
-          command: |
-            ./scripts/slack-notify-pr.sh
-
 ######################## MERGE TO MASTER ########################
   publish:
     <<: *default_container_config

--- a/scripts/slack-notify-pr.sh
+++ b/scripts/slack-notify-pr.sh
@@ -1,2 +1,0 @@
-#! /bin/bash
-curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "warning", "fallback": "Build Notification: '$CIRCLE_BUILD_URL'", "title": "Kubernetes-Monitor Publish Notification", "text": ":egg: A new version is about to be published! :egg:\n'$CIRCLE_PULL_REQUEST'\nbranch of origin is `TODO`"}]}' $SLACK_WEBHOOK


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

when we used Travis, we had a workflow/job/command/egg to handle cases where PRs are open from staging to the master branch.
this flow has been irrelevant since our migration to CircleCI, which cares less about opening PRs and more about pushing commits.
removing its unused references and the script it used to invoke.