### PR TITLE
Fix/distroless flag static scanning

### DIFF
--- a/bin/start-tilt
+++ b/bin/start-tilt
@@ -1,4 +1,3 @@
 #! /bin/sh
 
-npm install tslint typescript tsc-watch -g
-exec tsc-watch --project tsconfig.json --onSuccess 'node --inspect-brk=0.0.0.0:9229 .'
+exec npx tsc-watch --project tsconfig.json --onSuccess 'node --inspect-brk=0.0.0.0:9229 .'

--- a/package-lock.json
+++ b/package-lock.json
@@ -3593,9 +3593,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-2.6.1.tgz",
-      "integrity": "sha512-v3LIPILRL5faZ+qiIhF9on0rAxuFaQku3UwaiGumoTrfXywLkv7x8PJgdMnrsWUxDwB8EZFc1k2qvI6V6rTF5g==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-2.6.2.tgz",
+      "integrity": "sha512-6i5QOPJakqPtHUprVMyl5vP8tDpJNA+bv3rHDZ2PeqrcvAj5llEHIFmcIBHk2woddghc8JuWmwCpT8lLkE3lqg==",
       "requires": {
         "debug": "^4.1.1",
         "dockerfile-ast": "0.0.19",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "needle": "^2.4.0",
     "sleep-promise": "^8.0.1",
     "snyk-config": "3.0.0",
-    "snyk-docker-plugin": "2.6.1",
+    "snyk-docker-plugin": "2.6.2",
     "source-map-support": "^0.5.16",
     "typescript": "^3.8.3",
     "ws": "^7.2.1",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [x] Potential release notes have been inspected

### What this does

Fixes the distroless image scanning - we missed to pass the `distroless` flag to the snyk-docker-plugin

### Screenshots

![image](https://user-images.githubusercontent.com/40919381/77510967-a618de80-6e78-11ea-85f6-6805440e2fc9.png)
