### PR TITLE
chore: remove TODOs that won't be handled

### DIFF
--- a/src/supervisor/watchers/handlers/cron-job.ts
+++ b/src/supervisor/watchers/handlers/cron-job.ts
@@ -6,7 +6,6 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 export async function cronJobWatchHandler(cronJob: V1beta1CronJob): Promise<void> {
   if (!cronJob.metadata || !cronJob.spec || !cronJob.spec.jobTemplate.spec ||
       !cronJob.spec.jobTemplate.metadata || !cronJob.spec.jobTemplate.spec.template.spec) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/watchers/handlers/daemon-set.ts
+++ b/src/supervisor/watchers/handlers/daemon-set.ts
@@ -6,7 +6,6 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 export async function daemonSetWatchHandler(daemonSet: V1DaemonSet): Promise<void> {
   if (!daemonSet.metadata || !daemonSet.spec || !daemonSet.spec.template.metadata ||
       !daemonSet.spec.template.spec || !daemonSet.status) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/watchers/handlers/deployment.ts
+++ b/src/supervisor/watchers/handlers/deployment.ts
@@ -6,7 +6,6 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 export async function deploymentWatchHandler(deployment: V1Deployment): Promise<void> {
   if (!deployment.metadata || !deployment.spec || !deployment.spec.template.metadata ||
       !deployment.spec.template.spec || !deployment.status) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/watchers/handlers/job.ts
+++ b/src/supervisor/watchers/handlers/job.ts
@@ -5,7 +5,6 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 
 export async function jobWatchHandler(job: V1Job): Promise<void> {
   if (!job.metadata || !job.spec || !job.spec.template.metadata || !job.spec.template.spec) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/watchers/handlers/replica-set.ts
+++ b/src/supervisor/watchers/handlers/replica-set.ts
@@ -6,7 +6,6 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 export async function replicaSetWatchHandler(replicaSet: V1ReplicaSet): Promise<void> {
   if (!replicaSet.metadata || !replicaSet.spec || !replicaSet.spec.template ||
       !replicaSet.spec.template.metadata || !replicaSet.spec.template.spec || !replicaSet.status) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/watchers/handlers/replication-controller.ts
+++ b/src/supervisor/watchers/handlers/replication-controller.ts
@@ -7,7 +7,6 @@ export async function replicationControllerWatchHandler(replicationController: V
   if (!replicationController.metadata || !replicationController.spec || !replicationController.spec.template ||
       !replicationController.spec.template.metadata || !replicationController.spec.template.spec ||
       !replicationController.status) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/watchers/handlers/stateful-set.ts
+++ b/src/supervisor/watchers/handlers/stateful-set.ts
@@ -6,7 +6,6 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 export async function statefulSetWatchHandler(statefulSet: V1StatefulSet): Promise<void> {
   if (!statefulSet.metadata || !statefulSet.spec || !statefulSet.spec.template.metadata ||
       !statefulSet.spec.template.spec || !statefulSet.status) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/workload-reader.ts
+++ b/src/supervisor/workload-reader.ts
@@ -14,7 +14,6 @@ const deploymentReader: IWorkloadReaderFunc = async (workloadName, namespace) =>
 
   if (!deployment.metadata || !deployment.spec || !deployment.spec.template.metadata ||
       !deployment.spec.template.spec || !deployment.status) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
     return undefined;
   }
 
@@ -35,7 +34,6 @@ const replicaSetReader: IWorkloadReaderFunc = async (workloadName, namespace) =>
 
   if (!replicaSet.metadata || !replicaSet.spec || !replicaSet.spec.template ||
       !replicaSet.spec.template.metadata || !replicaSet.spec.template.spec || !replicaSet.status) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
     return undefined;
   }
 
@@ -56,7 +54,6 @@ const statefulSetReader: IWorkloadReaderFunc = async (workloadName, namespace) =
 
   if (!statefulSet.metadata || !statefulSet.spec || !statefulSet.spec.template.metadata ||
       !statefulSet.spec.template.spec || !statefulSet.status) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
     return undefined;
   }
 
@@ -77,7 +74,6 @@ const daemonSetReader: IWorkloadReaderFunc = async (workloadName, namespace) => 
 
   if (!daemonSet.metadata || !daemonSet.spec || !daemonSet.spec.template.spec ||
       !daemonSet.spec.template.metadata || !daemonSet.status) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
     return undefined;
   }
 
@@ -97,7 +93,6 @@ const jobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
   const job = jobResult.body;
 
   if (!job.metadata || !job.spec || !job.spec.template.spec || !job.spec.template.metadata) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
     return undefined;
   }
 
@@ -120,7 +115,6 @@ const cronJobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
 
   if (!cronJob.metadata || !cronJob.spec || !cronJob.spec.jobTemplate.metadata ||
       !cronJob.spec.jobTemplate.spec || !cronJob.spec.jobTemplate.spec.template.spec) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
     return undefined;
   }
 
@@ -141,7 +135,6 @@ const replicationControllerReader: IWorkloadReaderFunc = async (workloadName, na
   if (!replicationController.metadata || !replicationController.spec || !replicationController.spec.template ||
       !replicationController.spec.template.metadata || !replicationController.spec.template.spec ||
       !replicationController.status) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
     return undefined;
   }
 


### PR DESCRIPTION
Review and remove most of the TODOs in the code. We don't need to actively log when the K8s API server returns insufficient metadata because even if it did, we couldn't perform any action to remediate this behaviour.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
