### PR TITLE
chore: semantic release breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "url": "https://github.com/snyk/kubernetes-monitor.git"
   },
   "release": {
-    "branch": "staging",
+    "branches": "staging",
     "verifyConditions": [
       "@semantic-release/github"
     ],


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

semantic release 16.0.0 introduced these breaking changes:

> The branch option has been removed in favor of branches

> The new branches option expect either an Array or a single branch definition. To migrate your configuration:

> If you want to publish package from multiple branches, please see the configuration documentation
> If you use the default configuration and want to publish only from master: nothing to change
> If you use the branch configuration and want to publish only from one branch: replace branch with branches ("branch": "my-release-branch" => "branches": "my-release-branch")

this commit aligns our semantic release config to the new format

### More information

https://circleci.com/gh/snyk/kubernetes-monitor/2519
https://snyksec.atlassian.net/browse/RUN-615
https://semantic-release.gitbook.io/semantic-release/usage/configuration
https://github.com/semantic-release/semantic-release/releases