### PR TITLE
chore: look for a Pod not a Deployment when using kubectl run in tests

### DIFF
--- a/test/helpers/kubectl.ts
+++ b/test/helpers/kubectl.ts
@@ -61,7 +61,7 @@ export async function applyK8sYaml(pathToYamlDeployment: string): Promise<void> 
   console.log(`Applied ${pathToYamlDeployment}`);
 }
 
-export async function createDeploymentFromImage(name: string, image: string, namespace: string) {
+export async function createPodFromImage(name: string, image: string, namespace: string) {
   console.log(`Letting Kubernetes decide how to manage image ${image} with name ${name}`);
   await exec(`./kubectl run ${name} --image=${image} -n ${namespace} -- sleep 999999999`);
   console.log(`Done Letting Kubernetes decide how to manage image ${image} with name ${name}`);

--- a/test/integration/kubernetes.test.ts
+++ b/test/integration/kubernetes.test.ts
@@ -39,7 +39,7 @@ tap.test('deploy sample workloads', async (t) => {
     kubectl.applyK8sYaml('./test/fixtures/redis-deployment.yaml'),
     kubectl.applyK8sYaml('./test/fixtures/centos-deployment.yaml'),
     kubectl.applyK8sYaml('./test/fixtures/scratch-deployment.yaml'),
-    kubectl.createDeploymentFromImage('alpine-from-sha', someImageWithSha, servicesNamespace),
+    kubectl.createPodFromImage('alpine-from-sha', someImageWithSha, servicesNamespace),
   ]);
   t.pass('successfully deployed sample workloads');
 });
@@ -79,7 +79,7 @@ tap.test('snyk-monitor sends data to kubernetes-upstream', async (t) => {
       workloads.find((workload) => workload.name === 'redis' &&
         workload.type === WorkloadKind.Deployment) !== undefined &&
       workloads.find((workload) => workload.name === 'alpine-from-sha' &&
-        workload.type === WorkloadKind.Deployment) !== undefined &&
+        workload.type === WorkloadKind.Pod) !== undefined &&
       workloads.find((workload) => workload.name === 'busybox' &&
         workload.type === WorkloadKind.Deployment) !== undefined &&
       workloads.find((workload) => workload.name === 'centos' &&


### PR DESCRIPTION
kubectl 1.18 deprecated creating deployments using the kubectl run command, so our checks no longer pass.
Adjust the tests to this new behaviour so that they now expect a Pod.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [ ] Potential release notes have been inspected

### More information

- [kubectl 1.18 changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#kubectl)
