### PR TITLE
chore: extract the condition for retry request to the new function

### DIFF
--- a/src/supervisor/types.ts
+++ b/src/supervisor/types.ts
@@ -1,3 +1,4 @@
+import { IncomingMessage }  from 'http';
 import { AppsV1Api, BatchV1Api, BatchV1beta1Api, CoreV1Api, KubeConfig,
   V1ObjectMeta, V1OwnerReference, V1PodSpec } from '@kubernetes/client-node';
 
@@ -10,6 +11,10 @@ export enum WorkloadKind {
   CronJob = 'CronJob',
   ReplicationController = 'ReplicationController',
   Pod = 'Pod',
+}
+
+export interface IRequestError {
+  response?: IncomingMessage;
 }
 
 export interface IKubeObjectMetadata {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

It has a small refactoring that moves the conditions that decides if k8s-monitor should or not retry a request using kubernetes API. It'll help include new logics that allow k8s-monitor retry for other errors.

### Notes for the reviewer

It's first step before include retry policies for errors in this ticket [RUN-818](https://snyksec.atlassian.net/browse/RUN-818).
