### PR TITLE
feat: WIP: add proxying test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,6 +454,12 @@ workflows:
           requires:
             - build_image
           <<: *main_branches_filter
+      ## TODO: vvv REMOVE vvv
+      - integration_tests_proxy:
+          requires:
+            - build_image
+          <<: *main_branches_filter
+      ## TODO: ^^^ REMOVE ^^^
 
   MERGE_TO_STAGING:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,6 +216,28 @@ jobs:
       - store_artifacts:
           path: /tmp/logs/test/integration/kind-helm
 
+    integration_tests_proxy:
+      <<: *default_machine_config
+      steps:
+        - checkout
+        - setup_node12
+        - install_python_requests
+        - run:
+            name: Create temporary directory for logs
+            command: mkdir -p /tmp/logs/test/integration/proxy
+        - run:
+            name: Integration tests with Helm deployment
+            command: |
+              export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
+              npm run test:integration:kind:helm:proxy
+        - run:
+            name: Notify Slack on failure
+            command: |
+              ./scripts/slack/notify_failure_on_branch.py "staging-integration-proxy-tests-${CIRCLE_SHA1}"
+            when: on_fail
+        - store_artifacts:
+            path: /tmp/logs/test/integration/proxy
+
   eks_integration_tests:
     <<: *default_machine_config
     steps:
@@ -455,6 +477,10 @@ workflows:
           requires:
             - build_image
           <<: *staging_branch_only_filter
+      - integration_tests_proxy:
+          requires:
+            - build_image
+          <<: *staging_branch_only_filter
       - eks_integration_tests:
           requires:
             - build_image
@@ -477,6 +503,7 @@ workflows:
             - system_tests
             - integration_tests
             - integration_tests_helm
+            - integration_tests_proxy
           <<: *staging_branch_only_filter
       - deploy_dev:
           requires:

--- a/README.md
+++ b/README.md
@@ -87,3 +87,35 @@ Finally, to launch the Snyk monitor in your cluster, run the following:
 ```shell
 kubectl apply -f snyk-monitor-deployment.yaml
 ```
