### PR TITLE
chore: extract test tools into their own module

### DIFF
--- a/test/setup/tools/index.ts
+++ b/test/setup/tools/index.ts
@@ -1,0 +1,16 @@
+import {
+  path as skopeoPath,
+  install as installSkopeo,
+  remove as removeSkopeo,
+} from './skopeo';
+import { IThirdPartyTool } from './types';
+
+type SupportedTools = 'skopeo';
+
+export const tools: Record<SupportedTools, IThirdPartyTool> = {
+  skopeo: {
+    path: skopeoPath,
+    install: installSkopeo,
+    remove: removeSkopeo,
+  },
+};

--- a/test/setup/tools/skopeo.ts
+++ b/test/setup/tools/skopeo.ts
@@ -1,0 +1,39 @@
+import { platform, tmpdir } from 'os';
+import { exec } from 'child-process-promise';
+
+import { existsSync, unlinkSync, mkdirSync } from 'fs';
+
+const directory = `${tmpdir()}/skopeo`;
+export const path = `${directory}/skopeo`;
+
+export async function install() {
+  try {
+    await exec('which skopeo');
+    console.log('Skopeo already installed :tada:');
+  } catch (err) {
+    if (platform() !== 'linux') {
+      throw new Error(
+        'skopeo is missing from the system, please install with brew',
+      );
+    }
+
+    console.log('installing Skopeo');
+    await exec('git clone https://github.com/containers/skopeo');
+    await exec('(cd skopeo && make binary-static DISABLE_CGO=1)');
+    await exec('sudo mkdir -p /etc/containers');
+    await exec('sudo chown circleci:circleci /etc/containers');
+    await exec('cp ./skopeo/default-policy.json /etc/containers/policy.json');
+    if (!existsSync(directory)) {
+      mkdirSync(directory, { recursive: true });
+    }
+    await exec(`mv ./skopeo/skopeo ${path}`);
+    process.env['PATH'] = process.env['PATH'] + `:${directory}`;
+    await exec('rm -rf ./skopeo');
+  }
+}
+
+export async function remove() {
+  if (existsSync(path)) {
+    unlinkSync(path);
+  }
+}

--- a/test/setup/tools/types.ts
+++ b/test/setup/tools/types.ts
@@ -1,0 +1,6 @@
+export interface IThirdPartyTool {
+  readonly path: string;
+
+  install(): Promise<void>;
+  remove(): Promise<void>;
+}

--- a/test/system/kind.test.ts
+++ b/test/system/kind.test.ts
@@ -1,10 +1,10 @@
 import * as tap from 'tap';
 import * as nock from 'nock';
 import * as sleep from 'sleep-promise';
-import { exec } from 'child-process-promise';
 
 import * as kubectl from '../helpers/kubectl';
 import * as kind from '../setup/platforms/kind';
+import { tools } from '../setup/tools';
 
 // let integrationId: string;
 
@@ -25,24 +25,7 @@ tap.test('Kubernetes-Monitor with KinD', async (t) => {
     console.log(`could not start with a clean environment: ${error.message}`);
   }
 
-  // install Skopeo
-  // TODO: this thing should probably be in a setup test environment script
-  // not in this file
-  try {
-    await exec('which skopeo');
-    console.log('Skopeo already installed :tada:');
-  } catch (err) {
-    // linux-oriented, not mac
-    // for mac, install skopeo with brew
-    console.log('installing Skopeo');
-    await exec('git clone https://github.com/containers/skopeo');
-    await exec('(cd skopeo && make binary-static DISABLE_CGO=1)');
-    await exec('sudo mkdir -p /etc/containers');
-    await exec('sudo chown circleci:circleci /etc/containers');
-    await exec('cp ./skopeo/default-policy.json /etc/containers/policy.json');
-
-    process.env['PATH'] = process.env['PATH'] + ':./skopeo';
-  }
+  await tools.skopeo.install();
 
   // kubectl
   await kubectl.downloadKubectl();


### PR DESCRIPTION
This allows to consolidate all the tools we use during tests into one place and make it easier to install them and clean them up.
This current change starts with skopeo and simplifies the system test, the idea is to do the same for all tools we use (kubectl, kind).

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [ ] Potential release notes have been inspected
