### PR TITLE
chore/cleanup tested operators

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,11 @@ jobs:
             docker pull ${KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG} &&
             .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:openshift4
       - run:
+          name: Delete Operator from Quay
+          command: |
+            ./scripts/delete-operator-from-quay.sh
+          when: always
+      - run:
           name: Notify Slack on failure
           command: |
             if [[ "$CIRCLE_BRANCH" == "staging" ]]; then

--- a/scripts/delete-operator-from-quay.sh
+++ b/scripts/delete-operator-from-quay.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+set -e
+
+QUAY_TOKEN=$(curl -H "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d "{\"user\": {\"username\": \"${QUAY_USERNAME}\", \"password\": \"${QUAY_PASSWORD}\"}}" | jq -r .token)
+OPERATOR_VERSION="0.0.1-${CIRCLE_SHA1}"
+
+STATUSCODE=$( curl --silent --output /dev/stderr --write-out "%{http_code}" -XDELETE -H "Accept: application/json" -H "Content-Type: application/json" -H "Authorization: $QUAY_TOKEN" "https://quay.io/cnr/api/v1/packages/snyk-runtime/snyk-operator/${OPERATOR_VERSION}/helm" )
+
+if test $STATUSCODE -ge 300; then
+  echo "Unexpected status code $STATUSCODE"
+  exit 1
+fi


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [x] Potential release notes have been inspected

### What this does

The versioning scheme for our test Operators is `0.0.1-<commit sha>`.
Quay orders releases alphabetically when deciding what is the latest Operator release, meaning that the commit SHA with the highest string value wins - in the current case it is a several weeks old release starting with the SHA f6162b...
This means we have been testing the wrong release with every OpenShift test run.

The Operator catalog does not give us an easy way to pin to a specific version of the Operator, it will always choose the latest.
Hence as a workaround we can delete the Operator from Quay once we are done testing it.
