### PR TITLE
feat: Add cpu and mem limits/requests to values.yaml

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -50,11 +50,11 @@ spec:
             value: /srv/app
           resources:
             requests:
-              cpu: '250m'
-              memory: '400Mi'
+              cpu: {{ .Values.requests.cpu }}
+              memory: {{ .Values.requests.memory }}
             limits:
-              cpu: '1'
-              memory: '2Gi'
+              cpu: {{ .Values.limits.cpu }}
+              memory: {{ .Values.limits.memory }}
           securityContext:
             runAsUser: 10001
             runAsGroup: 10001

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -28,3 +28,12 @@ clusterName: ""
 # The snyk-monitor requires disk storage to temporarily pull container images and to scan them for vulnerabilities.
 # This value controls how much disk storage _at most_ may be allocated for the snyk-monitor. The snyk-monitor mounts an emptyDir for storage.
 temporaryStorageSize: 50Gi
+
+# CPU/Mem requests and limits for snyk-monitor
+requests:
+  cpu: '250m'
+  memory: '400Mi'
+
+limits:
+  cpu: '1'
+  memory: '2Gi'


### PR DESCRIPTION
Presently there is no way to control the limits and requests the snyk-monitor deploys with, this simply enables that ability

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [ ] Potential release notes have been inspected

### What this does

Moves resource limits to values.yaml

### Notes for the reviewer

Originally suggested by https://github.com/Joeskyyy in https://github.com/snyk/kubernetes-monitor/pull/381 