### PR TITLE
Chore/cci exclusive job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
             export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable") &&
             export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=snyk/kubernetes-monitor:${IMAGE_TAG}-${CIRCLE_SHA1} &&
             docker pull ${KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG} &&
-            .circleci/do-exclusively --branch staging npm run test:integration:eks
+            .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:eks
       - run:
           name: Notify Slack on failure
           command: |

--- a/.circleci/do-exclusively
+++ b/.circleci/do-exclusively
@@ -8,6 +8,7 @@ parse_args() {
         case $1 in
             -b|--branch) branch="$2" ;;
             -t|--tag) tag="$2" ;;
+            -j|--job) job="$2" ;;
             *) break ;;
         esac
         shift 2
@@ -41,6 +42,10 @@ make_jq_prog() {
 
     if [[ $tag ]]; then
         jq_filters+=" and (.subject | contains(\"[$tag]\"))"
+    fi
+
+    if [[ $job ]]; then
+        jq_filters+=" and .workflows.job_name == \"$job\""
     fi
 
     jq_prog=".[] | select(.build_num < $CIRCLE_BUILD_NUM and (.status | test(\"running|pending|queued\")) $jq_filters) | .build_num"


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

We use a script to help us run tests sequentially for things like EKS, which require that we access the EKS cluster one at a time. The script currently waits for all jobs on a branch to clear before proceeding. If we added more jobs that depend on this script they would all block even though only the ones of the same kind should be sequential and the rest are safe to run parallel.
For example if an `rpm` job claims exclusivity it should be blocked by other `rpm` jobs and not by every job.

### Notes for the reviewer

Tested manually with...
```shell
CIRCLE_BUILD_NUM=4000 CIRCLE_BRANCH=ivan/test2 CIRCLE_PROJECT_USERNAME=snyk CIRCLE_PROJECT_REPONAME=kubernetes-monitor CIRCLE_TOKEN=<token from CircleCI> ./.circleci/do-exclusively -b ivan/test2 -j package_manager_test_rpm echo "done"
```
...while pushing something to the branch - this allowed to detect an `rpm` job and wait on it until it completed.
