### PR TITLE
chore: extract snyk-monitor deployment in tests

### DIFF
--- a/test/setup/deployers/index.ts
+++ b/test/setup/deployers/index.ts
@@ -1,0 +1,20 @@
+import * as yaml from './yaml';
+import { DeploymentType } from './types';
+
+interface IDeployer {
+  deploy: (
+    integrationId: string,
+    imageOpts: {
+      imageNameAndTag: string;
+      imagePullPolicy: string;
+    },
+  ) => Promise<void>;
+}
+
+const yamlDeployer: IDeployer = {
+  deploy: yaml.deployKubernetesMonitor,
+};
+
+export default {
+  [DeploymentType.YAML]: yamlDeployer,
+};

--- a/test/setup/deployers/types.ts
+++ b/test/setup/deployers/types.ts
@@ -1,0 +1,5 @@
+export enum DeploymentType {
+  YAML,
+  Helm,
+  Operator,
+}

--- a/test/setup/deployers/yaml.ts
+++ b/test/setup/deployers/yaml.ts
@@ -1,0 +1,63 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { parse, stringify } from 'yaml';
+
+import * as kubectl from '../../helpers/kubectl';
+
+export async function deployKubernetesMonitor(
+  integrationId: string,
+  imageOpts: {
+    imageNameAndTag: string;
+    imagePullPolicy: string;
+  },
+): Promise<void> {
+  const namespace = 'snyk-monitor';
+  await kubectl.createNamespace(namespace);
+
+  const secretName = 'snyk-monitor';
+  const gcrDockercfg = process.env['GCR_IO_DOCKERCFG'] || '{}';
+  await kubectl.createSecret(secretName, namespace, {
+    'dockercfg.json': gcrDockercfg,
+    integrationId,
+  });
+
+  const testYaml = 'snyk-monitor-test-deployment.yaml';
+  createTestYamlDeployment(testYaml, integrationId, imageOpts.imageNameAndTag, imageOpts.imagePullPolicy);
+
+  await kubectl.applyK8sYaml('./snyk-monitor-cluster-permissions.yaml');
+  await kubectl.applyK8sYaml('./snyk-monitor-test-deployment.yaml');
+}
+
+function createTestYamlDeployment(
+  newYamlPath: string,
+  integrationId: string,
+  imageNameAndTag: string,
+  imagePullPolicy: string,
+): void {
+  console.log('Creating YAML snyk-monitor deployment...');
+  const originalDeploymentYaml = readFileSync('./snyk-monitor-deployment.yaml', 'utf8');
+  const deployment = parse(originalDeploymentYaml);
+
+  deployment.spec.template.spec.containers[0].image = imageNameAndTag;
+  deployment.spec.template.spec.containers[0].imagePullPolicy = imagePullPolicy;
+
+  // This is important due to an odd bug when running on Travis.
+  // By adding the Google nameserver, the container can start resolving external hosts.
+  deployment.spec.template.spec.dnsConfig = {
+    nameservers: ['8.8.8.8'],
+  };
+
+  // Inject the integration ID that will be used throughout the integration tests.
+  deployment.spec.template.spec.containers[0].env[0] = {
+    name: 'SNYK_INTEGRATION_ID',
+    value: integrationId,
+  };
+
+  // Inject the baseUrl of kubernetes-upstream that snyk-monitor container use to send metadata
+  deployment.spec.template.spec.containers[0].env[2] = {
+    name: 'SNYK_INTEGRATION_API',
+    value: 'https://kubernetes-upstream.dev.snyk.io',
+  };
+
+  writeFileSync(newYamlPath, stringify(deployment));
+  console.log('Created YAML snyk-monitor deployment');
+}

--- a/test/setup/index.ts
+++ b/test/setup/index.ts
@@ -1,10 +1,11 @@
-import { readFileSync, writeFileSync } from 'fs';
 import * as sleep from 'sleep-promise';
 import * as uuidv4 from 'uuid/v4';
-import { parse, stringify } from 'yaml';
+
 import platforms from './platforms';
+import deployers from './deployers';
 import * as kubectl from '../helpers/kubectl';
 import * as waiters from './waiters';
