### PR TITLE
chore: bump KinD version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ config.local.json
 # test utilities
 kind
 kubectl
+kubeconfig-integration-test-kind
+snyk-monitor-test-deployment.yaml

--- a/test/setup/platforms/kind.ts
+++ b/test/setup/platforms/kind.ts
@@ -20,8 +20,10 @@ export async function deleteCluster(): Promise<void> {
 
 export async function exportKubeConfig(): Promise<void> {
   console.log('Exporting K8s config...');
-  const kindResponse = await exec(`./kind get kubeconfig-path --name="${clusterName}"`);
-  const configPath = kindResponse.stdout.replace(/[\n\t\r]/g, '');
+  const kubeconfigResult = await exec('./kind get kubeconfig');
+  const kubeconfigContent = kubeconfigResult.stdout;
+  const configPath = './kubeconfig-integration-test-kind';
+  writeFileSync(configPath, kubeconfigContent);
   process.env.KUBECONFIG = configPath;
   console.log('Exported K8s config!');
 }
@@ -48,7 +50,7 @@ async function download(osDistro: string): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/camelcase
     const requestOptions = { follow_max: 2 };
     await needle('get',
-      `https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-${osDistro}-amd64`,
+      `https://github.com/kubernetes-sigs/kind/releases/download/v0.6.1/kind-${osDistro}-amd64`,
       bodyData,
       requestOptions,
     ).then((response) => {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

KinD 0.3.0 was released on May 2019, let's bump this

as part of the version bump, KinD is deprecating the "get kubeconfig-path".
instead, they alter supposedly the default kubeconfig file, and recommend to use it through the context flag.
this makes our testing infra a bit more complex because we're using sometimes the Kubernetes API client and sometimes kubectl.

an easy workaround I have chosen was to dump kubeconfig's content to a new file, and just export its location as we used to.

[RUN-572](https://snyksec.atlassian.net/browse/RUN-572)