### PR TITLE
fix: stop logging during unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "pretest": "./scripts/build-image.sh",
     "test": "npm run lint && npm run build && npm run test:unit && npm run test:integration",
-    "test:unit": "tap test/unit -R spec",
+    "test:unit": "NODE_ENV=test tap test/unit -R spec",
     "test:integration": "TEST_PLATFORM=kind CREATE_CLUSTER=true tap test/integration/kubernetes.test.ts -R spec --timeout=1200",
     "test:integration:kind": "TEST_PLATFORM=kind CREATE_CLUSTER=true tap test/integration/kubernetes.test.ts -R spec --timeout=1200",
     "test:integration:eks": "TEST_PLATFORM=eks CREATE_CLUSTER=false tap test/integration/kubernetes.test.ts -R spec --timeout=1200",

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -12,4 +12,8 @@ const logger: bunyan = bunyan.createLogger({
   },
 });
 
+if (process.env.NODE_ENV === 'test') {
+  logger.level(bunyan.FATAL + 1);
+}
+
 export = logger;


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

our logs add a lot of noise and don't really contribute to anything when running "npm run test:unit".
this commit turns off logs during that context using an envrionment variable NODE_ENV.
anything else should be unaffected.

"fix" instead of "chore" because this commit changes actual production code and I want it to be treated as such.

seeing the console spammed with these messages doesn't really help:
>     {"name":"kubernetes-monitor","hostname":"Amirs-MacBook-Pro.local","pid":16039,"level":40,"message":"Unknown reason","bin":"skopeo","loggableArguments":["copy","docker://nginx:latest","docker-archive:undefined"],"msg":"child process failure","time":"2020-01-01T13:30:40.622Z","v":0}
>
    {"name":"kubernetes-monitor","hostname":"Amirs-MacBook-Pro.local","pid":16039,"level":50,"error":{"message":"spawn skopeo ENOENT","name":"Error","stack":"Error: spawn skopeo ENOENT\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:232:19)\n    at onErrorNT (internal/child_process.js:407:16)\n    at process._tickCallback (internal/process/next_tick.js:63:19)\n    at Function.Module.runMain (internal/modules/cjs/loader.js:744:11)\n    at runMain (/Users/amir/.node-spawn-wrap-16034-f3cd61a1f72c/node:68:10)\n    at Function.<anonymous> (/Users/amir/.node-spawn-wrap-16034-f3cd61a1f72c/node:171:5)\n    at Object.<anonymous> (/Users/amir/projects/kubernetes-monitor/node_modules/nyc/bin/wrap.js:27:4)\n    at Module._compile (internal/modules/cjs/loader.js:688:30)\n    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)\n    at Module.load (internal/modules/cjs/loader.js:598:32)","code":"ENOENT"},"image":"nginx:latest","msg":"failed to pull image","time":"2020-01-01T13:30:40.624Z","v":0}
