### PR TITLE
fix: simplify scanner module by removing the usage of class

### DIFF
--- a/src/supervisor/watchers/handlers/workload.ts
+++ b/src/supervisor/watchers/handlers/workload.ts
@@ -1,6 +1,6 @@
 import { IKubeObjectMetadata } from '../../types';
 import { buildWorkloadMetadata } from '../../metadata-extractor';
-import WorkloadWorker = require('../../../scanner');
+import { sendDeleteWorkloadRequest } from '../../../scanner';
 import logger = require('../../../common/logger');
 
 export async function deleteWorkload(kubernetesMetadata: IKubeObjectMetadata, workloadName: string): Promise<void> {
@@ -10,8 +10,7 @@ export async function deleteWorkload(kubernetesMetadata: IKubeObjectMetadata, wo
     }
 
     const localWorkloadLocator = buildWorkloadMetadata(kubernetesMetadata);
-    const workloadWorker = new WorkloadWorker(workloadName);
-    await workloadWorker.delete(localWorkloadLocator);
+    await sendDeleteWorkloadRequest(workloadName, localWorkloadLocator);
   } catch (error) {
     logger.error({error, resourceType: kubernetesMetadata.kind, resourceName: kubernetesMetadata.objectMeta.name},
       'could not delete workload');


### PR DESCRIPTION
The class was initially added to conceptually separate the scanning/processing logic from the rest of the code. This separation is in order to later transfer this piece of logic into a separate worker mechanism, e.g. a Kubernetes Job. This separation however never happened, and this is the only place in the code that uses a class but without an apparent reason.

Convert the class functions into plain async functions and export them in the scanner module.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [x] Potential release notes have been inspected
