### PR TITLE
fix: retry transmissions on certain network failures

### DIFF
--- a/test/system/kind.test.ts
+++ b/test/system/kind.test.ts
@@ -78,6 +78,14 @@ tap.test('Kubernetes-Monitor with KinD', async (t) => {
   nock('https://kubernetes-upstream.snyk.io')
     .post('/api/v1/dependency-graph')
     .times(1)
+    .replyWithError({
+      code: 'ECONNRESET',
+      message: 'socket hang up',
+    });
+
+  nock('https://kubernetes-upstream.snyk.io')
+    .post('/api/v1/dependency-graph')
+    .times(1)
     .reply(200, (uri, requestBody) => {
       // TODO assert POST payload
     });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

when failing to transmit data to the Kubernetes-Upstream service, if the failure is a result of specific network errors, retry a certain amount of times.
otherwise, fail the request.

this is done because networks are often unpredictable and we see some socket hangups or unexpected network socket disconnections. in these scenarios we want to retry sending the request, so the important data isn't lost.

### More information

https://snyk.slack.com/archives/CFSQFR0TH/p1583315253000500