### PR TITLE
fix: use high uid/gid to support openshift

### DIFF
--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -64,8 +64,8 @@ spec:
             cpu: '1'
             memory: '2Gi'
         securityContext:
-          runAsUser: 10001
-          runAsGroup: 10001
+          runAsUser: 1000510001
+          runAsGroup: 1000510001
           privileged: false
           runAsNonRoot: true
           allowPrivilegeEscalation: false

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -54,8 +54,8 @@ spec:
               cpu: '1'
               memory: '2Gi'
           securityContext:
-            runAsUser: 10001
-            runAsGroup: 10001
+            runAsUser: 1000510001
+            runAsGroup: 1000510001
             privileged: false
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/test/helpers/deployment.ts
+++ b/test/helpers/deployment.ts
@@ -42,8 +42,8 @@ export function validateSecureConfiguration(test: tap, deployment: V1Deployment)
   tap.ok(securityContext.allowPrivilegeEscalation === false, 'must explicitly set allowPrivilegeEscalation to false');
   tap.ok(securityContext.privileged === false, 'must explicitly set privileged to false');
   tap.ok(securityContext.runAsNonRoot === true, 'must explicitly set runAsNonRoot to true');
-  tap.ok(securityContext.runAsUser === 10001, 'must explicitly set runAsUser to 10001');
-  tap.ok(securityContext.runAsGroup === 10001, 'must explicitly set runAsGroup to 10001');
+  tap.ok(securityContext.runAsUser === 1000510001, 'must explicitly set runAsUser to 1000510001');
+  tap.ok(securityContext.runAsGroup === 1000510001, 'must explicitly set runAsGroup to 1000510001');
 }
 
 export function validateVolumeMounts(test: tap, deployment: V1Deployment) {


### PR DESCRIPTION
OpenShift supports runAsUser and runAsGroup from as high as 1000510000.
Change these values in our deployments to enable the snyk-monitor to run there.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### More information

- [Notion page](https://www.notion.so/snyk/Setting-up-an-Open-Shift-Cluster-34e68e60d9cf4e9f895bfa7bdf786556)

