### PR TITLE
Fix/bump docker plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1242,9 +1242,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
-          "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
         }
       }
     },
@@ -3335,9 +3335,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-2.2.0.tgz",
-      "integrity": "sha512-adoerkNsYNNZFKnvtjJLJeEgjUf2js0hnG32aUJSRtbDN1Ejgbj88a0UYc90C+s2xZJaulJgImy9/5IsG5/omg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-2.2.3.tgz",
+      "integrity": "sha512-zAcg4jI2xIigZ6QkjmdbxYcFZA/ywEK5JXA2WWoMK3+zaTeNHlpqFDt+3z0h+Jfcu0Kagr/zJLCH6WufpFQmuQ==",
       "requires": {
         "debug": "^4.1.1",
         "dockerfile-ast": "0.0.19",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "needle": "^2.4.0",
     "sleep-promise": "^8.0.1",
     "snyk-config": "3.0.0",
-    "snyk-docker-plugin": "2.2.0",
+    "snyk-docker-plugin": "2.2.3",
     "source-map-support": "^0.5.9",
     "typescript": "^3.7.2",
     "ws": "^7.0.0",

--- a/test/fixtures/nginx-replicationcontroller.yaml
+++ b/test/fixtures/nginx-replicationcontroller.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nginx
   namespace: services
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     app: nginx
   template:

--- a/test/fixtures/scratch-deployment.yaml
+++ b/test/fixtures/scratch-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: busybox
+  namespace: services
+  labels:
+    app.kubernetes.io/name: busybox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: busybox
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: busybox
+    spec:
+      containers:
+      - image: busybox:1.31.1
+        imagePullPolicy: Always
+        name: busybox
+        command: ['/bin/sleep']
+        args: ['360000']
+      securityContext: {}


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

the snyk-docker-plugin now supports scanning scratch images, and not throw errors.
bumping the version and enhancing our tests to assert the dep graphs we send are correct.

### More information

https://snyksec.atlassian.net/browse/RUN-731