### PR TITLE
chore: add colors to Slack webhook messages

### DIFF
--- a/scripts/slack-notify-deploy.sh
+++ b/scripts/slack-notify-deploy.sh
@@ -1,2 +1,7 @@
 #! /bin/bash
-curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "warning", "fallback": "Build Notification: '$CIRCLE_BUILD_URL'", "title": "Kubernetes-Monitor Deploy Notification", "text": ":hatching_chick: Deploying Kubernetes-Monitor on `'$2'`: `'$1'` :hatching_chick:"}]}' $SLACK_WEBHOOK
+
+IMAGE_NAME="$1"
+DEPLOYMENT_ENVIRONMENT_NAME="$2"
+NOTIFICATION_COLOR=${3:-#7CD197}
+
+curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "'$NOTIFICATION_COLOR'", "fallback": "Build Notification: '$CIRCLE_BUILD_URL'", "title": "Kubernetes-Monitor Deploy Notification", "text": ":hatching_chick: Deploying Kubernetes-Monitor on `'$DEPLOYMENT_ENVIRONMENT_NAME'`: `'$IMAGE_NAME'` :hatching_chick:"}]}' $SLACK_WEBHOOK

--- a/scripts/slack-notify-failure.sh
+++ b/scripts/slack-notify-failure.sh
@@ -1,2 +1,6 @@
 #! /bin/bash
-curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "warning", "fallback": "Build Notification: '$CIRCLE_BUILD_URL'", "title": ":warning: Kubernetes-Monitor Merge Failure :warning:", "text": ":egg_broken_1: Kubernetes-Monitor broken branch: `'$1'` :egg_broken_1:"}]}' $SLACK_WEBHOOK
+
+BRANCH_NAME="$1"
+NOTIFICATION_COLOR=${2:-#EE0000}
+
+curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "'$NOTIFICATION_COLOR'", "fallback": "Build Notification: '$CIRCLE_BUILD_URL'", "title": ":warning: Kubernetes-Monitor Merge Failure :warning:", "text": ":egg_broken_1: Kubernetes-Monitor broken branch: `'$BRANCH_NAME'` :egg_broken_1:"}]}' $SLACK_WEBHOOK

--- a/scripts/slack-notify-push.sh
+++ b/scripts/slack-notify-push.sh
@@ -1,2 +1,6 @@
 #! /bin/bash
-curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "warning", "fallback": "Build Notification: '$CIRCLE_BUILD_URL'", "title": "Kubernetes-Monitor Publish Notification", "text": ":egg_fancy: Published Kubernetes-Monitor: `'$1'` :egg_fancy:"}]}' $SLACK_WEBHOOK
+
+BRANCH_NAME="$1"
+NOTIFICATION_COLOR=${2:-#7CD197}
+
+curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "'$NOTIFICATION_COLOR'", "fallback": "Build Notification: '$CIRCLE_BUILD_URL'", "title": "Kubernetes-Monitor Publish Notification", "text": ":egg_fancy: Published Kubernetes-Monitor: `'$BRANCH_NAME'` :egg_fancy:"}]}' $SLACK_WEBHOOK

--- a/scripts/slack-notify-success-no-publish.sh
+++ b/scripts/slack-notify-success-no-publish.sh
@@ -1,2 +1,5 @@
 #! /bin/bash
-curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "warning", "fallback": "Build Notification: '$CIRCLE_BUILD_URL'", "title": "Kubernetes-Monitor Publish Notification", "text": ":egg_fancy: Successful `master` merge, but no `gh-pages` release occurring :egg_fancy:"}]}' $SLACK_WEBHOOK
+
+NOTIFICATION_COLOR=${1:-#7CD197}
+
+curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "'$NOTIFICATION_COLOR'", "fallback": "Build Notification: '$CIRCLE_BUILD_URL'", "title": "Kubernetes-Monitor Publish Notification", "text": ":egg_fancy: Successful `master` merge, but no `gh-pages` release occurring :egg_fancy:"}]}' $SLACK_WEBHOOK

--- a/scripts/slack-notify-success-no-release.sh
+++ b/scripts/slack-notify-success-no-release.sh
@@ -1,2 +1,5 @@
 #! /bin/bash
-curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "warning", "fallback": "Build Notification: '$CIRCLE_BUILD_URL'", "title": "Kubernetes-Monitor Publish Notification", "text": ":egg_fancy: Successful `staging` merge, but no semantic-release occurring :egg_fancy:"}]}' $SLACK_WEBHOOK
+
+NOTIFICATION_COLOR=${1:-#7CD197}
+
+curl -X POST -H 'Content-Type:application/json' -d '{"attachments": [{"color": "'$NOTIFICATION_COLOR'", "fallback": "Build Notification: '$CIRCLE_BUILD_URL'", "title": "Kubernetes-Monitor Publish Notification", "text": ":egg_fancy: Successful `staging` merge, but no semantic-release occurring :egg_fancy:"}]}' $SLACK_WEBHOOK


### PR DESCRIPTION
To allow us to quickly infer if something went wrong (e.g. bright red on broken tests), improve the colors of the webhook (they used to be yellow for everything).

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### More information

- [Examples on Slack #runtime-deployment](https://snyk.slack.com/archives/CLW30N31V/p1583420539002400)
