### PR TITLE
feat: docker-plugin with Distroless scanning support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3593,9 +3593,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-2.2.4.tgz",
-      "integrity": "sha512-ppKn6gwlilNcd6L97jtPvCq9U3p1LiKo1beGPlKjY14HV9N+DkJUKMt6sTUdMFzFTYmcAre/4Pfje0h2td4ZQw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-2.6.1.tgz",
+      "integrity": "sha512-v3LIPILRL5faZ+qiIhF9on0rAxuFaQku3UwaiGumoTrfXywLkv7x8PJgdMnrsWUxDwB8EZFc1k2qvI6V6rTF5g==",
       "requires": {
         "debug": "^4.1.1",
         "dockerfile-ast": "0.0.19",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "needle": "^2.4.0",
     "sleep-promise": "^8.0.1",
     "snyk-config": "3.0.0",
-    "snyk-docker-plugin": "2.2.4",
+    "snyk-docker-plugin": "2.6.1",
     "source-map-support": "^0.5.16",
     "typescript": "^3.8.3",
     "ws": "^7.2.1",

--- a/src/scanner/images/index.ts
+++ b/src/scanner/images/index.ts
@@ -5,7 +5,7 @@ import logger = require('../../common/logger');
 import { pull as skopeoCopy, getDestinationForImage } from './skopeo';
 import config = require('../../common/config');
 import { IPullableImage } from './types';
-import { IStaticAnalysisOptions, StaticAnalysisImageType, IScanResult } from '../types';
+import { IStaticAnalysisOptions, StaticAnalysisImageType, IScanResult, IPluginOptions } from '../types';
 
 export async function pullImages(images: IPullableImage[]): Promise<IPullableImage[]> {
   const pulledImages: IPullableImage[] = [];
@@ -59,13 +59,11 @@ export function getImageTag(imageWithTag: string): string {
 // Exported for testing
 export function constructStaticAnalysisOptions(
   fileSystemPath: string,
-): { staticAnalysisOptions: IStaticAnalysisOptions } {
+): IStaticAnalysisOptions {
   return {
-    staticAnalysisOptions: {
-      imagePath: fileSystemPath,
-      imageType: StaticAnalysisImageType.DockerArchive,
-      tmpDirPath: config.IMAGE_STORAGE_ROOT,
-    },
+    imagePath: fileSystemPath,
+    imageType: StaticAnalysisImageType.DockerArchive,
+    tmpDirPath: config.IMAGE_STORAGE_ROOT,
   };
 }
 
@@ -76,7 +74,11 @@ export async function scanImages(images: IPullableImage[]): Promise<IScanResult[
 
   for (const {imageName, fileSystemPath} of images) {
     try {
-      const options = constructStaticAnalysisOptions(fileSystemPath);
+      const staticAnalysisOptions = constructStaticAnalysisOptions(fileSystemPath);
+      const options: IPluginOptions = {
+        staticAnalysisOptions,
+        experimental: true,
+      };
 
       const result = await plugin.inspect(imageName, dockerfile, options);
 

--- a/src/scanner/types.ts
+++ b/src/scanner/types.ts
@@ -8,6 +8,11 @@ export enum StaticAnalysisImageType {
   DockerArchive = 'docker-archive',
 }
 
+export interface IPluginOptions {
+  staticAnalysisOptions: IStaticAnalysisOptions;
+  experimental: boolean;
+}
+
 export interface IStaticAnalysisOptions {
   imagePath: string;
   imageType: StaticAnalysisImageType;

--- a/test/integration/kubernetes.test.ts
+++ b/test/integration/kubernetes.test.ts
@@ -106,7 +106,7 @@ tap.test('snyk-monitor sends data to kubernetes-upstream', async (t) => {
   t.ok('busybox' in depGraphScratchImage.dependencyGraphResults, 'busybox was scanned');
   const busyboxPluginResult = JSON.parse(depGraphScratchImage.dependencyGraphResults.busybox);
   t.same(busyboxPluginResult.package.packageFormatVersion, 'linux:0.0.1', 'the version of the package format');
-  t.same(busyboxPluginResult.package.targetOS, {name: 'unknown', version: '0.0'}, 'busybox operating system unknown');
+  t.same(busyboxPluginResult.package.targetOS, {name: 'unknown', version: '0.0', prettyName: ""}, 'busybox operating system unknown');
   t.same(busyboxPluginResult.plugin.packageManager, 'linux', 'linux is the default package manager for scratch containers');
 });
 

--- a/test/unit/scanner/images.test.ts
+++ b/test/unit/scanner/images.test.ts
@@ -49,11 +49,9 @@ tap.test('constructStaticAnalysisOptions() tests', async (t) => {
   const somePath = '/var/tmp/file.tar';
   const options = scannerImages.constructStaticAnalysisOptions(somePath);
   const expectedResult = {
-    staticAnalysisOptions: {
-      imagePath: somePath,
-      imageType: 'docker-archive',
-      tmpDirPath: '/var/tmp',
-    },
+    imagePath: somePath,
+    imageType: 'docker-archive',
+    tmpDirPath: '/var/tmp',
   };
 
   t.deepEqual(options, expectedResult, 'returned options match expectations');


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [ ] Potential release notes have been inspected

### What this does

bump docker-plugin with Distroless scanning support

### Notes for the reviewer

that's how I tested it locally:
1. build a local Distroless image
2. modify the system test to load it into the KinD cluster and run it
3. hack Skopeo's arguments during runtime so it doesn't try to save it from an image registry, but from my local docker daemon
4. observe the plugin scan the archive and return the same results as it does when running just the plugin on that image

I didn't enhance any of our tests since the logic of scanning Distroless belongs to the docker-plugin and not the Monitor. happy to enhance the testing in the Monitor if we think there's additional value in checking something specific.

### More information

https://snyksec.atlassian.net/browse/RUN-827