+
+## Setting up proxying ##
+
+Proxying traffic through a forwarding proxy can be achieved by modifying the `snyk-monitor-cluster-permissions.yaml` or `snyk-monitor-namespaced-permissions.yaml` (depending on which one was applied) and setting the following variables in the `ConfigMap`:
+
+* http_proxy
+* https_proxy
+* no_proxy
+
+For example:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  ...
+data:
+  ...
+  https_proxy: "http://192.168.99.100:8080"
+```
+
+Note that `snyk-monitor` does not proxy requests to the Kubernetes API server.
+
+Note that `snyk-monitor` does not support wildcards or CIDR addresses in `no_proxy` -- it will only look for exact matches. For example:
+
+```yaml
+# not OK:
+no_proxy: *.example.local,*.other.global,192.168.0.0/16
+
+# OK:
+no_proxy: long.domain.name.local,example.local
+```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:system": "tap test/system --timeout=600",
     "test:integration:kind:yaml": "DEPLOYMENT_TYPE=YAML TEST_PLATFORM=kind CREATE_CLUSTER=true tap test/integration/kubernetes.test.ts --timeout=900",
     "test:integration:kind:helm": "DEPLOYMENT_TYPE=Helm TEST_PLATFORM=kind CREATE_CLUSTER=true tap test/integration/kubernetes.test.ts --timeout=900",
+    "test:integration:kind:helm:proxy": "DEPLOYMENT_TYPE=Proxy TEST_PLATFORM=kind CREATE_CLUSTER=true tap test/integration/kubernetes.test.ts --timeout=900",
     "test:integration:eks:yaml": "DEPLOYMENT_TYPE=YAML TEST_PLATFORM=eks CREATE_CLUSTER=false tap test/integration/kubernetes.test.ts --timeout=900",
     "test:integration:openshift3:yaml": "DEPLOYMENT_TYPE=YAML TEST_PLATFORM=openshift3 CREATE_CLUSTER=true tap test/integration/kubernetes.test.ts --timeout=900",
     "test:integration:openshift4:operator": "DEPLOYMENT_TYPE=Operator TEST_PLATFORM=openshift4 CREATE_CLUSTER=false tap test/integration/kubernetes.test.ts --timeout=900",

--- a/snyk-monitor-cluster-permissions.yaml
+++ b/snyk-monitor-cluster-permissions.yaml
@@ -87,4 +87,7 @@ data:
   namespace: ""
   integrationApi: ""
   clusterName: ""
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
 ---

--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -58,6 +58,24 @@ spec:
             value: IMAGE_TAG_OVERRIDE_WHEN_PUBLISHING
           - name: HOME
             value: /srv/app
+          - name: HTTP_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: snyk-monitor
+                key: http_proxy
+                optional: true
+          - name: HTTPS_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: snyk-monitor
+                key: https_proxy
+                optional: true
+          - name: NO_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: snyk-monitor
+                key: no_proxy
+                optional: true
         resources:
           requests:
             cpu: '250m'

--- a/snyk-monitor-namespaced-permissions.yaml
+++ b/snyk-monitor-namespaced-permissions.yaml
@@ -79,4 +79,7 @@ data:
   namespace: snyk-monitor
   integrationApi: ""
   clusterName: ""
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
 ---

--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -74,3 +74,34 @@ For Helm 3, you may run the following:
 ```shell
 helm upgrade --generate-name --install snyk-monitor snyk-charts/snyk-monitor --namespace snyk-monitor --set clusterName="Production cluster"
 ```
+
+## Setting up proxying ##
+
+Proxying traffic through a forwarding proxy can be achieved by setting the following values in the Helm chart:
+
+* http_proxy
+* https_proxy
+* no_proxy
+
+For example:
+
+```bash
+helm upgrade --install snyk-monitor snyk-charts/snyk-monitor \
+  --namespace snyk-monitor \
+  --set clusterName="Production cluster" \
+  --set https_proxy=http://192.168.99.100:8080
+```
+
+Note that `snyk-monitor` does not proxy requests to the Kubernetes API server.
+
+Note that `snyk-monitor` does not support wildcards or CIDR addresses in `no_proxy` -- it will only look for exact matches. For example:
+
+```bash
+# not ok:
+helm upgrade --install ... \
+  --set no_proxy=*.example.local,*.other.global,192.168.0.0/16
+
+# ok:
+helm upgrade --install ... \
+  --set no_proxy=long.domain.name.local,example.local
+```

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -48,6 +48,18 @@ spec:
             value: {{ .Values.image.tag }}
           - name: HOME
             value: /srv/app
+          {{- with .Values.http_proxy }}
+          - name: HTTP_PROXY
+            value: {{ . }}
+          {{- end }}
+          {{- with .Values.https_proxy }}
+          - name: HTTPS_PROXY
+            value: {{ . }}
+          {{- end }}
+          {{- with .Values.no_proxy }}
+          - name: NO_PROXY
+            value: {{ . }}
+          {{- end }}
           resources:
             requests:
               cpu: {{ .Values.requests.cpu }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -37,3 +37,7 @@ requests:
 limits:
   cpu: '1'
   memory: '2Gi'
+
+http_proxy:
+https_proxy:
+no_proxy:

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -10,4 +10,15 @@ config.INTEGRATION_ID = config.INTEGRATION_ID.trim();
 config.CLUSTER_NAME = config.CLUSTER_NAME || 'Default cluster';
 config.IMAGE_STORAGE_ROOT = '/var/tmp';
 
+/**
+ * Important: we delete the following env vars because we don't want to proxy requests to the Kubernetes API server.
+ * The Kubernetes client library would honor the NO/HTTP/HTTPS_PROXY env vars.
+ */
+config.HTTPS_PROXY = process.env['HTTPS_PROXY'];
+config.HTTP_PROXY = process.env['HTTP_PROXY'];
+config.NO_PROXY = process.env['NO_PROXY'];
+delete process.env['HTTPS_PROXY'];
+delete process.env['HTTP_PROXY'];
+delete process.env['NO_PROXY'];
+
 export = config;

--- a/src/common/process.ts
+++ b/src/common/process.ts
@@ -1,5 +1,6 @@
 import { spawn, SpawnPromiseResult } from 'child-process-promise';
 import logger = require('./logger');
+import config = require('./config');
 
 export interface IProcessArgument {
   body: string;
@@ -17,6 +18,9 @@ export function exec(bin: string, ...processArgs: IProcessArgument[]):
   const env = {
     PATH: process.env.PATH,
     HOME: process.env.HOME,
+    HTTPS_PROXY: config.HTTPS_PROXY,
+    HTTP_PROXY: config.HTTP_PROXY,
+    NO_PROXY: config.NO_PROXY,
   };
 
   const allArguments = processArgs.map((arg) => arg.body);

--- a/test/fixtures/proxying/Dockerfile
+++ b/test/fixtures/proxying/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:buster-slim
+WORKDIR /src
+
+RUN apt-get update && apt-get install -y libpcre3-dev wget patch build-essential git zlib1g-dev libssl-dev
+
+RUN cd /tmp && \
+  wget https://nginx.org/download/nginx-1.16.1.tar.gz && \
+  tar -xzvf nginx-1.16.1.tar.gz && \
+  git clone https://github.com/chobits/ngx_http_proxy_connect_module && \
+  cd nginx-1.16.1/ && \
+  wget https://raw.githubusercontent.com/chobits/ngx_http_proxy_connect_module/master/patch/proxy_connect_rewrite_101504.patch && \
+  patch -p1 < proxy_connect_rewrite_101504.patch && \
+  ./configure --add-module=/tmp/ngx_http_proxy_connect_module && \
+  make && \
+  make install
+
+RUN apt-get purge -y libpcre3-dev wget patch build-essential git zlib1g-dev libssl-dev && \
+  apt-get remove --purge --auto-remove -y && \
+  rm -rf /tmp/*
+
+RUN mkdir -p /var/log/nginx && \
+  ln -sf /dev/stdout /var/log/nginx/access.log && \
+  ln -sf /dev/stderr /var/log/nginx/error.log
+
+ADD nginx.conf /etc/nginx/nginx.conf
+
+ENV PATH="/usr/local/nginx/sbin:${PATH}"
+CMD ["nginx", "-g", "daemon off;"]

--- a/test/fixtures/proxying/nginx-deployment.yaml
+++ b/test/fixtures/proxying/nginx-deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forwarding-proxy
+  namespace: snyk-monitor
+spec:
+  selector:
+    matchLabels:
+      app: forwarding-proxy
+  template:
+    metadata:
+      labels:
+        app: forwarding-proxy
+    spec:
+      containers:
+      - name: forwarding-proxy
+        image: snyk/runtime-fixtures:nginx
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+        ports:
+          - containerPort: 8080

--- a/test/fixtures/proxying/nginx-service.yaml
+++ b/test/fixtures/proxying/nginx-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: forwarding-proxy
+  namespace: snyk-monitor
+  labels:
+    app: forwarding-proxy
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+  selector:
+    app: forwarding-proxy

--- a/test/fixtures/proxying/nginx.conf
+++ b/test/fixtures/proxying/nginx.conf
@@ -1,0 +1,32 @@
+user nginx;
+worker_processes 1;
+
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+  
+  access_log /var/log/nginx/access.log;
+  
+  server {
+    listen 8080;
+    resolver 8.8.8.8;
+
+    proxy_connect;
+    proxy_connect_allow 443 563;
+    proxy_connect_connect_timeout 10s;
+    proxy_connect_read_timeout 10s;
+    proxy_connect_send_timeout 10s;
+
+    location / {
+      proxy_set_header Host $host;
+      proxy_pass $scheme://$http_host$uri$is_args$args;
+    }
+  }
+}

--- a/test/setup/deployers/helm-with-proxy.ts
+++ b/test/setup/deployers/helm-with-proxy.ts
@@ -1,0 +1,51 @@
+import { exec } from 'child-process-promise';
+import { platform } from 'os';
+import { existsSync, chmodSync } from 'fs';
+
+import { IDeployer, IImageOptions } from './types';
+import * as kubectl from '../../helpers/kubectl';
+
+const helmVersion = '3.0.0';
+const helmPath = './helm';
+const helmChartPath = './snyk-monitor';
+
+export const helmWithProxyDeployer: IDeployer = {
+  deploy: deployKubernetesMonitor,
+};
+
+async function deployKubernetesMonitor(
+  imageOptions: IImageOptions,
+): Promise<void> {
+  if (!existsSync(helmPath)) {
+    await downloadHelm();
+  }
+
+  await kubectl.applyK8sYaml('test/fixtures/proxying/nginx-service.yaml');
+  await kubectl.applyK8sYaml('test/fixtures/proxying/nginx-deployment.yaml');
+  await kubectl.waitForDeployment('forwarding-proxy', 'snyk-monitor');
+
+  const imageNameAndTag = imageOptions.nameAndTag.split(':');
+  const imageName = imageNameAndTag[0];
+  const imageTag = imageNameAndTag[1];
+  const imagePullPolicy = imageOptions.pullPolicy;
+
+  await exec(
+    `${helmPath} upgrade --install snyk-monitor ${helmChartPath} --namespace snyk-monitor ` +
+      `--set image.repository=${imageName} ` +
+      `--set image.tag=${imageTag} ` +
+      `--set image.pullPolicy=${imagePullPolicy} ` +
+      '--set integrationApi=https://kubernetes-upstream.dev.snyk.io ' +
+      '--set https_proxy=http://forwarding-proxy:8080',
+  );
+  console.log(`Deployed ${imageOptions.nameAndTag} with pull policy ${imageOptions.pullPolicy}`);
+}
+
+async function downloadHelm(): Promise<void> {
+  console.log(`Downloading Helm ${helmVersion}...`);
+  const os = platform();
+  await exec(
+    `curl https://get.helm.sh/helm-v${helmVersion}-${os}-amd64.tar.gz | tar xfzO - ${os}-amd64/helm > ${helmPath}`,
+  );
+  chmodSync(helmPath, 0o755); // rwxr-xr-x
+  console.log('Downloaded Helm');
+}

