### PR TITLE
fix: upgrade K8s client to capture errors in Watch done() handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,9 +143,9 @@
       }
     },
     "@kubernetes/client-node": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.10.3.tgz",
-      "integrity": "sha512-mw+1zdKfMW4QN2ns82SKFhAvqC4SVUAiItto4oFg3Me+a510h3h9N5O7ad6m4efAmlQBlMc6Y5FHz70dAwuiMg==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.11.1.tgz",
+      "integrity": "sha512-0A4nwErxzJiGt3WYMR6rvcQF46hFz04b6uCmW7Kuj+Cl0zwe7KKxeMiqbZDtHPOq1CcOHOIcKNWCacUKL5CdxQ==",
       "requires": {
         "@types/js-yaml": "^3.12.1",
         "@types/node": "^10.12.0",
@@ -159,6 +159,7 @@
         "jsonpath-plus": "^0.19.0",
         "openid-client": "2.5.0",
         "request": "^2.88.0",
+        "rfc4648": "^1.3.0",
         "shelljs": "^0.8.2",
         "tslib": "^1.9.3",
         "underscore": "^1.9.1",
@@ -3559,6 +3560,11 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "rfc4648": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.3.0.tgz",
+      "integrity": "sha512-x36K12jOflpm1V8QjPq3I+pt7Z1xzeZIjiC8J2Oxd7bE1efTrOG241DTYVJByP/SxR9jl1t7iZqYxDX864jgBQ=="
     },
     "rimraf": {
       "version": "2.4.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "private",
   "private": true,
   "dependencies": {
-    "@kubernetes/client-node": "^0.10.3",
+    "@kubernetes/client-node": "^0.11.1",
     "@types/async": "^3.0.8",
     "@types/child-process-promise": "^2.2.1",
     "@types/lru-cache": "^5.1.0",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [x] Potential release notes have been inspected

### What this does

Introduces a fix that allows errors to be emitted in Informer/Watch done() handlers.
This way we will be able to now see any API server errors, instead of receiving null in all cases.

### More information

- [The fix mentioned](https://github.com/kubernetes-client/javascript/commit/568a853dc10b41067f66e562853b2ca6d90d9c7b)
- [0.11.1 commits](https://github.com/kubernetes-client/javascript/commits/0.11.1)
