### PR TITLE
fix: bump snyk-docker-plugin to 1.36.0 to fix static scanning bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3153,8 +3153,7 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -3252,9 +3251,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.34.0.tgz",
-      "integrity": "sha512-b3NP5/mmqo4iOvhJL2HBq8DyfzvRtPH9AQLb+wYdJS++HyPErE0xvtKVd6ES8JDVZONG4v5UFhViAsoFETH5yA==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.36.0.tgz",
+      "integrity": "sha512-WAK8Oqw11XZyHR6hYB1Bfhol+HxBvozjUkLAIyXoVZ/BmnDcxM/IhCHqIdNcypCUh2Aml+TZFKOYIc0Mq42w8g==",
       "requires": {
         "debug": "^4.1.1",
         "dockerfile-ast": "0.0.16",
@@ -3270,11 +3269,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "needle": "^2.4.0",
     "sleep-promise": "^8.0.1",
     "snyk-config": "3.0.0",
-    "snyk-docker-plugin": "1.34.0",
+    "snyk-docker-plugin": "1.36.0",
     "source-map-support": "^0.5.9",
     "typescript": "^3.7.2",
     "ws": "^7.0.0",


### PR DESCRIPTION
added another possible location of the os-release file

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

bumps snyk-docker-plugin in order to fix a bug in static scanning

### More information

- [Jira ticket RUN-558](https://snyksec.atlassian.net/browse/RUN-558)

