### PR TITLE
chore: restore environment setup in EKS tests to fix test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,13 +227,17 @@ jobs:
     <<: *default_machine_config
     steps:
       - checkout
-      - setup_node12
       - run:
           name: Create temp dir for logs
           command: mkdir -p /tmp/logs/test/integration/eks
       - run:
           name: Integration tests EKS
+          # WARNING! Do not use the step "setup_node12" here - the call to "nvm use 12" breaks the tests!
           command: |
+            export NVM_DIR="/opt/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            nvm install v12
+            npm install
             export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
             .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:eks
       - run:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [ ] Potential release notes have been inspected

### What this does

Restore environment setup in EKS tests to fix test failures.
The CI job fails with an obscure error which seems like a bad interaction between the environment and pip.

