### PR TITLE
Fix/include errors for k8s api calls

### DIFF
--- a/src/supervisor/kuberenetes-api-wrappers.ts
+++ b/src/supervisor/kuberenetes-api-wrappers.ts
@@ -46,6 +46,14 @@ function shouldRetryRequest(err: IRequestError, attempt: number): boolean {
     return false;
   }
 
+  if (err.code === 'ECONNREFUSED') {
+    return true;
+  }
+
+  if (err.code === 'ETIMEDOUT') {
+    return true;
+  }
+
   if (!(err.response)) {
     return false;
   }

--- a/src/supervisor/types.ts
+++ b/src/supervisor/types.ts
@@ -14,6 +14,7 @@ export enum WorkloadKind {
 }
 
 export interface IRequestError {
+  code?: string;
   response?: IncomingMessage;
 }
 

--- a/src/supervisor/watchers/handlers/index.ts
+++ b/src/supervisor/watchers/handlers/index.ts
@@ -10,6 +10,7 @@ import { replicaSetWatchHandler } from './replica-set';
 import { replicationControllerWatchHandler } from './replication-controller';
 import { statefulSetWatchHandler } from './stateful-set';
 import { k8sApi, kubeConfig } from '../../cluster';
+import * as kubernetesApiWrappers from '../../kuberenetes-api-wrappers';
 import { IWorkloadWatchMetadata, FALSY_WORKLOAD_NAME_MARKER } from './types';
 
 /**
@@ -98,7 +99,8 @@ export function setupInformer(namespace: string, workloadKind: WorkloadKind) {
   const listMethod = workloadMetadata.listFactory(namespace);
   const loggedListMethod = async () => {
     try {
-      return await listMethod();
+      return await kubernetesApiWrappers.retryKubernetesApiRequest(
+        () => listMethod());
     } catch (err) {
       logger.error({err, namespace, workloadKind}, 'error while listing entities on namespace');
       throw err;

--- a/src/supervisor/watchers/index.ts
+++ b/src/supervisor/watchers/index.ts
@@ -6,6 +6,7 @@ import logger = require('../../common/logger');
 import { WorkloadKind } from '../types';
 import { setupInformer } from './handlers';
 import { kubeConfig, k8sApi } from '../cluster';
+import * as kubernetesApiWrappers from '../kuberenetes-api-wrappers';
 import { kubernetesInternalNamespaces } from './internal-namespaces';
 
 /**
@@ -52,7 +53,8 @@ function setupWatchesForCluster(): void {
     '/api/v1/namespaces',
     async () => {
       try {
-        return await k8sApi.coreClient.listNamespace();
+        return await kubernetesApiWrappers.retryKubernetesApiRequest(
+          () => k8sApi.coreClient.listNamespace());
       } catch (err) {
         logger.error({err}, 'error while listing namespaces');
         throw err;

--- a/test/system/kind.test.ts
+++ b/test/system/kind.test.ts
@@ -69,6 +69,30 @@ tap.test('Kubernetes-Monitor with KinD', async (t) => {
   ]);
 
   // Setup nocks
+  nock(/https\:\/\/127\.0\.0\.1\:\d+/, { allowUnmocked: true})
+    .get('/api/v1/namespaces')
+    .times(1)
+    .replyWithError({
+      code: 'ECONNREFUSED'
+    })
+    .get('/api/v1/namespaces')
+    .times(1)
+    .replyWithError({
+      code: 'ETIMEDOUT'
+    });
+
+  nock(/https\:\/\/127\.0\.0\.1\:\d+/, { allowUnmocked: true})
+    .get('/apis/apps/v1/namespaces/snyk-monitor/deployments')
+    .times(1)
+    .replyWithError({
+      code: 'ECONNREFUSED'
+    })
+    .get('/apis/apps/v1/namespaces/snyk-monitor/deployments')
+    .times(1)
+    .replyWithError({
+      code: 'ETIMEDOUT'
+    });
+
   nock('https://kubernetes-upstream.snyk.io')
     .post('/api/v1/workload')
     .times(1)


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

It includes new error cases to k8s API retry mechanism, and wrap two k8s API calls in the retry mechanism.

### Notes for the reviewer

It was broken in two commits. The first includes the new error cases to retry mechanism. The second wrap the k8s API calls in the retry mechanism.

### More information

- [Jira ticket RUN-818](https://snyksec.atlassian.net/browse/RUN-818)
