### PR TITLE
chore: send proposed release notes when feature-branch tests pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,11 @@ default_container_config: &default_container_config
     - image: circleci/node:10
   working_directory: ~/kubernetes-monitor
 
+python_container_config: &python_container_config
+  docker:
+    - image: circleci/python:3
+  working_directory: ~/kubernetes-monitor
+
 staging_branch_only_filter: &staging_branch_only_filter
   filters:
     branches:
@@ -291,6 +296,14 @@ jobs:
             fi
           when: on_fail
 
+  preview_release_notes:
+    <<: *python_container_config
+    steps:
+      - checkout
+      - run:
+          name: SEND RELEASE NOTES PREVIEW TO SLACK
+          command: ./scripts/post-release-notes-preview.py
+
 ######################## MERGE TO STAGING ########################
   tag_and_push:
     <<: *default_container_config
@@ -403,6 +416,13 @@ workflows:
       - package_manager_test_rpm:
           requires:
             - build_image
+          <<: *main_branches_filter
+      - preview_release_notes:
+          requires:
+            - build_image
+            - unit_tests
+            - system_tests
+            - integration_tests
           <<: *main_branches_filter
 
   MERGE_TO_STAGING:

--- a/scripts/post-release-notes-preview.py
+++ b/scripts/post-release-notes-preview.py
@@ -1,0 +1,95 @@
+#!/usr/local/bin/python3
+
+import os
+import requests
+import subprocess
+import sys
+
+BRANCH_PREFIXES_TO_POST = ['feat', 'fix', 'chore', 'test', 'docs', 'revert']
+GIT_ORG = os.environ['CIRCLE_PROJECT_USERNAME']
+GIT_REPO = os.environ['CIRCLE_PROJECT_REPONAME']
+GIT_BRANCH = os.environ['CIRCLE_BRANCH']
+gitBranchParts = GIT_BRANCH.split('/')
+if len(gitBranchParts) <= 1:
+    sys.exit(0)
+
+gitBranchPrefix = gitBranchParts[0]
+if not gitBranchPrefix in BRANCH_PREFIXES_TO_POST:
+    sys.exit(0)
+
+def main():
+    # last version:
+    lastVersion = subprocess.check_output(['git', 'describe', '--abbrev=0', '--tags', 'origin/staging'], text=True).strip()
+
+    # commits since last version
+    commitsSinceLastVersion = subprocess.check_output(['git', 'log', '--no-decorate', lastVersion + '..HEAD', '--oneline'], text=True).strip()
+    commits = processCommits(commitsSinceLastVersion)
+
+    if not (commits['features'] or commits['fixes']):
+        sys.exit(0)
+
+    pullRequestUrls = os.environ.get('CIRCLE_PULL_REQUESTS', '')
+    if not pullRequestUrls:
+        sys.exit(0)
+
+    # TODO: support multiple PRs
+    pullRequestUrl = pullRequestUrls.split(',')[0]
+    pullRequestNumber = pullRequestUrl.split('/')[-1]
+    # TODO error handling
+    pullRequest = requests.get('https://api.github.com/repos/{org}/{repo}/pulls/{pr}'.format(org=GIT_ORG,repo=GIT_REPO,pr=pullRequestNumber))
+    issue = pullRequest.json()['_links']['issue']
+
+    textToPost = getTextToPost(commits)
+    comment = '*{title}*\n{body}'.format(**textToPost)
+
+    headers = {'Authorization': 'token ' + os.environ['GITHUB_TOKEN']}
+    # TODO what if we get an error?
+    requests.post(
+        '%s/comments' % issue['href'],
+        json={'body': comment},
+        headers=headers,
+    )
+
+def processCommits(commitsSinceLastVersion):
+    # TODO: handle reverts?
+    commits = {
+        "features": [],
+        "fixes": [],
+        "others": [],
+    }
+
+    lines = commitsSinceLastVersion.split('\n')
+    for line in lines:
+        words = line.split(' ')
+        hash = words[0]
+        prefix = words[1]
+        rest = ' '.join(words[2:])
+
+        title = ''.join(rest) + ' (%s)' % hash
+        if prefix == 'feat:':
+            commits['features'].append(title)
+        elif prefix == 'fix:':
+            commits['fixes'].append(title)
+        else:
+            commits['others'].append(title)
+    
+    return commits
+
+def getTextToPost(commits):
+    USERNAME = os.environ.get('CIRCLE_USERNAME', 'USER_NOT_FOUND')
+    textToPost = {
+        'title': 'Expected release notes (by @%s)' % USERNAME,
+        'body': '',
+    }
+
+    if commits['features']:
+        textToPost['body'] += '\nfeatures:\n' + '\n'.join(commits['features'])
+    if commits['fixes']:
+        textToPost['body'] += '\n\nfixes:\n' + '\n'.join(commits['fixes'])
+    if commits['others']:
+        textToPost['body'] += '\n\nothers (will not be included in Semantic-Release notes):\n' + '\n'.join(commits['others'])
+
+    return textToPost
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

send a summary of the feat/fix commits to a Slack channel so we can see what Semantic-Release will probably use to decorate the release once we merge to `staging`.
this helps us be more mindful of the release notes and their meaning to our users.

### More information

context
https://snyk.slack.com/archives/CDSMEJ29E/p158332105057200

### Screenshots

look at the bottom of the PR