### PR TITLE
Fix/ecr image determination

### DIFF
--- a/src/scanner/images/credentials.ts
+++ b/src/scanner/images/credentials.ts
@@ -11,8 +11,10 @@ export async function getSourceCredentials(imageSource: string): Promise<string 
 }
 
 export function isEcrSource(imageSource: string): boolean {
-  // TODO is this the best way we can determine the image's source?
-  return imageSource.indexOf('.ecr.') !== -1;
+  // this regex tests the image source against the template:
+  // <SOMETHING>.dkr.ecr.<SOMETHING>.amazonaws.com/<SOMETHING>
+  const ecrImageRegex = new RegExp('\.dkr\.ecr\..*\.amazonaws\.com\/', 'i');
+  return ecrImageRegex.test(imageSource);
 }
 
 function getEcrCredentials(region: string): Promise<string> {

--- a/test/unit/scanner/image-registry-credentials.test.ts
+++ b/test/unit/scanner/image-registry-credentials.test.ts
@@ -22,8 +22,14 @@ tap.test('isEcrSource()', async (t) => {
   t.equals(sourceCredentialsForRandomImageName, false, 'unidentified image source is not ECR');
 
   const sourceCredentialsForInvalidEcrImage = credentials.isEcrSource('derka.ecr.derka');
-  t.equals(sourceCredentialsForInvalidEcrImage, true, 'image with .ecr. is considered ECR');
+  t.equals(sourceCredentialsForInvalidEcrImage, false, 'image just with .ecr. is not considered from ECR');
 
   const sourceCredentialsForEcrImage = credentials.isEcrSource('aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:latest');
-  t.equals(sourceCredentialsForEcrImage, true, 'image with .ecr. is considered ECR');
+  t.equals(sourceCredentialsForEcrImage, true, 'correct ECR template');
+
+  const sourceCredentialsForEcrImageWithRepo = credentials.isEcrSource('a291964488713.dkr.ecr.us-east-2.amazonaws.com/snyk/debian:10');
+  t.equals(sourceCredentialsForEcrImageWithRepo, true, 'correct ECR template');
+
+  const sourceCredentialsForEcrImageMixedCase = credentials.isEcrSource('aws_account_id.dKr.ecR.region.amazonAWS.cOm/my-web-app:latest');
+  t.equals(sourceCredentialsForEcrImageMixedCase, true, 'correct ECR template');
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

refine how we identify images from ECR so we're less prone to falsely identifying them.
instead of just looking for the ".ecr." string, we'll look for all constant parts of the string as documented in AWS here: https://docs.aws.amazon.com/AmazonECR/latest/userguide/ECR_on_EKS.html

### More information

https://snyksec.atlassian.net/browse/RUN-608
