### PR TITLE
Fix/when retry request

### DIFF
--- a/src/transmitter/index.ts
+++ b/src/transmitter/index.ts
@@ -122,5 +122,9 @@ function shouldRetryRequest(err: IRequestError, stillHaveRetries: boolean): bool
     return true;
   }
 
+  if (err.code === 'EAI_AGAIN') {
+    return true;
+  }
+
   return false;
 }

--- a/src/transmitter/types.ts
+++ b/src/transmitter/types.ts
@@ -72,3 +72,8 @@ export interface IResponseWithAttempts {
   response: NeedleResponse;
   attempt: number;
 }
+
+export interface IRequestError {
+  code: string;
+  message: string;
+}

--- a/test/system/kind.test.ts
+++ b/test/system/kind.test.ts
@@ -106,6 +106,14 @@ tap.test('Kubernetes-Monitor with KinD', async (t) => {
   nock('https://kubernetes-upstream.snyk.io')
     .post('/api/v1/dependency-graph')
     .times(1)
+    .replyWithError({
+      code: 'EAI_AGAIN',
+      message: 'getaddrinfo EAI_AGAIN kubernetes-upstream.snyk.io',
+    });
+
+  nock('https://kubernetes-upstream.snyk.io')
+    .post('/api/v1/dependency-graph')
+    .times(1)
     .reply(200, (uri, requestBody: transmitterTypes.IDependencyGraphPayload) => {
       t.ok('metadata' in requestBody, 'metadata is present in dependency graph payload');
       // TODO: this is weird, why is agentId present in two places?


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

It has a small refactoring moving the condition that decide if k8s-monitor should or not retry a request. Also it includes a new error code that allows k8s-monitor decides if it should retry a request or not.


### Notes for the reviewer

This new error code was introduced because sometimes kubernetes cluster can have timeout caused by slow DNS lookup. And k8s-monitor should retry the request if it stills having remaining retries.

### More information

- [Jira ticket RUN-882](https://snyksec.atlassian.net/browse/RUN-882)
