### PR TITLE
chore: relax checks on runAsUser and runAsGroup

### DIFF
--- a/test/helpers/deployment.ts
+++ b/test/helpers/deployment.ts
@@ -42,8 +42,16 @@ export function validateSecureConfiguration(test: tap, deployment: V1Deployment)
   tap.ok(securityContext.allowPrivilegeEscalation === false, 'must explicitly set allowPrivilegeEscalation to false');
   tap.ok(securityContext.privileged === false, 'must explicitly set privileged to false');
   tap.ok(securityContext.runAsNonRoot === true, 'must explicitly set runAsNonRoot to true');
-  tap.ok(securityContext.runAsUser === 10001, 'must explicitly set runAsUser to 10001');
-  tap.ok(securityContext.runAsGroup === 10001, 'must explicitly set runAsGroup to 10001');
+  tap.ok(
+    securityContext.runAsUser !== undefined &&
+      securityContext.runAsUser >= 10001,
+    'must explicitly set runAsUser to be 10001 or greater',
+  );
+  tap.ok(
+    securityContext.runAsGroup !== undefined &&
+      securityContext.runAsGroup >= 10001,
+    'must explicitly set runAsGroup to be 10001 or greater',
+  );
 }
 
 export function validateVolumeMounts(test: tap, deployment: V1Deployment) {


### PR DESCRIPTION
To allow our tests to check some security properties at runtime, we need to relax specifically runAsUser and runAsGroup.
For OpenShift the UID/GID is a very high number but it is also randomised, so there is no need for us to try and predict it and be exact in our tests.
The change will allow any sufficiently high UID/GID (>=10001), which should still be a good measure of following security best practices.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
