### PR TITLE
chore: rearrange the YAML deployer in tests

### DIFF
--- a/test/setup/deployers/index.ts
+++ b/test/setup/deployers/index.ts
@@ -1,19 +1,5 @@
-import * as yaml from './yaml';
 import { DeploymentType } from './types';
-
-interface IDeployer {
-  deploy: (
-    integrationId: string,
-    imageOpts: {
-      imageNameAndTag: string;
-      imagePullPolicy: string;
-    },
-  ) => Promise<void>;
-}
-
-const yamlDeployer: IDeployer = {
-  deploy: yaml.deployKubernetesMonitor,
-};
+import { yamlDeployer } from './yaml';
 
 export default {
   [DeploymentType.YAML]: yamlDeployer,

--- a/test/setup/deployers/types.ts
+++ b/test/setup/deployers/types.ts
@@ -3,3 +3,13 @@ export enum DeploymentType {
   Helm,
   Operator,
 }
+
+export interface IDeployer {
+  deploy: (
+    integrationId: string,
+    imageOpts: {
+      imageNameAndTag: string;
+      imagePullPolicy: string;
+    },
+  ) => Promise<void>;
+}

--- a/test/setup/deployers/yaml.ts
+++ b/test/setup/deployers/yaml.ts
@@ -2,8 +2,13 @@ import { readFileSync, writeFileSync } from 'fs';
 import { parse, stringify } from 'yaml';
 
 import * as kubectl from '../../helpers/kubectl';
+import { IDeployer } from './types';
 
-export async function deployKubernetesMonitor(
+export const yamlDeployer: IDeployer = {
+  deploy: deployKubernetesMonitor,
+};
+
+async function deployKubernetesMonitor(
   integrationId: string,
   imageOpts: {
     imageNameAndTag: string;


### PR DESCRIPTION
Ensure that the different deployers export the deployer themselves, instead of individual functions.
The deployers are expected to stick to the interface, rather than having the index/entrypoint construct it for the consumers.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### Notes for the reviewer

I would like us to have the individual deployers export an object that conforms to the IDeployer interface. So the `index.ts` just exports a simple collection of these different deployers.
Small refactor preceding the Operator tests we're about to add.