### PR TITLE
fix: check k8s-api error for response before assuming it's there

### DIFF
--- a/src/supervisor/kuberenetes-api-wrappers.ts
+++ b/src/supervisor/kuberenetes-api-wrappers.ts
@@ -12,6 +12,10 @@ export async function retryKubernetesApiRequest(func: IKubernetesApiFunction) {
     try {
       return await func();
     } catch (err) {
+      if (!(err.response)) {
+        throw err;
+      }
+
       const response = err.response;
       if (response.statusCode !== 429) {
         throw err;

--- a/test/unit/supervisor/kubernetes-api-wrappers.test.ts
+++ b/test/unit/supervisor/kubernetes-api-wrappers.test.ts
@@ -100,3 +100,20 @@ tap.test('retryKubernetesApiRequest for non-retryable errors', async (t) => {
   );
   t.equals(failures, 1, 'did not retry even once for non-retryable error code');
 });
+
+tap.test('retryKubernetesApiRequest for errors without response', async (t) => {
+  const errorWithoutResponse = 'there\'s butter on my face!';
+
+  let failures = 0;
+  const functionThatFails = () => {
+    failures +=1;
+    return Promise.reject(new Error(errorWithoutResponse));
+  };
+
+  t.rejects(
+    () => kubernetesApiWrappers.retryKubernetesApiRequest(functionThatFails),
+    new Error(errorWithoutResponse),
+    'errors without a response property are immediately rethrown',
+  );
+  t.equals(failures, 1, 'did not retry even once for non-retryable error code');
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

rethrow errors from Kubernetes-API that are not retry-able.
check the error object for the expected HTTP response before assuming it's there.

I expect that next time we'll see the real error that we masked here.

https://snyk.slack.com/archives/CFSQFR0TH/p1580138622000100