### PR TITLE
chore: single quotation marks instead of double

### DIFF
--- a/test/integration/kubernetes.test.ts
+++ b/test/integration/kubernetes.test.ts
@@ -106,7 +106,7 @@ tap.test('snyk-monitor sends data to kubernetes-upstream', async (t) => {
   t.ok('busybox' in depGraphScratchImage.dependencyGraphResults, 'busybox was scanned');
   const busyboxPluginResult = JSON.parse(depGraphScratchImage.dependencyGraphResults.busybox);
   t.same(busyboxPluginResult.package.packageFormatVersion, 'linux:0.0.1', 'the version of the package format');
-  t.same(busyboxPluginResult.package.targetOS, {name: 'unknown', version: '0.0', prettyName: ""}, 'busybox operating system unknown');
+  t.same(busyboxPluginResult.package.targetOS, {name: 'unknown', version: '0.0', prettyName: ''}, 'busybox operating system unknown');
   t.same(busyboxPluginResult.plugin.packageManager, 'linux', 'linux is the default package manager for scratch containers');
 });
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [ ] Potential release notes have been inspected

### What this does

single quotation marks instead of double