### PR TITLE
fix: bump snyk-docker-plugin to a version with better key-binary scanning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -614,11 +614,11 @@
       "dev": true
     },
     "bl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
-      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.1.tgz",
+      "integrity": "sha512-FL/TdvchukRCuWVxT0YMO/7+L5TNeNrVFvRU2IY63aUyv9mpt8splf2NEr6qXtPo5fya5a66YohQKvGNmLrWNA==",
       "requires": {
-        "readable-stream": "^3.0.1"
+        "readable-stream": "^3.4.0"
       }
     },
     "brace-expansion": {
@@ -3749,9 +3749,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-2.2.3.tgz",
-      "integrity": "sha512-zAcg4jI2xIigZ6QkjmdbxYcFZA/ywEK5JXA2WWoMK3+zaTeNHlpqFDt+3z0h+Jfcu0Kagr/zJLCH6WufpFQmuQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-2.2.4.tgz",
+      "integrity": "sha512-ppKn6gwlilNcd6L97jtPvCq9U3p1LiKo1beGPlKjY14HV9N+DkJUKMt6sTUdMFzFTYmcAre/4Pfje0h2td4ZQw==",
       "requires": {
         "debug": "^4.1.1",
         "dockerfile-ast": "0.0.19",
@@ -3936,13 +3936,6 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
         "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-        }
       }
     },
     "strip-ansi": {
@@ -5207,11 +5200,11 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
-      "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.1.tgz",
+      "integrity": "sha512-GZjLk64XcE/58qwIc1ZfXGqTSE4OutPMEkfBE/oh9eJ4x1eMRjYkgrLrav7PzddpvIpSJSGi8FgNNYXdB9Vumg==",
       "requires": {
-        "bl": "^3.0.0",
+        "bl": "^4.0.1",
         "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "needle": "^2.4.0",
     "sleep-promise": "^8.0.1",
     "snyk-config": "3.0.0",
-    "snyk-docker-plugin": "2.2.3",
+    "snyk-docker-plugin": "2.2.4",
     "source-map-support": "^0.5.16",
     "typescript": "^3.8.3",
     "ws": "^7.2.1",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [x] Potential release notes have been inspected

### What this does

the snyk-docker-plugin has released a new version with better key-binary scanning in terms of type validation between dynamic/static flows.
upgrading to make sure the new functionality is correct and fits the Monitor.

### More information

https://snyksec.atlassian.net/browse/RUN-761