### PR TITLE
Chore/delete old release notes comments

### DIFF
--- a/scripts/post-release-notes-preview.py
+++ b/scripts/post-release-notes-preview.py
@@ -15,26 +15,41 @@ with open(eventPath) as f:
 GIT_OWNER_AND_REPO = os.environ['GITHUB_REPOSITORY']
 
 def main():
-    # last version:
-    lastVersion = subprocess.check_output(['git', 'describe', '--abbrev=0', '--tags', 'origin/staging'], text=True, stderr=subprocess.STDOUT).strip()
+    pullRequestNumber = eventData['number']
 
-    # commits since last version
+    headers = {'Authorization': 'token ' + os.environ['GITHUB_TOKEN']}
+    # TODO error handling
+    pullRequest = requests.get('https://api.github.com/repos/{orgAndRepo}/pulls/{pr}'.format(orgAndRepo=GIT_OWNER_AND_REPO, pr=pullRequestNumber))
+    issue = pullRequest.json()['_links']['issue']
+
+    # get all existing comments for this issue/PR
+    allCommentsResponse = requests.get(
+        '%s/comments' % issue['href'],
+        headers=headers,
+    ).json()
+    commentIds = [
+        comment['id'] for comment in allCommentsResponse
+        if comment['user']['login'] == 'snyk-deployer'
+        and comment['user']['id'] == 18642669
+        and 'Expected release notes' in comment['body']
+    ]
+
+    # delete old & irrelevant release notes previews
+    for id in commentIds:
+        requests.delete(
+            'https://api.github.com/repos/{orgAndRepo}/issues/comments/{commentId}'.format(orgAndRepo=GIT_OWNER_AND_REPO, commentId=id),
+            headers=headers,
+        )
+
+    lastVersion = subprocess.check_output(['git', 'describe', '--abbrev=0', '--tags', 'origin/staging'], text=True, stderr=subprocess.STDOUT).strip()
     commitsSinceLastVersion = subprocess.check_output(['git', 'log', '--no-decorate', lastVersion + '..HEAD', '--oneline'], text=True).strip()
     commits = processCommits(commitsSinceLastVersion)
-
     if not (commits['features'] or commits['fixes']):
         sys.exit(0)
 
-    pullRequestNumber = eventData['number']
-    # TODO error handling
-    pullRequest = requests.get('https://api.github.com/repos/{orgAndRepo}/pulls/{pr}'.format(orgAndRepo=GIT_OWNER_AND_REPO,pr=pullRequestNumber))
-    issue = pullRequest.json()['_links']['issue']
-
+    # post new release notes
     textToPost = getTextToPost(commits)
     comment = '*{title}*\n{body}'.format(**textToPost)
-
-    headers = {'Authorization': 'token ' + os.environ['GITHUB_TOKEN']}
-    # TODO what if we get an error?
     requests.post(
         '%s/comments' % issue['href'],
         json={'body': comment},
@@ -67,7 +82,6 @@ def processCommits(commitsSinceLastVersion):
     return commits
 
 def getTextToPost(commits):
-    # TODO - maybe get from PR?
     USERNAME = os.environ.get('USERNAME', 'USER_NOT_FOUND')
     textToPost = {
         'title': 'Expected release notes (by @%s)' % USERNAME,


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [x] Potential release notes have been inspected

### What this does

remove old release notes previews from ```snyk-deployer``` before posting new ones, to keep the pull request clean 💅

### More information

https://snyksec.atlassian.net/browse/RUN-754

### Screenshots

before:
![image](https://user-images.githubusercontent.com/1255387/76144859-f3c9d480-608c-11ea-818b-631e5cf631f8.png)

after:
![image](https://user-images.githubusercontent.com/1255387/76145029-5ff90800-608e-11ea-8d9e-f2f12e8841f4.png)
