### PR TITLE
fix: address TODO comments

### DIFF
--- a/src/supervisor/watchers/handlers/cron-job.ts
+++ b/src/supervisor/watchers/handlers/cron-job.ts
@@ -6,7 +6,6 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 export async function cronJobWatchHandler(cronJob: V1beta1CronJob): Promise<void> {
   if (!cronJob.metadata || !cronJob.spec || !cronJob.spec.jobTemplate.spec ||
       !cronJob.spec.jobTemplate.metadata || !cronJob.spec.jobTemplate.spec.template.spec) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/watchers/handlers/daemon-set.ts
+++ b/src/supervisor/watchers/handlers/daemon-set.ts
@@ -6,7 +6,6 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 export async function daemonSetWatchHandler(daemonSet: V1DaemonSet): Promise<void> {
   if (!daemonSet.metadata || !daemonSet.spec || !daemonSet.spec.template.metadata ||
       !daemonSet.spec.template.spec || !daemonSet.status) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/watchers/handlers/deployment.ts
+++ b/src/supervisor/watchers/handlers/deployment.ts
@@ -6,7 +6,6 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 export async function deploymentWatchHandler(deployment: V1Deployment): Promise<void> {
   if (!deployment.metadata || !deployment.spec || !deployment.spec.template.metadata ||
       !deployment.spec.template.spec || !deployment.status) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/watchers/handlers/job.ts
+++ b/src/supervisor/watchers/handlers/job.ts
@@ -5,7 +5,6 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 
 export async function jobWatchHandler(job: V1Job): Promise<void> {
   if (!job.metadata || !job.spec || !job.spec.template.metadata || !job.spec.template.spec) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/watchers/handlers/replica-set.ts
+++ b/src/supervisor/watchers/handlers/replica-set.ts
@@ -6,7 +6,6 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 export async function replicaSetWatchHandler(replicaSet: V1ReplicaSet): Promise<void> {
   if (!replicaSet.metadata || !replicaSet.spec || !replicaSet.spec.template ||
       !replicaSet.spec.template.metadata || !replicaSet.spec.template.spec || !replicaSet.status) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/watchers/handlers/replication-controller.ts
+++ b/src/supervisor/watchers/handlers/replication-controller.ts
@@ -7,7 +7,6 @@ export async function replicationControllerWatchHandler(replicationController: V
   if (!replicationController.metadata || !replicationController.spec || !replicationController.spec.template ||
       !replicationController.spec.template.metadata || !replicationController.spec.template.spec ||
       !replicationController.status) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/watchers/handlers/stateful-set.ts
+++ b/src/supervisor/watchers/handlers/stateful-set.ts
@@ -6,7 +6,6 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 export async function statefulSetWatchHandler(statefulSet: V1StatefulSet): Promise<void> {
   if (!statefulSet.metadata || !statefulSet.spec || !statefulSet.spec.template.metadata ||
       !statefulSet.spec.template.spec || !statefulSet.status) {
-    // TODO(ivanstanev): possibly log this. It shouldn't happen but we should track it!
     return;
   }
 

--- a/src/supervisor/workload-reader.ts
+++ b/src/supervisor/workload-reader.ts
@@ -3,6 +3,7 @@ import { V1OwnerReference } from '@kubernetes/client-node';
 import * as kubernetesApiWrappers from './kuberenetes-api-wrappers';
 import { k8sApi } from './cluster';
 import { IKubeObjectMetadata, WorkloadKind } from './types';
+import logger = require('../common/logger');
 
 type IWorkloadReaderFunc = (
   workloadName: string,
@@ -16,7 +17,8 @@ const deploymentReader: IWorkloadReaderFunc = async (workloadName, namespace) =>
 
   if (!deployment.metadata || !deployment.spec || !deployment.spec.template.metadata ||
       !deployment.spec.template.spec || !deployment.status) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
+    logIncompleteWorkload(workloadName, namespace);
+
     return undefined;
   }
 
@@ -37,7 +39,8 @@ const replicaSetReader: IWorkloadReaderFunc = async (workloadName, namespace) =>
 
   if (!replicaSet.metadata || !replicaSet.spec || !replicaSet.spec.template ||
       !replicaSet.spec.template.metadata || !replicaSet.spec.template.spec || !replicaSet.status) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
+    logIncompleteWorkload(workloadName, namespace);
+
     return undefined;
   }
 
@@ -58,7 +61,8 @@ const statefulSetReader: IWorkloadReaderFunc = async (workloadName, namespace) =
 
   if (!statefulSet.metadata || !statefulSet.spec || !statefulSet.spec.template.metadata ||
       !statefulSet.spec.template.spec || !statefulSet.status) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
+    logIncompleteWorkload(workloadName, namespace);
+
     return undefined;
   }
 
@@ -79,7 +83,8 @@ const daemonSetReader: IWorkloadReaderFunc = async (workloadName, namespace) => 
 
   if (!daemonSet.metadata || !daemonSet.spec || !daemonSet.spec.template.spec ||
       !daemonSet.spec.template.metadata || !daemonSet.status) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
+    logIncompleteWorkload(workloadName, namespace);
+
     return undefined;
   }
 
@@ -99,7 +104,8 @@ const jobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
   const job = jobResult.body;
 
   if (!job.metadata || !job.spec || !job.spec.template.spec || !job.spec.template.metadata) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
+    logIncompleteWorkload(workloadName, namespace);
+
     return undefined;
   }
 
@@ -122,7 +128,8 @@ const cronJobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
 
   if (!cronJob.metadata || !cronJob.spec || !cronJob.spec.jobTemplate.metadata ||
       !cronJob.spec.jobTemplate.spec || !cronJob.spec.jobTemplate.spec.template.spec) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
+    logIncompleteWorkload(workloadName, namespace);
+
     return undefined;
   }
 
@@ -143,7 +150,8 @@ const replicationControllerReader: IWorkloadReaderFunc = async (workloadName, na
   if (!replicationController.metadata || !replicationController.spec || !replicationController.spec.template ||
       !replicationController.spec.template.metadata || !replicationController.spec.template.spec ||
       !replicationController.status) {
-    // TODO(ivanstanev): add logging to know when/if it happens!
+    logIncompleteWorkload(workloadName, namespace);
+
     return undefined;
   }
 
@@ -156,6 +164,10 @@ const replicationControllerReader: IWorkloadReaderFunc = async (workloadName, na
     podSpec: replicationController.spec.template.spec,
   };
 };
+
+function logIncompleteWorkload(workloadName: string, namespace: string): void {
+  logger.info({ workloadName, namespace }, 'kubernetes api could not return workload');
+}
 
 // Here we are using the "kind" property of a k8s object as a key to map it to a reader.
 // This gives us a quick look up table where we can abstract away the internal implementation of reading a resource


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

 Address TODO comments, either removing it or improve code, once it was clear which action we should take about each one.

### Notes for the reviewer

Basically the TODOs are in two kinds of functions, the handlers and the readers.

For the handlers, we think it's ok we just remove the TODO and do nothing, we're already doing it in other handlers, and these handlers basically remove the workload from Homebase once it is removed from the cluster. If we have any problem, this workload would be removed from Homebase in 4 days anyway.

For the readers, it is worth including an info log with the workload name and namespace. Just because, in the future, if a customer has any problem, we will have some logs that will help us to investigate it.

### More information

- [Jira ticket RUN-545](https://snyksec.atlassian.net/browse/RUN-545)
