### PR TITLE
fix: assert file system path for skopeo copy is truthy

### DIFF
--- a/src/scanner/images/index.ts
+++ b/src/scanner/images/index.ts
@@ -8,6 +8,10 @@ export async function pullImages(images: IPullableImage[]): Promise<IPullableIma
 
   for (const image of images) {
     const {imageName, fileSystemPath} = image;
+    if (!fileSystemPath) {
+      continue;
+    }
+
     try {
       await skopeoCopy(imageName, fileSystemPath);
       pulledImages.push(image);


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

pullImages implicitly relies on the list of pullable images it receives to have fileSystemPaths for each image, as a valid path in the filesystem where we can instruct Skopeo to pull images to.
right now, it accepts undefined values as these paths, resulting in calls to Skopeo creating a file named "undefined" on the filesystem.
this commit amends this behaviour by asserting the fileSystemPath is truthy before calling Skopeo.

### More information

https://snyksec.atlassian.net/browse/RUN-614