### PR TITLE
fix: Revert "remove usage of class in scanner module"

### DIFF
--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -5,58 +5,64 @@ import { constructDeleteWorkload, constructDepGraph } from '../transmitter/paylo
 import { IWorkload, ILocalWorkloadLocator } from '../transmitter/types';
 import { IPullableImage } from './images/types';
 
-export async function processWorkload(workloadMetadata: IWorkload[]): Promise<void> {
-  // every workload metadata references the same workload name, grab it from the first one
-  const workloadName = workloadMetadata[0].name;
-  const allImages = workloadMetadata.map((meta) => meta.imageName);
-  logger.info({workloadName, imageCount: allImages.length}, 'queried workloads');
-  const uniqueImages = [...new Set<string>(allImages)];
+export = class WorkloadWorker {
+  private readonly name: string;
 
-  logger.info({workloadName, imageCount: uniqueImages.length}, 'pulling unique images');
-  const imagesWithFileSystemPath = getImagesWithFileSystemPath(uniqueImages);
-  const pulledImages = await pullImages(imagesWithFileSystemPath);
-  if (pulledImages.length === 0) {
-    logger.info({workloadName}, 'no images were pulled, halting scanner process.');
-    return;
+  constructor(name: string) {
+    this.name = name;
   }
 
-  try {
-    await scanImagesAndSendResults(workloadName, pulledImages, workloadMetadata);
-  } finally {
-    await removePulledImages(pulledImages);
-  }
-}
+  public async process(workloadMetadata: IWorkload[]): Promise<void> {
+    const workloadName = this.name;
+    const allImages = workloadMetadata.map((meta) => meta.imageName);
+    logger.info({workloadName, imageCount: allImages.length}, 'queried workloads');
+    const uniqueImages = [...new Set<string>(allImages)];
 
-// TODO: should be extracted from here and moved to the supervisor
-export async function sendDeleteWorkloadRequest(workloadName: string, localWorkloadLocator: ILocalWorkloadLocator): Promise<void> {
-  const deletePayload = constructDeleteWorkload(localWorkloadLocator);
-  logger.info({workloadName, workload: localWorkloadLocator},
-    'removing workloads from upstream');
-  await deleteWorkload(deletePayload);
-}
+    logger.info({workloadName, imageCount: uniqueImages.length}, 'pulling unique images');
+    const imagesWithFileSystemPath = getImagesWithFileSystemPath(uniqueImages);
+    const pulledImages = await pullImages(imagesWithFileSystemPath);
+    if (pulledImages.length === 0) {
+      logger.info({workloadName}, 'no images were pulled, halting scanner process.');
+      return;
+    }
 
-async function scanImagesAndSendResults(
-  workloadName: string,
-  pulledImages: IPullableImage[],
-  workloadMetadata: IWorkload[],
-): Promise<void> {
-  const scannedImages = await scanImages(pulledImages);
-
-  if (scannedImages.length === 0) {
-    logger.info({workloadName}, 'no images were scanned, halting scanner process.');
-    return;
+    try {
+      await this.scanImagesAndSendResults(workloadName, pulledImages, workloadMetadata);
+    } finally {
+      await removePulledImages(pulledImages);
+    }
   }
 
-  logger.info({workloadName, imageCount: scannedImages.length}, 'successfully scanned images');
+  // TODO: should be extracted from here and moved to the supervisor
+  public async delete(localWorkloadLocator: ILocalWorkloadLocator): Promise<void> {
+    const deletePayload = constructDeleteWorkload(localWorkloadLocator);
+    logger.info({workloadName: this.name, workload: localWorkloadLocator},
+      'removing workloads from upstream');
+    await deleteWorkload(deletePayload);
+  }
 
-  const depGraphPayloads = constructDepGraph(scannedImages, workloadMetadata);
-  await sendDepGraph(...depGraphPayloads);
+  private async scanImagesAndSendResults(
+    workloadName: string,
+    pulledImages: IPullableImage[],
+    workloadMetadata: IWorkload[],
+  ): Promise<void> {
+    const scannedImages = await scanImages(pulledImages);
 
-  const pulledImagesNames = pulledImages.map((image) => image.imageName);
-  const pulledImageMetadata = workloadMetadata.filter((meta) =>
-    pulledImagesNames.includes(meta.imageName),
-  );
+    if (scannedImages.length === 0) {
+      logger.info({workloadName}, 'no images were scanned, halting scanner process.');
+      return;
+    }
 
-  logger.info({workloadName, imageCount: pulledImageMetadata.length}, 'processed images');
-}
+    logger.info({workloadName, imageCount: scannedImages.length}, 'successfully scanned images');
 
+    const depGraphPayloads = constructDepGraph(scannedImages, workloadMetadata);
+    await sendDepGraph(...depGraphPayloads);
+
+    const pulledImagesNames = pulledImages.map((image) => image.imageName);
+    const pulledImageMetadata = workloadMetadata.filter((meta) =>
+      pulledImagesNames.includes(meta.imageName),
+    );
+
+    logger.info({workloadName, imageCount: pulledImageMetadata.length}, 'processed images');
+  }
+};

--- a/src/supervisor/watchers/handlers/pod.ts
+++ b/src/supervisor/watchers/handlers/pod.ts
@@ -2,7 +2,7 @@ import { V1Pod } from '@kubernetes/client-node';
 import async = require('async');
 import config = require('../../../common/config');
 import logger = require('../../../common/logger');
-import { processWorkload } from '../../../scanner';
+import WorkloadWorker = require('../../../scanner');
 import { sendWorkloadMetadata } from '../../../transmitter';
 import { IWorkload } from '../../../transmitter/types';
 import { constructWorkloadMetadata } from '../../../transmitter/payload';
@@ -28,9 +28,9 @@ function deleteFailedKeysFromState(keys): void {
 }
 
 async function queueWorkerWorkloadScan(task, callback): Promise<void> {
-  const {workloadMetadata, imageKeys} = task;
+  const {workloadWorker, workloadMetadata, imageKeys} = task;
   try {
-    await processWorkload(workloadMetadata);
+    await workloadWorker.process(workloadMetadata);
   } catch (err) {
     logger.error({err, task}, 'error processing a workload in the pod handler 2');
     deleteFailedKeysFromState(imageKeys);
@@ -54,7 +54,7 @@ metadataToSendQueue.error(function(err, task) {
   logger.error({err, task}, 'error processing a workload metadata send task');
 });
 
-function handleReadyPod(workloadMetadata: IWorkload[]): void {
+function handleReadyPod(workloadWorker: WorkloadWorker, workloadMetadata: IWorkload[]): void {
   const imagesToScan: IWorkload[] = [];
   const imageKeys: string[] = [];
   for (const image of workloadMetadata) {
@@ -68,7 +68,7 @@ function handleReadyPod(workloadMetadata: IWorkload[]): void {
   }
 
   if (imagesToScan.length > 0) {
-    workloadsToScanQueue.push({workloadMetadata: imagesToScan, imageKeys});
+    workloadsToScanQueue.push({workloadWorker, workloadMetadata: imagesToScan, imageKeys});
   }
 }
 
@@ -106,7 +106,9 @@ export async function podWatchHandler(pod: V1Pod): Promise<void> {
       metadataToSendQueue.push({workloadMetadataPayload});
     }
 
-    handleReadyPod(workloadMetadata);
+    const workloadName = workloadMember.name;
+    const workloadWorker = new WorkloadWorker(workloadName);
+    handleReadyPod(workloadWorker, workloadMetadata);
   } catch (error) {
     logger.error({error, podName}, 'could not build image metadata for pod');
   }

--- a/src/supervisor/watchers/handlers/workload.ts
+++ b/src/supervisor/watchers/handlers/workload.ts
@@ -1,6 +1,6 @@
 import { IKubeObjectMetadata } from '../../types';
 import { buildWorkloadMetadata } from '../../metadata-extractor';
-import { sendDeleteWorkloadRequest } from '../../../scanner';
+import WorkloadWorker = require('../../../scanner');
 import logger = require('../../../common/logger');
 
 export async function deleteWorkload(kubernetesMetadata: IKubeObjectMetadata, workloadName: string): Promise<void> {
@@ -10,7 +10,8 @@ export async function deleteWorkload(kubernetesMetadata: IKubeObjectMetadata, wo
     }
 
     const localWorkloadLocator = buildWorkloadMetadata(kubernetesMetadata);
-    await sendDeleteWorkloadRequest(workloadName, localWorkloadLocator);
+    const workloadWorker = new WorkloadWorker(workloadName);
+    await workloadWorker.delete(localWorkloadLocator);
   } catch (error) {
     logger.error({error, resourceType: kubernetesMetadata.kind, resourceName: kubernetesMetadata.objectMeta.name},
       'could not delete workload');


### PR DESCRIPTION
This reverts commit a3ae2575f69377ccaef188b8d36794e8a20fef05, reversing
changes made to 1860d23e431d5dbcfce9801b26c80b68e134de30.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [x] Potential release notes have been inspected

### More information

The change was supposed to be a simple refactor but introduced test failures that we cannot reproduce locally. Trying to understand what went wrong already took an hour so there is no point to continue investigating right now.