--- a/test/setup/deployers/index.ts
+++ b/test/setup/deployers/index.ts
@@ -1,9 +1,11 @@
 import { yamlDeployer } from './yaml';
 import { operatorDeployer } from './operator';
 import { helmDeployer } from './helm';
+import { helmWithProxyDeployer } from './helm-with-proxy';
 
 export default {
   YAML: yamlDeployer,
   Operator: operatorDeployer,
   Helm: helmDeployer,
+  Proxy: helmWithProxyDeployer,
 };

--- a/test/unit/transmitter-get-proxy.test.ts
+++ b/test/unit/transmitter-get-proxy.test.ts
@@ -1,0 +1,103 @@
+import * as tap from 'tap';
+
+import { getProxy } from '../../src/transmitter/';
+
+tap.test('returns undefined when nothing is set', async (t) => {
+  t.equals(
+    getProxy({}, 'https://example.endpoint'),
+    undefined,
+    'should return undefined on missing PROXY properties',
+  );
+});
+
+tap.test('returns undefined on empty PROXY values', async (t) => {
+  t.equals(
+    getProxy({ HTTP_PROXY: '' }, 'https://example.endpoint'),
+    undefined,
+    'should return undefined on empty HTTP_PROXY',
+  );
+  t.equals(
+    getProxy({ HTTPS_PROXY: '' }, 'https://example.endpoint'),
+    undefined,
+    'should return undefined on empty HTTPS_PROXY',
+  );
+});
+
+tap.test(
+  'returns undefined on when the endpoint is present in NO_PROXY',
+  async (t) => {
+    t.equals(
+      getProxy({ NO_PROXY: 'example.endpoint' }, 'https://example.endpoint'),
+      undefined,
+      'should return undefined on URL appearing in NO_PROXY',
+    );
+  },
+);
+
+tap.test('returns the HTTP_PROXY address for HTTP URLs', async (t) => {
+  t.equals(
+    getProxy(
+      { HTTP_PROXY: 'should-return', HTTPS_PROXY: 'should-not-return' },
+      'http://example.endpoint',
+    ),
+    'should-return',
+    'returns the value passed in HTTP_PROXY for HTTP endpoints',
+  );
+});
+
+tap.test('returns the HTTP_PROXY address for HTTP URLs', async (t) => {
+  t.equals(
+    getProxy(
+      { HTTP_PROXY: 'should-not-return', HTTPS_PROXY: 'should-return' },
+      'https://example.endpoint',
+    ),
+    'should-return',
+    'returns the value passed in HTTP_PROXY for HTTP endpoints',
+  );
+});
+
+tap.test(
+  'NO_PROXY takes precedence over HTTP_PROXY or HTTPS_PROXY',
+  async (t) => {
+    t.equals(
+      getProxy(
+        {
+          NO_PROXY: 'example.endpoint',
+          HTTP_PROXY: 'should-not-return',
+          HTTPS_PROXY: 'should-not-return',
+        },
+        'https://example.endpoint',
+      ),
+      undefined,
+      'NO_PROXY should override HTTP/S_PROXY',
+    );
+  },
+);
+
+tap.test('CIDR addresses in NO_PROXY are not yet supported', async (t) => {
+  t.equals(
+    getProxy(
+      {
+        NO_PROXY: '192.168.0.0/16',
+        HTTP_PROXY: 'should-return',
+      },
+      'http://192.168.1.1',
+    ),
+    'should-return',
+    'CIDR addresses should not be supported',
+  );
+});
+
+tap.test('wildcards in NO_PROXY are not yet supported', async (t) => {
+  t.equals(
+    getProxy(
+      {
+        NO_PROXY: '*.example.endpoint',
+        HTTP_PROXY: 'should-return',
+      },
+      'http://test.example.endpoint',
+    ),
+    'should-return',
+    'wildcards should not be supported',
+  );
+});


### PR DESCRIPTION
Some WIP on adding proxying support.
The idea is to use the provided files during tests to spin up a local forwarding proxy, and then use it to send results to the upstream.

### To test

```shell
kind create cluster

# apply the sample deployment
kubectl apply -f test/fixtures/proxying/nginx-conf.yaml
kubectl apply -f test/fixtures/proxying/nginx-service.yaml
kubectl apply -f test/fixtures/proxying/nginx-deployment.yaml

# build and load the image
./scripts/docker/build-image.sh 
kind load docker-image snyk/kubernetes-monitor:local

kubectl create ns snyk-monitor
kubectl create secret generic snyk-monitor -n snyk-monitor --from-literal=dockercfg
.json={} --from-literal=integrationId=###########

helm upgrade --install snyk-monitor ./snyk-monitor --set image.tag=local --set imag
e.pullPolicy=Never --namespace snyk-monitor --set clusterName="Forward proxy test"
```