### PR TITLE
[RUN-848] Feat/add ssl certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Finally, create the secret in Kubernetes by running the following command:
 kubectl create secret generic snyk-monitor -n snyk-monitor --from-file=./dockercfg.json --from-literal=integrationId=abcd1234-abcd-1234-abcd-1234abcd1234
 ```
 
+4. If your private registry requires installing certificates (*.crt, *.cert, *.key only) please put them in a folder and create the following ConfigMap:
+```shell
+kubectl create configmap snyk-monitor-certs -n snyk-monitor --from-file=<path_to_certs_folder>
+```
+
 ## Installation from YAML files ##
 
 The `kubernetes-monitor` can run in one of two modes: constrained to a single namespace, or with access to the whole cluster.

--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -30,6 +30,8 @@ spec:
           mountPath: "/srv/app/.docker"
         - name: temporary-storage
           mountPath: "/var/tmp"
+        - name: ssl-certs
+          mountPath: "/srv/app/certs"
         env:
           - name: SNYK_INTEGRATION_ID
             valueFrom:
@@ -101,4 +103,8 @@ spec:
       - name: temporary-storage
         emptyDir:
           sizeLimit: 50Gi
+      - name: ssl-certs
+        configMap:
+          name: snyk-monitor-certs
+          optional: true
       serviceAccountName: snyk-monitor

--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -50,6 +50,11 @@ Finally, create the secret in Kubernetes by running the following command:
 kubectl create secret generic snyk-monitor -n snyk-monitor --from-file=./dockercfg.json --from-literal=integrationId=abcd1234-abcd-1234-abcd-1234abcd1234
 ```
 
+4. If your private registry requires installing certificates (*.crt, *.cert, *.key only) please put them in a folder and create the following ConfigMap:
+```shell
+kubectl create configmap snyk-monitor-certs -n snyk-monitor --from-file=<path_to_certs_folder>
+```
+
 ## Installation from Helm repo ##
 
 Add Snyk's Helm repo:

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
             mountPath: "/srv/app/.docker"
           - name: temporary-storage
             mountPath: "/var/tmp"
+          - name: ssl-certs
+            mountPath: "/srv/app/certs"
           env:
           - name: SNYK_INTEGRATION_ID
             valueFrom:
@@ -79,3 +81,7 @@ spec:
         - name: temporary-storage
           emptyDir:
             sizeLimit: {{ .Values.temporaryStorageSize }}
+        - name: ssl-certs
+          configMap:
+            name: {{ .Values.certsConfigMap }}
+            optional: true

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -5,6 +5,7 @@
 # The secrets should be created externally, before applying this Helm chart.
 # The currently used keys within the secret are: "dockercfg.json", "integrationId".
 monitorSecrets: snyk-monitor
+certsConfigMap: snyk-monitor-certs
 
 # One of: Cluster, Namespaced
 # Cluster - creates a ClusterRole and ClusterRoleBinding with the ServiceAccount

--- a/src/scanner/images/skopeo.ts
+++ b/src/scanner/images/skopeo.ts
@@ -38,10 +38,12 @@ export async function pull(
 ): Promise<void> {
   const creds = await credentials.getSourceCredentials(image);
   const credentialsParameters = getCredentialParameters(creds);
+  const certificatesParameters = getCertificatesParameters();
 
   const args: Array<processWrapper.IProcessArgument> = [];
   args.push({body: 'copy', sanitise: false});
   args.push(...credentialsParameters);
+  args.push(...certificatesParameters);
   args.push({body: prefixRespository(image, SkopeoRepositoryType.ImageRegistry), sanitise: false});
   args.push({body: prefixRespository(destination, SkopeoRepositoryType.DockerArchive), sanitise: false});
 
@@ -79,4 +81,11 @@ export function getCredentialParameters(credentials: string | undefined): Array<
     credentialsParameters.push({body: credentials, sanitise: true});
   }
   return credentialsParameters;
+}
+
+export function getCertificatesParameters(): Array<processWrapper.IProcessArgument> {
+  const certificatesParameters: Array<processWrapper.IProcessArgument> = [];
+  certificatesParameters.push({body: '--src-cert-dir', sanitise: true});
+  certificatesParameters.push({body: '/srv/app/certs', sanitise: true});
+  return certificatesParameters;
 }

--- a/test/unit/scanner/skopeo.test.ts
+++ b/test/unit/scanner/skopeo.test.ts
@@ -17,8 +17,17 @@ tap.test('getCredentialParameters()', async (t) => {
     credentialParametersForSomeCredentials,
     [
       {body: '--src-creds', sanitise: true},
-      {body: someCredentials, sanitise: true}
+      {body: someCredentials, sanitise: true},
     ],
     'returns Skopeo\'s args for source credentials',
+  );
+  const certificatesParameters = skopeo.getCertificatesParameters();
+  t.same(
+    certificatesParameters,
+    [
+      {body: '--src-cert-dir', sanitise: true},
+      {body: '/srv/app/certs', sanitise: true},
+    ],
+    'returns Skopeo\'s certificate args',
   );
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds support in injecting SSL certs to skopeo copy for onprem registries

### Notes for the reviewer

Tested manually.
* Modified our dockerfile and added `RUN rm -rf /etc/ssl/cert.pem` which caused:

```
{"name":"kubernetes-monitor","hostname":"snyk-monitor-6987fc6b67-2prkg","pid":51,"level":40,"message":"time=\"2020-05-10T11:57:05Z\" level=fatal msg=\"Error initializing source docker://rancher/local-path-provisioner:v0.0.11: pinging docker registry returned: Get https://registry-1.docker.io/v2/: x509: certificate signed by unknown authority\"\n","bin":"skopeo","loggableArguments":["copy","docker://rancher/local-path-provisioner:v0.0.11","docker-archive:/var/tmp/rancher_local_path_provisioner_v0_0_11_55801_148479917.tar"],"msg":"child process failure","time":"2020-05-10T11:57:05.149Z","v":0}
```

* got myself an equivalent cert.crt file by:
  * running `alpine:3.6`
  * executing `apk add -U --no-cache ca-certificates` inside
  * copied `/etc/ssl/certs/ca-certificates.crt` outside
* created the secret: ` kubectl create configmap snyk-monitor-certs --from-file=<path to crt file> -n snyk-monitor`

the result: working as expected

### More information

- [Jira ticket RUN-848](https://snyksec.atlassian.net/browse/RUN-848)
