### PR TITLE
fix: hardcode HOME in the deployment of snyk-monitor

### DIFF
--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -56,6 +56,8 @@ spec:
                 optional: true
           - name: SNYK_MONITOR_VERSION
             value: IMAGE_TAG_OVERRIDE_WHEN_PUBLISHING
+          - name: HOME
+            value: /srv/app
         resources:
           requests:
             cpu: '250m'

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
             value: {{ .Values.clusterName }}
           - name: SNYK_MONITOR_VERSION
             value: {{ .Values.image.tag }}
+          - name: HOME
+            value: /srv/app
           resources:
             requests:
               cpu: '250m'

--- a/src/common/process.ts
+++ b/src/common/process.ts
@@ -16,6 +16,7 @@ export function exec(bin: string, ...processArgs: IProcessArgument[]):
   // For example, that process doesn't need to know secrets like our integrationId!
   const env = {
     PATH: process.env.PATH,
+    HOME: process.env.HOME,
   };
 
   const allArguments = processArgs.map((arg) => arg.body);

--- a/test/helpers/deployment.ts
+++ b/test/helpers/deployment.ts
@@ -1,6 +1,26 @@
 import * as tap from 'tap';
 import { V1Deployment } from '@kubernetes/client-node';
 
+export function validateEnvironmentVariables(test: tap, deployment: V1Deployment) {
+  if (
+    !deployment.spec ||
+    !deployment.spec.template.spec ||
+    !deployment.spec.template.spec.containers ||
+    deployment.spec.template.spec.containers.length === 0 ||
+    !deployment.spec.template.spec.containers[0].env
+  ) {
+    test.fail('bad container spec or missing env');
+    return;
+  }
+
+  const env = deployment.spec.template.spec.containers[0].env;
+
+  const envHasHomeEntry = env.some(
+    (entry) => entry.name === 'HOME' && entry.value === '/srv/app',
+  );
+  test.ok(envHasHomeEntry, 'has HOME entry in env variables');
+}
+
 export function validateSecureConfiguration(test: tap, deployment: V1Deployment) {
   if (
     !deployment.spec ||

--- a/test/integration/kubernetes.test.ts
+++ b/test/integration/kubernetes.test.ts
@@ -8,7 +8,11 @@ import {
   validateUpstreamStoredMetadata,
   getUpstreamResponseBody,
 } from '../helpers/kubernetes-upstream';
-import { validateSecureConfiguration, validateVolumeMounts } from '../helpers/deployment';
+import {
+  validateSecureConfiguration,
+  validateVolumeMounts,
+  validateEnvironmentVariables,
+} from '../helpers/deployment';
 import * as kubectl from '../helpers/kubectl';
 
 let integrationId: string;
@@ -241,6 +245,7 @@ tap.test('snyk-monitor secure configuration is as expected', async (t) => {
 
   validateSecureConfiguration(t, deployment);
   validateVolumeMounts(t, deployment);
+  validateEnvironmentVariables(t, deployment);
 });
 
 /**

--- a/test/unit/deployment-files.test.ts
+++ b/test/unit/deployment-files.test.ts
@@ -3,7 +3,11 @@ import { parse } from 'yaml';
 import { readFileSync } from 'fs';
 import { V1Deployment } from '@kubernetes/client-node';
 import * as snykConfig from '../../src/common/config';
-import { validateSecureConfiguration, validateVolumeMounts } from '../helpers/deployment';
+import {
+  validateSecureConfiguration,
+  validateVolumeMounts,
+  validateEnvironmentVariables,
+} from '../helpers/deployment';
 
 /**
  * Note that these checks are also performed at runtime on the deployed snyk-monitor, see the integration tests.
@@ -20,5 +24,6 @@ tap.test('ensure the security properties of the deployment files are unchanged',
 
     validateSecureConfiguration(t, deployment);
     validateVolumeMounts(t, deployment);
+    validateEnvironmentVariables(t, deployment);
   }
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This ensures that HOME is set/overridden as an environment variable in the snyk-monitor container in both plain YAMLs and Helm.
This fixes an issue when deploying on OpenShift where the HOME env var points to / instead of /srv/app, even though we run the container as the user "snyk" whose home directory is /srv/app.
The wrong HOME (pointing at /) makes skopeo (the tool we use to pull images currently) look for image pull secrets (dockercfg) in the wrong place. By default skopeo looks under $HOME/.docker/config.json but when HOME points to the wrong place, this means it stops being able to pull from private registries. By hardcoding HOME in the deployment files, we are able to fix this problem.

### More information

- [Jira ticket RUN-623](https://snyksec.atlassian.net/browse/RUN-623)
