### PR TITLE
Fix/fail on invalid parent

### DIFF
--- a/src/supervisor/metadata-extractor.ts
+++ b/src/supervisor/metadata-extractor.ts
@@ -83,7 +83,7 @@ async function findParentWorkload(
           {name: supportedWorkload.name, kind: supportedWorkload.kind, namespace},
           'could not find workload, it probably no longer exists',
         );
-        return parentMetadata;
+        return undefined;
       } else {
         throw err;
       }

--- a/src/supervisor/metadata-extractor.ts
+++ b/src/supervisor/metadata-extractor.ts
@@ -84,9 +84,8 @@ async function findParentWorkload(
           'could not find workload, it probably no longer exists',
         );
         return undefined;
-      } else {
-        throw err;
       }
+      throw err;
     }
 
     if (nextParentMetadata === undefined) {

--- a/src/supervisor/watchers/handlers/pod.ts
+++ b/src/supervisor/watchers/handlers/pod.ts
@@ -91,7 +91,7 @@ export async function podWatchHandler(pod: V1Pod): Promise<void> {
     const workloadMetadata = await buildMetadataForWorkload(pod);
 
     if (workloadMetadata === undefined || workloadMetadata.length === 0) {
-      logger.warn({podName}, 'could not process pod, the workload is possibly unsupported');
+      logger.warn({podName}, 'could not process pod, the workload is possibly unsupported or deleted');
       return;
     }
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

- bail out on scanning a workload when failing to find its parent, when we know it's supposed to have a parent
- improve log message
- removing a redundant else clause

### More information

https://snyksec.atlassian.net/browse/RUN-749
https://snyk.slack.com/archives/CDSMEJ29E/p1583316349044500
