### PR TITLE
chore: running install_python_requests always

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ commands:
           command: |
             sudo apt update
             sudo apt install python3-requests
+          when: always
            
 
 jobs:


### PR DESCRIPTION
To make sure we can always send slack notification in any failures we have to always install requests library, which is used to send the request when failed.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [x] Potential release notes have been inspected

### What this does

To make sure we can always send slack notification in any failures we have to always install requests library, which is used to send the request when failed.