### PR TITLE
chore: fix bad name on type in kind.test.ts due to bad merge

### DIFF
--- a/test/system/kind.test.ts
+++ b/test/system/kind.test.ts
@@ -106,7 +106,7 @@ tap.test('Kubernetes-Monitor with KinD', async (t) => {
   nock('https://kubernetes-upstream.snyk.io')
     .post('/api/v1/dependency-graph')
     .times(1)
-    .reply(200, (uri, requestBody: transmitterTypes.IDepGraphPayload) => {
+    .reply(200, (uri, requestBody: transmitterTypes.IDependencyGraphPayload) => {
       t.ok('metadata' in requestBody, 'metadata is present in dependency graph payload');
       // TODO: this is weird, why is agentId present in two places?
       t.ok('agentId' in requestBody, 'agent ID is present in dependency graph payload');


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
