### PR TITLE
[RUN-900] chore: bump release-notes-preview GH action to 1.6.1

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -14,9 +14,9 @@ jobs:
     - uses: actions/checkout@v2
     - run: |
         git fetch --prune --unshallow --tags
-    - uses: snyk/release-notes-preview@v1.5.2
+    - uses: snyk/release-notes-preview@v1.6.1
       with:
         releaseBranch: staging
       env:
         GITHUB_PR_USERNAME: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.RELEASE_NOTES_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

It updates the Release-Notes-Pewview GitHub action to the latest version because it is currently not using the latest version and it should probably be using the latest version.

### More information

- [Jira ticket RUN-900](https://snyksec.atlassian.net/browse/RUN-900)
