### PR TITLE
fix: bump snyk-docker-plugin - now supporting key-binary hashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -974,9 +974,9 @@
       "dev": true
     },
     "dockerfile-ast": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.18.tgz",
-      "integrity": "sha512-SEp95qCox1KAzf8BBtjHoBDD0a7/eNlZJ6fgDf9RxqeSEDwLuEN9YjdZ/tRlkrYLxXR4i+kqZzS4eDRSqs8VKQ==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.19.tgz",
+      "integrity": "sha512-iDRNFeAB2j4rh/Ecc2gh3fjciVifCMsszfCfHlYF5Wv8yybjZLiRDZUBt/pS3xrAz8uWT8fCHLq4pOQMmwCDwA==",
       "requires": {
         "vscode-languageserver-types": "^3.5.0"
       }
@@ -1242,9 +1242,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+          "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
         }
       }
     },
@@ -3335,12 +3335,12 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-2.1.0.tgz",
-      "integrity": "sha512-Og7cUMdTpr9JKz7a03i+AL+JSnmOQqodcCwrlQy5mPbBjccE6lI/4gd/FmzwCJm9PZLJ/Nje14F/EbwGh146+Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-2.2.0.tgz",
+      "integrity": "sha512-adoerkNsYNNZFKnvtjJLJeEgjUf2js0hnG32aUJSRtbDN1Ejgbj88a0UYc90C+s2xZJaulJgImy9/5IsG5/omg==",
       "requires": {
         "debug": "^4.1.1",
-        "dockerfile-ast": "0.0.18",
+        "dockerfile-ast": "0.0.19",
         "event-loop-spinner": "^1.1.0",
         "semver": "^6.1.0",
         "tar-stream": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "needle": "^2.4.0",
     "sleep-promise": "^8.0.1",
     "snyk-config": "3.0.0",
-    "snyk-docker-plugin": "2.1.0",
+    "snyk-docker-plugin": "2.2.0",
     "source-map-support": "^0.5.9",
     "typescript": "^3.7.2",
     "ws": "^7.0.0",

--- a/test/fixtures/node-deployment.yaml
+++ b/test/fixtures/node-deployment.yaml
@@ -1,22 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: node-deployment
   namespace: services
   labels:
-    app: nginx
+    app: node
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: nginx
+      app: node
   template:
     metadata:
       labels:
-        app: nginx
+        app: node
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.7.9
+      - name: node
+        image: node:lts-alpine3.11
+        command: ['sh', '-c', 'echo Hello from node:lts-alpine3.11 pod! && sleep 360000']
         ports:
         - containerPort: 80


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

bumping the snyk-docker-plugin version to 2.2.0, where key-binary hashing was introduced.
repurposing one of the tests and fixtures from just testing how the Monitor handles newly introduced workloads to also asserting that the "hashes" data is also present and correct on a node image.

### More information

https://snyksec.atlassian.net/browse/RUN-705