### PR TITLE
chore: restore to master branch after publishing to gh-pages

### DIFF
--- a/scripts/publish-gh-pages.sh
+++ b/scripts/publish-gh-pages.sh
@@ -1,6 +1,8 @@
 #! /bin/bash
 set -e
 
+trap "git checkout --force master" EXIT
+
 NEW_TAG=$1
 echo About to update the gh-pages branch with new tag ${NEW_TAG}
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [ ] Potential release notes have been inspected

### What this does

Ensures that all the repo files are again available for subsequent CI job steps.

### More information
- Fixes #371 
- Tested manually by running the script