### PR TITLE
fix: passing data keyword, instead of json, to requests.post()

### DIFF
--- a/scripts/slack/notify_deploy.py
+++ b/scripts/slack/notify_deploy.py
@@ -2,6 +2,7 @@
 
 import os
 import requests
+import json
 import sys
 
 
@@ -21,7 +22,7 @@ def notifySlack(image_name, deployment_env_name):
         ]
     }
 
-    requests.post(url, json=data)
+    requests.post(url, data=json.dumps(data))
 
 
 if __name__ == '__main__':

--- a/scripts/slack/notify_failure.py
+++ b/scripts/slack/notify_failure.py
@@ -2,6 +2,7 @@
 
 import os
 import requests
+import json
 import sys
 
 def notifySlack(branch_name):
@@ -20,7 +21,7 @@ def notifySlack(branch_name):
       ]
     }
 
-    requests.post(url, json=data)
+    requests.post(url, data=json.dumps(data))
 
 if __name__ == '__main__':
     branch_name = sys.argv[1]

--- a/scripts/slack/notify_push.py
+++ b/scripts/slack/notify_push.py
@@ -2,6 +2,7 @@
 
 import os
 import requests
+import json
 import sys
 
 def notifySlack(branch_name):
@@ -20,7 +21,7 @@ def notifySlack(branch_name):
       ]
     }
 
-    requests.post(url, json=data)
+    requests.post(url, data=json.dumps(data))
 
 if __name__ == '__main__':
     branch_name = sys.argv[1]

--- a/scripts/slack/notify_success_no_publish.py
+++ b/scripts/slack/notify_success_no_publish.py
@@ -2,6 +2,7 @@
 
 import os
 import requests
+import json
 
 def notifySlack():
     circle_build_url = os.getenv('CIRCLE_BUILD_URL')
@@ -19,7 +20,7 @@ def notifySlack():
       ]
     }
 
-    requests.post(url, json=data)
+    requests.post(url, data=json.dumps(data))
 
 if __name__ == '__main__':
     notifySlack()

--- a/scripts/slack/notify_success_no_release.py
+++ b/scripts/slack/notify_success_no_release.py
@@ -2,6 +2,7 @@
 
 import os
 import requests
+import json
 
 def notifySlack():
     circle_build_url = os.getenv('CIRCLE_BUILD_URL')
@@ -19,7 +20,7 @@ def notifySlack():
       ]
     }
 
-    requests.post(url, json=data)
+    requests.post(url, data=json.dumps(data))
 
 if __name__ == '__main__':
     notifySlack()


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [x] Potential release notes have been inspected

### What this does

For some reason passing `json` keyword into python `requests.post()` fails on some container configs, I'm expecting different python versions (?). As a solution, I'm passing `data` and parsing a dictionary into json with a lib.
