### PR TITLE
chore: increase kubectl wait timeout in tests

### DIFF
--- a/test/helpers/kubectl.ts
+++ b/test/helpers/kubectl.ts
@@ -120,7 +120,7 @@ export async function waitForDeployment(name: string, namespace: string): Promis
   console.log(`Found deployment ${name} in namespace ${namespace}`);
 
   console.log(`Begin waiting for deployment ${name} in namespace ${namespace}`);
-  await exec(`./kubectl wait --for=condition=available deployment.apps/${name} -n ${namespace} --timeout=60s`);
+  await exec(`./kubectl wait --for=condition=available deployment.apps/${name} -n ${namespace} --timeout=120s`);
   console.log(`Deployment ${name} in namespace ${namespace} is available`);
 }
 


### PR DESCRIPTION
For OpenShift tests it may take a bit longer for the deployment to be created, so avoid flakiness by increasing the timeout.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [ ] Potential release notes have been inspected
