### PR TITLE
fix: adding comments to our plain yaml files for Jekyll to ignore them

### DIFF
--- a/snyk-monitor-cluster-permissions.yaml
+++ b/snyk-monitor-cluster-permissions.yaml
@@ -1,3 +1,7 @@
+#
+# This file sets up the cluster-wide permissions required to run the Kubernetes-Monitor
+#
+
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -1,3 +1,7 @@
+#
+# This file creates the deployment that runs the Kubernetes-Monitor
+#
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/snyk-monitor-namespaced-permissions.yaml
+++ b/snyk-monitor-namespaced-permissions.yaml
@@ -1,3 +1,7 @@
+#
+# This file sets up the namespace-specific permissions required to run the Kubernetes-Monitor
+#
+
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Jekyll, the web page builder that gh-pages uses by default, processes yaml files and changes their content by default.
adding a few comments at the beginning of the file appears to cause Jekyll to ignore them, which is what we need, as our users intend to use them as-is.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Said above

### More information

- [Jira ticket Run-558](https://snyksec.atlassian.net/browse/RUN-558)

