### PR TITLE
chore: bump release-notes-preview to require confirming the notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,6 @@
 - [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
 - [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
 - [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
-- [ ] Potential release notes have been inspected
 
 ### What this does
 

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -3,6 +3,8 @@ name: Release-Notes-Preview
 on:
   pull_request:
     branches: [ staging ]
+  issue_comment:
+    types: [ edited ]
 
 jobs:
   preview:
@@ -12,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - run: |
         git fetch --prune --unshallow --tags
-    - uses: snyk/release-notes-preview@v1.4.0
+    - uses: snyk/release-notes-preview@v1.5.2
       with:
         releaseBranch: staging
       env:

--- a/test/integration/kubernetes.test.ts
+++ b/test/integration/kubernetes.test.ts
@@ -143,8 +143,8 @@ tap.test('snyk-monitor sends binary hashes to kubernetes-upstream after adding a
   t.equals(nodePluginResult.hashes.length, 1, 'one key-binary hash found in node image');
   t.equals(
     nodePluginResult.hashes[0],
-    '1fd7117ccedc1c673381f71cc611131cb8a47852a882e3d731381f14355a3346',
-    'SHA256 for node v12.16.1 found',
+    '45cf3343b95cb067dec6d64ccc848f48b598baffed5b12be1d14142d087da0e8',
+    'SHA256 for whatever Node is on node:lts-alpine3.11',
   );
 
   const openjdkPluginResult = JSON.parse(depGraphResult.dependencyGraphResults.openjdk);


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
- [x] Potential release notes have been inspected

### What this does

bump release-notes-preview to require confirming the notes.
https://github.com/snyk/release-notes-preview/releases/tag/v1.5.0

### Screenshots

before
![image](https://user-images.githubusercontent.com/1255387/78948425-f32fbe00-7ad0-11ea-8758-fd3f8bbf7b2e.png)

after
![image](https://user-images.githubusercontent.com/1255387/78948429-f62aae80-7ad0-11ea-96b1-4453d67aad4a.png)