### PR TITLE
Fix/404 from k8s api

### DIFF
--- a/src/supervisor/metadata-extractor.ts
+++ b/src/supervisor/metadata-extractor.ts
@@ -135,7 +135,10 @@ export async function buildMetadataForWorkload(pod: V1Pod): Promise<IWorkload[] 
   const podOwner: IKubeObjectMetadata | undefined = await findParentWorkload(
     pod.metadata.ownerReferences, pod.metadata.namespace);
 
-  return podOwner === undefined
-    ? undefined
-    : buildImageMetadata(podOwner, pod.status.containerStatuses);
+  if (podOwner === undefined) {
+    logger.info({pod}, 'pod associated with owner, but owner not found. not building metadata.');
+    return undefined;
+  }
+
+  return buildImageMetadata(podOwner, pod.status.containerStatuses);
 }

--- a/test/fixtures/java-deployment.yaml
+++ b/test/fixtures/java-deployment.yaml
@@ -19,4 +19,6 @@ spec:
       - image: java:latest
         imagePullPolicy: Always
         name: java
+        command: ['/bin/sleep']
+        args: ['9999999']
       securityContext: {}

--- a/test/fixtures/java-deployment.yaml
+++ b/test/fixtures/java-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: java
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: java


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

attempt to fix the ```404``` errors we see when building workloads' metadata by ignoring  ```404``` responses when finding workloads' parents.
also some improved logging.

also some minor test fixture improvements.

### More information

https://snyk.slack.com/archives/CFSQFR0TH/p1583251519000600