### PR TITLE
chore: don't run any CircleCI job for the gh-pages branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,8 @@
+version: 2
+
+jobs:
+  build:
+    branches:
+      ignore:
+        - gh-pages
+        - chore/mock-circleci-config


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

ignore the ```gh-pages``` branch in CircleCI
it's a branch we automatically deploy to, and don't need CircleCI running anything for it.
this commit helps reduce some noise.

### Notes for the reviewer

this PR will not be merged. if it's approved, I will remove the ```chore/mock-circleci-config``` ignore rule put there just to test/prove it works, then cherry-pick the working commit directly to the ```gh-pages``` branch.
please note the lack of commit statuses for this commit from CircleCI.

### More information

https://snyksec.atlassian.net/browse/RUN-566

### Screenshots

_Visuals that may help the reviewer_
