### PR TITLE
chore: increase the timeout for unit tests to prevent flakiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "pretest": "./scripts/build-image.sh",
     "test": "npm run lint && npm run build && npm run test:unit && npm run test:integration",
-    "test:unit": "NODE_ENV=test tap test/unit",
+    "test:unit": "NODE_ENV=test tap test/unit --timeout=300",
     "test:system": "tap test/system --timeout=600",
     "test:integration": "TEST_PLATFORM=kind CREATE_CLUSTER=true tap test/integration/kubernetes.test.ts --timeout=900",
     "test:integration:kind": "TEST_PLATFORM=kind CREATE_CLUSTER=true tap test/integration/kubernetes.test.ts --timeout=900",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [x] Potential release notes have been inspected

### What this does

tap's default timeout for tests is 30 seconds.
our unit tests usually finish in about 29 seconds, but some times it crosses that limit, failing the run.
let's allow ourselves up to 5 minutes for unit tests to complete before failing builds.

### More information

https://snyk.slack.com/archives/CDSMEJ29E/p1583839235090400