### PR TITLE
Chore/rename depgraph type

### DIFF
--- a/src/transmitter/index.ts
+++ b/src/transmitter/index.ts
@@ -3,12 +3,17 @@ import { NeedleResponse, NeedleHttpVerbs, NeedleOptions } from 'needle';
 import * as sleep from 'sleep-promise';
 import * as config from '../common/config';
 import logger = require('../common/logger');
-import { IDeleteWorkloadPayload, IDepGraphPayload, IWorkloadMetadataPayload, IResponseWithAttempts } from './types';
+import {
+  IDeleteWorkloadPayload,
+  IDependencyGraphPayload,
+  IWorkloadMetadataPayload,
+  IResponseWithAttempts,
+} from './types';
 import { getProxyAgent } from './proxy';
 
 const upstreamUrl = config.INTEGRATION_API || config.DEFAULT_KUBERNETES_UPSTREAM_URL;
 
-export async function sendDepGraph(...payloads: IDepGraphPayload[]): Promise<void> {
+export async function sendDepGraph(...payloads: IDependencyGraphPayload[]): Promise<void> {
   for (const payload of payloads) {
     // Intentionally removing dependencyGraph as it would be too big to log
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/transmitter/payload.ts
+++ b/src/transmitter/payload.ts
@@ -3,7 +3,7 @@ import { currentClusterName } from '../supervisor/cluster';
 import { IScanResult } from '../scanner/types';
 import {
   IDeleteWorkloadPayload,
-  IDepGraphPayload,
+  IDependencyGraphPayload,
   IWorkload,
   ILocalWorkloadLocator,
   IImageLocator,
@@ -16,7 +16,7 @@ import {
 export function constructDepGraph(
     scannedImages: IScanResult[],
     workloadMetadata: IWorkload[],
-): IDepGraphPayload[] {
+): IDependencyGraphPayload[] {
   const results = scannedImages.map((scannedImage) => {
     // We know that .find() won't return undefined
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -44,7 +44,7 @@ export function constructDepGraph(
       agentId: config.AGENT_ID,
       dependencyGraph: JSON.stringify(scannedImage.pluginResult),
       metadata: monitorMetadata,
-    } as IDepGraphPayload;
+    } as IDependencyGraphPayload;
   });
 
   return results;

--- a/src/transmitter/payload.ts
+++ b/src/transmitter/payload.ts
@@ -17,7 +17,7 @@ export function constructDepGraph(
     scannedImages: IScanResult[],
     workloadMetadata: IWorkload[],
 ): IDependencyGraphPayload[] {
-  const results = scannedImages.map((scannedImage) => {
+  const results = scannedImages.map((scannedImage): IDependencyGraphPayload => {
     // We know that .find() won't return undefined
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const kubeWorkload: IWorkload = workloadMetadata.find((meta) => meta.imageName === scannedImage.imageWithTag)!;
@@ -44,7 +44,7 @@ export function constructDepGraph(
       agentId: config.AGENT_ID,
       dependencyGraph: JSON.stringify(scannedImage.pluginResult),
       metadata: monitorMetadata,
-    } as IDependencyGraphPayload;
+    };
   });
 
   return results;

--- a/src/transmitter/types.ts
+++ b/src/transmitter/types.ts
@@ -33,7 +33,7 @@ export interface IKubernetesMonitorMetadata {
   namespace?: string;
 }
 
-export interface IDepGraphPayload {
+export interface IDependencyGraphPayload {
   imageLocator: IImageLocator;
   agentId: string;
   dependencyGraph?: string;


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Rename a shortened type name to allow it to be searched more easily.

Add type hints to the mapping function constructing the dependency graph payload.
This helps us not introduce properties which are not part of the type. Previously we used "as IType" which could mask extra properties added to the object. Adding an explicit return type on the mapping function and removing the cast allows us to catch these errors at compile time.

### Screenshots

An example how this would now catch errors, previously we would have masked them with the cast:
<img width="529" alt="Screenshot 2020-04-20 at 16 21 42" src="https://user-images.githubusercontent.com/16717473/79769298-d773b580-8323-11ea-9e23-25287d0b9174.png">

