### PR TITLE
[RUN-903] chore: stop publishing the READMEs to gh-pages

### DIFF
--- a/scripts/publish-gh-pages.sh
+++ b/scripts/publish-gh-pages.sh
@@ -20,7 +20,8 @@ then
 fi
 
 echo overriding new yaml / chart files from master branch
-git checkout origin/master -- snyk-monitor snyk-monitor-cluster-permissions.yaml snyk-monitor-deployment.yaml snyk-monitor-namespaced-permissions.yaml README.md
+git checkout origin/master -- snyk-monitor snyk-monitor-cluster-permissions.yaml snyk-monitor-deployment.yaml snyk-monitor-namespaced-permissions.yaml
+git reset ./snyk-monitor/README.md
 
 echo overriding tag placeholders with latest semantic version
 sed -i "s/IMAGE_TAG_OVERRIDE_WHEN_PUBLISHING/${NEW_TAG}/g" ./snyk-monitor/values.yaml
@@ -38,7 +39,6 @@ git add ./snyk-monitor/values.yaml
 git add ./snyk-monitor-deployment.yaml
 git add ./snyk-monitor-cluster-permissions.yaml
 git add ./snyk-monitor-namespaced-permissions.yaml
-git add ./README.md
 COMMIT_MESSAGE='fix: :egg: Automatic Publish '${NEW_TAG}' :egg:'
 git commit -m "${COMMIT_MESSAGE}"
 git push --quiet --set-upstream origin-pages gh-pages

--- a/test/fixtures/binaries-deployment.yaml
+++ b/test/fixtures/binaries-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: node
-        image: node:lts-alpine3.11
+        image: node@sha256:215a9fbef4df2c1ceb7c79481d3cfd94ad8f1f0105bade39f3be907bf386c5e1
         command: ['sh', '-c', 'echo Hello from node:lts-alpine3.11 pod! && sleep 360000']
         ports:
         - containerPort: 80

--- a/test/integration/kubernetes.test.ts
+++ b/test/integration/kubernetes.test.ts
@@ -143,7 +143,7 @@ tap.test('snyk-monitor sends binary hashes to kubernetes-upstream after adding a
   t.equals(nodePluginResult.hashes.length, 1, 'one key-binary hash found in node image');
   t.equals(
     nodePluginResult.hashes[0],
-    '45cf3343b95cb067dec6d64ccc848f48b598baffed5b12be1d14142d087da0e8',
+    '6d5847d3cd69dfdaaf9dd2aa8a3d30b1a9b3bfa529a1f5c902a511e1aa0b8f55',
     'SHA256 for whatever Node is on node:lts-alpine3.11',
   );
 


### PR DESCRIPTION
since the repository is now open-source the READMEs in develop should be enough.
no reason to refer anyone to the gh-pages branch for docs

- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

stpp publishing the READMEs to gh-pages

### More information

- [Jira ticket RUN-903](https://snyksec.atlassian.net/browse/RUN-903)

