### PR TITLE
chore: removing unused reference to `gh-pages` branch from circle conf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,8 +363,3 @@ workflows:
             branches:
               only:
                 - master
-
-general:
-  branches:
-    ignore:
-      - gh-pages


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

whenever we push (automatically) to `gh-pages`, we get a build failure.
this piece of configuration is unused, as it's not even in the `gh-pages` branch.

this is not the actual fix ; the fix for the problem would come in the form of some minimal ```.circleci/config.yml``` config in the ```gh-pages``` branch.

https://snyksec.atlassian.net/browse/RUN-566