### PR TITLE
chore: rename EKS cluster used in integration tests

### DIFF
--- a/test/setup/platforms/eks.ts
+++ b/test/setup/platforms/eks.ts
@@ -10,7 +10,7 @@ export async function deleteCluster(): Promise<void> {
 }
 
 export async function exportKubeConfig(): Promise<void> {
-  await exec('aws eks update-kubeconfig --name runtime-experiments --kubeconfig ./kubeconfig');
+  await exec('aws eks update-kubeconfig --name runtime-integration-test --kubeconfig ./kubeconfig');
   process.env.KUBECONFIG = './kubeconfig';
 }
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

the cluster called "runtime-experiments" was used when researching/testing our solution.
since clusters apparently may not be renamed, I'm creating a new one for our integration test, with a name that would reflect its role.
the existing cluster will be used for actual experiments.

### More information

https://snyksec.atlassian.net/browse/RUN-514