### PR TITLE
Amir/ohgod

### DIFF
--- a/test/integration/kubernetes.test.ts
+++ b/test/integration/kubernetes.test.ts
@@ -13,20 +13,10 @@ import * as kubectl from '../helpers/kubectl';
 
 let integrationId: string;
 
-async function tearDown() {
+tap.tearDown(async() => {
   console.log('Begin removing the snyk-monitor...');
   await setup.removeMonitor();
   console.log('Removed the snyk-monitor!');
-}
-
-tap.tearDown(tearDown);
-
-tap.test('start with clean environment', async () => {
-  try {
-    await tearDown();
-  } catch (error) {
-    console.log(`could not start with a clean environment: ${error.message}`);
-  }
 });
 
 // Make sure this runs first -- deploying the monitor for the next tests

--- a/test/integration/package-manager.test.ts
+++ b/test/integration/package-manager.test.ts
@@ -19,13 +19,11 @@ if (!packageManager) {
   throw new Error('Missing PACKAGE_MANAGER environment variable');
 }
 
-async function tearDown() {
+tap.tearDown(async () => {
   console.log('Begin removing the snyk-monitor...');
   await removeMonitor();
   console.log('Removed the snyk-monitor!');
-}
-
-tap.tearDown(tearDown);
+});
 
 // Make sure this runs first -- deploying the monitor for the next tests
 tap.test('deploy snyk-monitor', async (t) => {

--- a/test/setup/index.ts
+++ b/test/setup/index.ts
@@ -135,9 +135,12 @@ export async function deployMonitor(): Promise<string> {
     await kubectl.downloadKubectl();
     if (createCluster) {
       await platforms[testPlatform].create();
+      await platforms[testPlatform].config();
+    } else {
+      await platforms[testPlatform].config();
+      await platforms[testPlatform].clean();
     }
     const remoteImageName = await platforms[testPlatform].loadImage(imageNameAndTag);
-    await platforms[testPlatform].config();
     await createEnvironment();
     await createSecretForGcrIoAccess();
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

- stop removing ```KUBECONFIG``` env var on test cleanup
- stop deleting snyk-monitor-test-deployment.yaml on test cleanup
- always cleanup before testing as part of the setup, not explicitly called by the test