+import { DeploymentType } from './deployers/types';
 
 const testPlatform = process.env['TEST_PLATFORM'] || 'kind';
 const createCluster = process.env['CREATE_CLUSTER'] === 'true';
@@ -20,41 +21,6 @@ function getEnvVariableOrDefault(envVarName: string, defaultValue: string): stri
   return value === undefined || value === ''
     ? defaultValue
     : value;
-}
-
-function createTestYamlDeployment(
-  newYamlPath: string,
-  integrationId: string,
-  imageNameAndTag: string,
-  imagePullPolicy: string,
-): void {
-  console.log('Creating test deployment...');
-  const originalDeploymentYaml = readFileSync('./snyk-monitor-deployment.yaml', 'utf8');
-  const deployment = parse(originalDeploymentYaml);
-
-  deployment.spec.template.spec.containers[0].image = imageNameAndTag;
-  deployment.spec.template.spec.containers[0].imagePullPolicy = imagePullPolicy;
-
-  // This is important due to an odd bug when running on Travis.
-  // By adding the Google nameserver, the container can start resolving external hosts.
-  deployment.spec.template.spec.dnsConfig = {
-    nameservers: ['8.8.8.8'],
-  };
-
-  // Inject the integration ID that will be used throughout the integration tests.
-  deployment.spec.template.spec.containers[0].env[0] = {
-    name: 'SNYK_INTEGRATION_ID',
-    value: integrationId,
-  };
-
-  // Inject the baseUrl of kubernetes-upstream that snyk-monitor container use to send metadata
-  deployment.spec.template.spec.containers[0].env[2] = {
-    name: 'SNYK_INTEGRATION_API',
-    value: 'https://kubernetes-upstream.dev.snyk.io',
-  };
-
-  writeFileSync(newYamlPath, stringify(deployment));
-  console.log('Created test deployment');
 }
 
 export async function removeMonitor(): Promise<void> {
@@ -96,30 +62,6 @@ async function createSecretForGcrIoAccess(): Promise<void> {
   );
 }
 
-async function installKubernetesMonitor(
-  imageNameAndTag: string,
-  imagePullPolicy: string,
-  ): Promise<string> {
-  const namespace = 'snyk-monitor';
-  await kubectl.createNamespace(namespace);
-
-  const secretName = 'snyk-monitor';
-  const integrationId = getIntegrationId();
-  const gcrDockercfg = getEnvVariableOrDefault('GCR_IO_DOCKERCFG', '{}');
-  await kubectl.createSecret(secretName, namespace, {
-    'dockercfg.json': gcrDockercfg,
-    integrationId,
-  });
-
-  const testYaml = 'snyk-monitor-test-deployment.yaml';
-  createTestYamlDeployment(testYaml, integrationId, imageNameAndTag, imagePullPolicy);
-
-  await kubectl.applyK8sYaml('./snyk-monitor-cluster-permissions.yaml');
-  await kubectl.applyK8sYaml('./snyk-monitor-test-deployment.yaml');
-
-  return integrationId;
-}
-
 export async function deployMonitor(): Promise<string> {
   console.log('Begin deploying the snyk-monitor...');
 
@@ -145,10 +87,18 @@ export async function deployMonitor(): Promise<string> {
     await createEnvironment();
     await createSecretForGcrIoAccess();
 
+    const integrationId = getIntegrationId();
+
     // TODO: hack, rewrite this
     const imagePullPolicy = testPlatform === 'kind' ? 'Never' : 'Always';
-
-    const integrationId = await installKubernetesMonitor(remoteImageName, imagePullPolicy);
+    const deploymentImageOptions = {
+      imageNameAndTag: remoteImageName,
+      imagePullPolicy,
+    };
+    await deployers[DeploymentType.YAML].deploy(
+      integrationId,
+      deploymentImageOptions,
+    );
     await waiters.waitForMonitorToBeReady();
     console.log(`Deployed the snyk-monitor with integration ID ${integrationId}`);
     return integrationId;


### PR DESCRIPTION
Similarly to our platforms module, create a module that handles the deployment of the snyk-monitor.
Today there are two ways to deploy the product: with YAMLs and with a Helm chart.
The goal of this deployment module is to add support for Helm deployments in the future, and for Operators.
This is the first step of organising the code, preserving the original flow, without extra refactoring.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
