### PR TITLE
chore: automate operator upgrade testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,520 +1,788 @@
-version: 2.1
-
-default_machine_config: &default_machine_config
-  machine:
-    enabled: true
-    docker_layer_caching: true
-  working_directory: ~/kubernetes-monitor
-
-default_container_config: &default_container_config
-  docker:
-    - image: circleci/node:12
-  working_directory: ~/kubernetes-monitor
-
-python_container_config: &python_container_config
-  docker:
-    - image: circleci/python:3
-  working_directory: ~/kubernetes-monitor
-
-staging_branch_only_filter: &staging_branch_only_filter
-  filters:
-    branches:
-      only:
-        - staging
-
-master_branch_only_filter: &master_branch_only_filter
-  filters:
-    branches:
-      only:
-        - master
-
-main_branches_filter: &main_branches_filter
-  filters:
-    branches:
-      ignore:
-        - staging
-        - master
-
 commands:
-  setup_node12:
-    description: Setup Node 12
-    steps:
-      - run:
-          command: |
-            export NVM_DIR="/opt/circleci/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            nvm install v12
-            npm install
-            echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
-            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
-            echo 'nvm use 12' >> $BASH_ENV
   install_python_requests:
     description: Install requests library
     steps:
-      - run:
-          command: |
-            sudo apt update
-            sudo apt install python3-requests
-          when: always
-           
-
+    - run:
+        command: |
+          sudo apt update
+          sudo apt install python3-requests
+        when: always
+  setup_node12:
+    description: Setup Node 12
+    steps:
+    - run:
+        command: |-
+          export NVM_DIR="/opt/circleci/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          nvm install v12
+          npm install
+          echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+          echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+          echo 'nvm use 12' >> $BASH_ENV
 jobs:
-######################## PR OR MERGE TO STAGING ########################
   build_image:
-    <<: *default_machine_config
+    machine:
+      docker_layer_caching: true
+      enabled: true
     steps:
-      - checkout
-      - install_python_requests
-      - run:
-          name: Build image
-          command: |
-            docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} &&
-            export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable") &&
-            IMAGE_NAME_CANDIDATE=snyk/kubernetes-monitor:${IMAGE_TAG}-${CIRCLE_SHA1} &&
-            ./scripts/docker/build-image.sh ${IMAGE_NAME_CANDIDATE} &&
-            docker push ${IMAGE_NAME_CANDIDATE}
-      - run:
-          name: Notify Slack on failure
-          command: |
-            ./scripts/slack/notify_failure_on_branch.py "staging-build-image-${CIRCLE_SHA1}"
-          when: on_fail
-
+    - checkout
+    - install_python_requests
+    - run:
+        command: |
+          docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} &&
+          export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable") &&
+          IMAGE_NAME_CANDIDATE=snyk/kubernetes-monitor:${IMAGE_TAG}-${CIRCLE_SHA1} &&
+          ./scripts/docker/build-image.sh ${IMAGE_NAME_CANDIDATE} &&
+          docker push ${IMAGE_NAME_CANDIDATE}
+        name: Build image
+    - run:
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-build-image-${CIRCLE_SHA1}"
+        name: Notify Slack on failure
+        when: on_fail
+    working_directory: ~/kubernetes-monitor
   build_operator:
-    <<: *default_machine_config
+    machine:
+      docker_layer_caching: true
+      enabled: true
     steps:
-      - checkout
-      - install_python_requests
-      - run:
-          name: Download Operator SDK
-          command: |
-            RELEASE_VERSION=v0.15.1
-            DOWNLOAD_LOCATION=./operator-sdk
-            CURL_FOLLOW_REDIRECTS="-L"
-            curl ${CURL_FOLLOW_REDIRECTS} https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu -o ${DOWNLOAD_LOCATION}
-            chmod +x ${DOWNLOAD_LOCATION}
-      - run:
-          name: Create Operator and push Operator image to DockerHub
-          command: |
-            export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
-            ./scripts/operator/create-operator-and-push.sh "${IMAGE_TAG}-${CIRCLE_SHA1}"
-      - run:
-          name: Package Operator
-          command: |
-            export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
-            export SNYK_MONITOR_IMAGE_TAG="${IMAGE_TAG}-${CIRCLE_SHA1}"
-            export SNYK_OPERATOR_VERSION="0.0.1-${CIRCLE_SHA1}"
-            export SNYK_OPERATOR_IMAGE_TAG="${SNYK_MONITOR_IMAGE_TAG}"
-            ./scripts/operator/package-operator.sh "${SNYK_OPERATOR_VERSION}" "${SNYK_OPERATOR_IMAGE_TAG}" "${SNYK_MONITOR_IMAGE_TAG}"
-      - run:
-          name: Remove templated Operator before persisting to workspace
-          command: |
-            rm -rf snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0
-      - persist_to_workspace:
-          root: snyk-operator
-          paths:
-            - deploy/olm-catalog/snyk-operator
-      - run:
-          name: Notify Slack on failure
-          command: |
-            ./scripts/slack/notify_failure_on_branch.py "staging-build-operator-${CIRCLE_SHA1}"
-          when: on_fail
+    - checkout
+    - install_python_requests
+    - run:
+        command: |
+          RELEASE_VERSION=v0.15.1
+          DOWNLOAD_LOCATION=./operator-sdk
+          CURL_FOLLOW_REDIRECTS="-L"
+          curl ${CURL_FOLLOW_REDIRECTS} https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu -o ${DOWNLOAD_LOCATION}
+          chmod +x ${DOWNLOAD_LOCATION}
+        name: Download Operator SDK
+    - run:
+        command: |
+          export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
+          ./scripts/operator/create-operator-and-push.sh "${IMAGE_TAG}-${CIRCLE_SHA1}"
+        name: Create Operator and push Operator image to DockerHub
+    - run:
+        command: |
+          export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
+          export SNYK_MONITOR_IMAGE_TAG="${IMAGE_TAG}-${CIRCLE_SHA1}"
+          export SNYK_OPERATOR_VERSION="0.0.1-${CIRCLE_SHA1}"
+          export SNYK_OPERATOR_IMAGE_TAG="${SNYK_MONITOR_IMAGE_TAG}"
+          ./scripts/operator/package-operator.sh "${SNYK_OPERATOR_VERSION}" "${SNYK_OPERATOR_IMAGE_TAG}" "${SNYK_MONITOR_IMAGE_TAG}"
+        name: Package Operator
+    - run:
+        command: |
+          rm -rf snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0
+        name: Remove templated Operator before persisting to workspace
+    - persist_to_workspace:
+        paths:
+        - deploy/olm-catalog/snyk-operator
+        root: snyk-operator
+    - run:
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-build-operator-${CIRCLE_SHA1}"
+        name: Notify Slack on failure
+        when: on_fail
+    working_directory: ~/kubernetes-monitor
+  create_local_cluster:
+    description: |
+      Creates an OpenShift instance within CircleCI that allows us to test
+      the the `snyk-monitor` operator upgrade path. The job uses a virutal
+      machine running in CircleCI to start the OpenShift Cluster, and uses
+      various scripts to install the operator, upgrade it, and verify the
+      expected functionality.
+    executor: redhat-openshift/default
+    steps:
+    - checkout
+    - run:
+        command: echo "${OPENSHIFT4_ETC_HOSTS_ENTRY}" | sudo tee -a /etc/hosts
+        name: Update hosts for test cluster
+    - redhat-openshift/login-and-update-kubeconfig:
+        insecure-skip-tls-verify: true
+        openshift-platform-version: 4.x
+        password: $OPENSHIFT4_PASSWORD
+        server-address: $OPENSHIFT4_CLUSTER_URL
+        username: $OPENSHIFT4_USER
+    - run:
+        command: |
+          set -xeo pipefail
 
-  upload_operator:
-    <<: *python_container_config
-    steps:
-      - attach_workspace:
-          at: snyk-operator
-      - run:
-          name: Install operator-courier
-          command: pip3 install operator-courier
-      - run:
-          name: Upload Operator to Quay
-          command: |
-            export QUAY_TOKEN=$(curl -H "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d "{\"user\": {\"username\": \"${QUAY_USERNAME}\", \"password\": \"${QUAY_PASSWORD}\"}}" | jq -r .token)
-            export OPERATOR_DIR=./snyk-operator/deploy/olm-catalog/snyk-operator/
-            export QUAY_NAMESPACE=snyk-runtime
-            export PACKAGE_NAME=snyk-operator
-            export PACKAGE_VERSION="0.0.1-${CIRCLE_SHA1}"
-            operator-courier push "${OPERATOR_DIR}" "${QUAY_NAMESPACE}" "${PACKAGE_NAME}" "${PACKAGE_VERSION}" "${QUAY_TOKEN}"
+          # Verify that python exists!
+          if ! which python > /dev/null; then
+            >&2 echo "Failed to find python"
+            exit 1
+          fi
 
-  unit_tests:
-    <<: *default_machine_config
-    steps:
-      - checkout
-      - setup_node12
-      - install_python_requests
-      - run:
-          name: Unit tests
-          command: |
-            npm run lint &&
-            npm run build &&
-            npm run test:unit
-      - run:
-          name: Notify Slack on failure
-          command: |
-            ./scripts/slack/notify_failure_on_branch.py "staging-unit-tests-${CIRCLE_SHA1}"
-          when: on_fail
-  
-  system_tests:
-    <<: *default_machine_config
-    steps:
-      - checkout
-      - setup_node12
-      - install_python_requests
-      - run:
-          name: System tests
-          command: |
-            npm run build &&
-            npm run test:system
-      - run:
-          name: Notify Slack on failure
-          command: |
-            ./scripts/slack/notify_failure_on_branch.py "staging-system-tests-${CIRCLE_SHA1}"
-          when: on_fail
+          python -m pip install requests pyyaml
 
-  integration_tests:
-    <<: *default_machine_config
-    steps:
-      - checkout
-      - setup_node12
-      - install_python_requests
-      - run:
-          name: create temp dir for logs
-          command: mkdir -p /tmp/logs/test/integration/kind
-      - run:
-          name: Integration tests
-          command: |
-            export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
-            npm run test:integration:kind:yaml
-      - run:
-          name: Notify Slack on failure
-          command: |
-            ./scripts/slack/notify_failure_on_branch.py "staging-integration-tests-${CIRCLE_SHA1}"
-          when: on_fail
-      - store_artifacts:
-          path: /tmp/logs/test/integration/kind
+          VERSION=$(python ./scripts/operator/tests/test-operator-upgrade.py)
 
-  integration_tests_helm:
-    <<: *default_machine_config
-    steps:
-      - checkout
-      - setup_node12
-      - install_python_requests
-      - run:
-          name: Create temporary directory for logs
-          command: mkdir -p /tmp/logs/test/integration/kind-helm
-      - run:
-          name: Integration tests with Helm deployment
-          command: |
-            export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
-            npm run test:integration:kind:helm
-      - run:
-          name: Notify Slack on failure
-          command: |
-            ./scripts/slack/notify_failure_on_branch.py "staging-integration-helm-tests-${CIRCLE_SHA1}"
-          when: on_fail
-      - store_artifacts:
-          path: /tmp/logs/test/integration/kind-helm
+          echo "Currently released version is: ${VERSION}"
+          echo "export OC_VERSION=${VERSION}" >> $BASH_ENV
+        name: Get last released operator version
+    - run:
+        command: |
+          set -xeo pipefail
 
-  integration_tests_proxy:
-    <<: *default_machine_config
-    steps:
-      - checkout
-      - setup_node12
-      - install_python_requests
-      - run:
-          name: Create temporary directory for logs
-          command: mkdir -p /tmp/logs/test/integration/proxy
-      - run:
-          name: Integration tests with Helm deployment
-          command: |
-            export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
-            npm run test:integration:kind:proxy
-      - run:
-          name: Notify Slack on failure
-          command: |
-            ./scripts/slack/notify_failure_on_branch.py "staging-integration-proxy-tests-${CIRCLE_SHA1}"
-          when: on_fail
-      - store_artifacts:
-          path: /tmp/logs/test/integration/proxy
+          if [[ -z $OC_VERSION ]]; then
+            >&2 echo "OC_VERSION variable is not set"
+            exit 1
+          fi
 
-  eks_integration_tests:
-    <<: *default_machine_config
-    steps:
-      - checkout
-      - install_python_requests
-      - run:
-          name: Create temp dir for logs
-          command: mkdir -p /tmp/logs/test/integration/eks
-      - run:
-          name: Integration tests EKS
-          # WARNING! Do not use the step "setup_node12" here - the call to "nvm use 12" breaks the tests!
-          command: |
-            export NVM_DIR="/opt/circleci/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            nvm install v12
-            npm install
-            export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
-            .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:eks:yaml
-      - run:
-          name: Notify Slack on failure
-          command: |
-            ./scripts/slack/notify_failure_on_branch.py "staging-eks-integration-tests-${CIRCLE_SHA1}"
-          when: on_fail
-      - store_artifacts:
-          path: /tmp/logs/test/integration/eks
+          # Package operator to be uploaded to quay.io
+          ./scripts/operator/package-operator.sh $OC_VERSION $OC_VERSION $OC_VERSION
 
-  openshift3_integration_tests:
-    <<: *default_machine_config
-    steps:
-      - checkout
-      - setup_node12
-      - install_python_requests
-      - run:
-          name: Create temporary directory for logs
-          command: mkdir -p /tmp/logs/test/integration/openshift3
-      - run:
-          name: Integration tests OpenShift 3
-          command: |
-            export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
-            npm run test:integration:openshift3:yaml
-      - run:
-          name: Notify Slack on failure
-          command: ./scripts/slack/notify_failure.py "staging-openshift3-integration-tests-${CIRCLE_SHA1}"
-          when: on_fail
-      - store_artifacts:
-          path: /tmp/logs/test/integration/openshift3
+          # We do not want to include the templating files when we push the operator,
+          # therefore we move the directory to /temp, and restore it later
+          mkdir temp
+          mv ./snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0 ./temp/
+        name: Package and deploy last released operator
+    - run:
+        command: |
+          set -eo pipefail
 
-  openshift4_integration_tests:
-    <<: *default_machine_config
-    steps:
-      - checkout
-      - setup_node12
-      - install_python_requests
-      - run:
-          name: create temp dir for logs
-          command: mkdir -p /tmp/logs/test/integration/openshift4
-      - run:
-          name: Append an entry to the test environment to /etc/hosts
-          command: |
-            echo "${OPENSHIFT4_ETC_HOSTS_ENTRY}" | sudo tee -a /etc/hosts
-      - run:
-          name: Integration tests OpenShift 4
-          command: |
-            export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
-            .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:openshift4:operator
-      - run:
-          name: Delete Operator from Quay
-          command: |
-            ./scripts/operator/delete-operator-from-quay.sh
-          when: always
-      - run:
-          name: Notify Slack on failure
-          command: |
-            ./scripts/slack/notify_failure_on_branch.py "staging-openshift4-integration-tests-${CIRCLE_SHA1}"
-          when: on_fail
-      - store_artifacts:
-          path: /tmp/logs/test/integration/openshift4
+          python -m pip install operator-courier
 
-######################## MERGE TO STAGING ########################
-  tag_and_push:
-    <<: *default_container_config
-    steps:
-      - checkout
-      - setup_remote_docker
-      - install_python_requests
-      - run:
-          name: Tag and push
-          command: |
-            npm install &&
-            docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} &&
-            unset CIRCLE_PULL_REQUEST &&
-            unset CI_PULL_REQUEST &&
-            unset CI_PULL_REQUESTS &&
-            unset CIRCLE_PULL_REQUESTS &&
-            npx semantic-release &&
-            NEW_VERSION=`cat ./package.json | jq -r '.version'` &&
-            ./scripts/docker/approve-image.sh $NEW_VERSION
-      - run:
-          name: Notify Slack on failure
-          command: ./scripts/slack/notify_failure.py "staging-release"
-          when: on_fail
-  
+          export QUAY_TOKEN=$(curl -H "Content-Type: application/json" \
+            -XPOST https://quay.io/cnr/api/v1/users/login \
+            -d "{\"user\": {\"username\": \"${QUAY_USERNAME}\", \"password\": \"${QUAY_PASSWORD}\"}}" \
+            | jq -r .token)
+
+          OPERATOR_DIR=./snyk-operator/deploy/olm-catalog/snyk-operator/
+          QUAY_NAMESPACE=snyk-runtime
+          PACKAGE_NAME=snyk-operator
+
+          operator-courier push "${OPERATOR_DIR}" "${QUAY_NAMESPACE}" "${PACKAGE_NAME}" "${OC_VERSION}" "${QUAY_TOKEN}"
+        name: Push operator to quay
+    - run:
+        command: |
+          set -xo pipefail
+          set +e
+
+          ns=$(kubectl get ns snyk-monitor --no-headers --output=go-template={{.metadata.name}} 2>/dev/null)
+
+          if [[ -z "${ns}" ]]; then
+            echo "snyk-monitor namespace not found, creating..."
+            kubectl create ns snyk-monitor
+          fi
+
+          set -e
+          kubectl create secret generic snyk-monitor -n snyk-monitor --from-literal=integrationId=2eb0b704-de07-4280-bab6-a7911153047b --from-literal=dockercfg.json={}
+        name: Configure snyk-monitor namespace
+    - run:
+        command: |
+          set -xe
+
+          kubectl apply -f ./test/fixtures/operator/operator-source.yaml
+
+          set +e
+          opsrc=$(kubectl get operatorsource snyk-operator -n openshift-marketplace --no-headers 2>/dev/null | awk '{print $9}')
+
+          set -e
+          while [[ "${opsrc}" != "Succeeded" ]]; do
+            if [[ -z "${opsrc}" || "${opsrc}" == "Failed" ]]; then
+              >&2 echo "failed to deploy operator source resource"
+              exit 1
+            fi
+            opsrc=$(kubectl get operatorsource snyk-operator -n openshift-marketplace --no-headers 2>/dev/null | awk '{print $9}')
+          done
+
+          kubectl apply -f ./test/fixtures/operator/installation.yaml
+          sleep 60
+          kubectl get pods -n snyk-monitor --no-headers | \
+            grep "snyk-operator" | \
+            awk 'END { if (NR==0) exit 1; else print $1 }' | \
+            xargs -I{} kubectl wait pod/{} -n snyk-monitor --timeout 60s --for condition=Ready
+        name: Apply operator installation files
+    - run:
+        command: |
+          set -o pipefail
+
+          kubectl apply -f ./test/fixtures/operator/test-resource.yaml
+          # Eventually consistent is fun!
+          sleep 30
+
+          kubectl get pods -n snyk-monitor --no-headers | \
+            grep "snyk-monitor" | \
+            awk 'END { if (NR==0) exit 1; else print $1 }' | \
+            xargs -I{} kubectl wait pod/{} -n snyk-monitor --timeout 60s --for condition=Ready
+        name: Deploy snyk-monitor resource
+    - run:
+        command: |
+          set -xeo pipefail
+
+          curl -XDELETE -H "Accept: application/json" -H "Content-Type: application/json" \
+            -H "Authorization: ${QUAY_DELETE_TOKEN}" "https://quay.io/cnr/api/v1/packages/snyk-runtime/snyk-operator/$OC_VERSION/helm"
+
+          mv ./temp/0.0.0 ./snyk-operator/deploy/olm-catalog/snyk-operator/
+          rm -rf ./snyk-operator/deploy/olm-catalog/snyk-operator/${OC_VERSION}
+
+          LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}` && \
+            LATEST_TAG=${LATEST_TAG_WITH_V:1}
+
+          ./scripts/operator/package-operator.sh ${LATEST_TAG} ${LATEST_TAG} ${LATEST_TAG}
+
+          export QUAY_TOKEN=$(curl -H "Content-Type: application/json" \
+            -XPOST https://quay.io/cnr/api/v1/users/login \
+            -d "{\"user\": {\"username\": \"${QUAY_USERNAME}\", \"password\": \"${QUAY_PASSWORD}\"}}" \
+            | jq -r .token)
+
+          OPERATOR_DIR=./snyk-operator/deploy/olm-catalog/snyk-operator/
+          QUAY_NAMESPACE=snyk-runtime
+          PACKAGE_NAME=snyk-operator
+
+          set +x
+          operator-courier push "${OPERATOR_DIR}" "${QUAY_NAMESPACE}" "${PACKAGE_NAME}" "${LATEST_TAG}" "${QUAY_TOKEN}"
+          set -x
+          echo "export LATEST_TAG=${LATEST_TAG}" >> $BASH_ENV
+
+          kubectl delete -f ./test/fixtures/operator/operator-source.yaml
+          kubectl apply -f ./test/fixtures/operator/operator-source.yaml
+          sleep 60
+
+          VERSION=$(kubectl get pods -n snyk-monitor --no-headers | \
+            grep "snyk-monitor" | \
+            awk 'END { if (NR==0) exit 1; else print $1 }' | \
+            xargs -I{} kubectl get pod {} -n snyk-monitor -o jsonpath={..image} | \
+            awk '{print $1}' | grep -oE "[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,3}$")
+
+          if [[ "${VERSION}" != "${LATEST_TAG}" ]]; then
+            &>2 echo "versions (${VERSION}) does not match expected (${LATEST_TAG})!"
+            exit 1
+          fi
+
+          echo "Update complete!"
+        name: Upgrade snyk-monitor operator
+    - run:
+        command: |
+          set +e
+          curl -XDELETE -H "Accept: application/json" -H "Content-Type: application/json" \
+            -H "Authorization: ${QUAY_DELETE_TOKEN}" "https://quay.io/cnr/api/v1/packages/snyk-runtime/snyk-operator/${OC_VERSION}/helm"
+          curl -XDELETE -H "Accept: application/json" -H "Content-Type: application/json" \
+            -H "Authorization: ${QUAY_DELETE_TOKEN}" "https://quay.io/cnr/api/v1/packages/snyk-runtime/snyk-operator/${LATEST_TAG}/helm"
+
+          kubectl delete -f ./test/fixtures/operator/operator-source.yaml
+          kubectl delete -f ./test/fixtures/operator/installation.yaml
+
+          kubectl patch customresourcedefinition snykmonitors.charts.helm.k8s.io -p '{"metadata":{"finalizers":[]}}' --type=merge -n snyk-monitor
+          kubectl patch snykmonitors.charts.helm.k8s.io snyk-monitor -p '{"metadata":{"finalizers":[]}}' --type=merge -n snyk-monitor
+          kubectl delete -f ./test/fixtures/operator/test-resource.yaml
+          kubectl delete clusterrolebinding snyk-monitor
+          kubectl delete clusterrole snyk-monitor
+
+          kubectl delete ns snyk-monitor
+        name: Cleanup
+        when: always
+    working_directory: ~/kubernetes-monitor
   deploy_dev:
-    <<: *default_container_config
+    docker:
+    - image: circleci/node:12
     steps:
-      - checkout
-      - install_python_requests
-      - run:
-          name: Deploy to dev
-          command: |
-            LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}` &&
-            LATEST_TAG=${LATEST_TAG_WITH_V:1}-approved &&
-            ./scripts/slack/notify_deploy.py $LATEST_TAG dev &&
-            curl -i -H "Accept: application/json" -H "Content-Type: application/json" \
-                -X POST -d "{\"docker_sha\":\"${LATEST_TAG}\", \
-                              \"commit_hash\":\"${CIRCLE_SHA1}\"}" \
-                https://my.dev.snyk.io/${DEV_DEPLOY_TOKEN}
-      - run:
-          name: Notify Slack on failure
-          command: ./scripts/slack/notify_failure.py "deploy-dev"
-          when: on_fail
-
-######################## MERGE TO MASTER ########################
-  publish:
-    <<: *default_container_config
-    steps:
-      - checkout
-      - setup_remote_docker
-      - install_python_requests
-      - run:
-          name: Publish
-          command: |
-            LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}` &&
-            LATEST_TAG=${LATEST_TAG_WITH_V:1} &&
-            IMAGE_NAME_APPROVED=snyk/kubernetes-monitor:${LATEST_TAG}-approved &&
-            IMAGE_NAME_PUBLISHED=snyk/kubernetes-monitor:${LATEST_TAG} &&
-            docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} &&
-            docker pull ${IMAGE_NAME_APPROVED} &&
-            docker tag ${IMAGE_NAME_APPROVED} ${IMAGE_NAME_PUBLISHED} &&
-            docker push ${IMAGE_NAME_PUBLISHED} &&
-            ./scripts/slack/notify_push.py ${IMAGE_NAME_PUBLISHED} &&
-            ./scripts/publish-gh-pages.sh ${LATEST_TAG}
-            # Preserve the latest tag for the next steps of this job
-            echo "export LATEST_TAG=${LATEST_TAG}" >> $BASH_ENV
-      - run:
-          name: Download operator-sdk
-          command: |
-            RELEASE_VERSION=v0.15.1
-            DOWNLOAD_LOCATION=./operator-sdk
-            CURL_FOLLOW_REDIRECTS="-L"
-            curl ${CURL_FOLLOW_REDIRECTS} https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu -o ${DOWNLOAD_LOCATION}
-            chmod +x ${DOWNLOAD_LOCATION}
-      - run:
-          name: Create Operator and push Operator image to DockerHub
-          command: |
-            ./scripts/operator/create-operator-and-push.sh "${LATEST_TAG}"
-      - run:
-          name: Package Operator
-          command: |
-            export SNYK_MONITOR_IMAGE_TAG="${LATEST_TAG}"
-            export SNYK_OPERATOR_VERSION="${LATEST_TAG}"
-            export SNYK_OPERATOR_IMAGE_TAG="${SNYK_MONITOR_IMAGE_TAG}"
-            ./scripts/operator/package-operator.sh "${SNYK_OPERATOR_VERSION}" "${SNYK_OPERATOR_IMAGE_TAG}" "${SNYK_MONITOR_IMAGE_TAG}"
-      - run:
-          name: Remove templated Operator before storing artifacts
-          command: |
-            rm -rf snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0
-      - store_artifacts:
-          path: snyk-operator/deploy/olm-catalog/snyk-operator
-          destination: snyk-operator
-      - run:
-          name: Notify Slack on failure
-          command: ./scripts/slack/notify_failure.py "master"
-          when: on_fail
-
+    - checkout
+    - install_python_requests
+    - run:
+        command: |
+          LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}` &&
+          LATEST_TAG=${LATEST_TAG_WITH_V:1}-approved &&
+          ./scripts/slack/notify_deploy.py $LATEST_TAG dev &&
+          curl -i -H "Accept: application/json" -H "Content-Type: application/json" \
+              -X POST -d "{\"docker_sha\":\"${LATEST_TAG}\", \
+                            \"commit_hash\":\"${CIRCLE_SHA1}\"}" \
+              https://my.dev.snyk.io/${DEV_DEPLOY_TOKEN}
+        name: Deploy to dev
+    - run:
+        command: ./scripts/slack/notify_failure.py "deploy-dev"
+        name: Notify Slack on failure
+        when: on_fail
+    working_directory: ~/kubernetes-monitor
   deploy_prod:
-    <<: *default_container_config
+    docker:
+    - image: circleci/node:12
     steps:
-      - checkout
-      - install_python_requests
-      - run:
-          name: Deploy to prod
-          command: |
-            LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}` &&
-            LATEST_TAG=${LATEST_TAG_WITH_V:1} &&
-            ./scripts/slack/notify_deploy.py $LATEST_TAG prod &&
-            curl -i -H "Accept: application/json" -H "Content-Type: application/json" \
-                -X POST -d "{}" \
-                https://my.prod.snyk.io/${PROD_DEPLOY_TOKEN}
-      - run:
-          name: Notify Slack on failure
-          command: ./scripts/slack/notify_failure.py "deploy-prod"
-          when: on_fail
-
-#######################################################################
-
+    - checkout
+    - install_python_requests
+    - run:
+        command: |
+          LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}` &&
+          LATEST_TAG=${LATEST_TAG_WITH_V:1} &&
+          ./scripts/slack/notify_deploy.py $LATEST_TAG prod &&
+          curl -i -H "Accept: application/json" -H "Content-Type: application/json" \
+              -X POST -d "{}" \
+              https://my.prod.snyk.io/${PROD_DEPLOY_TOKEN}
+        name: Deploy to prod
+    - run:
+        command: ./scripts/slack/notify_failure.py "deploy-prod"
+        name: Notify Slack on failure
+        when: on_fail
+    working_directory: ~/kubernetes-monitor
+  eks_integration_tests:
+    machine:
+      docker_layer_caching: true
+      enabled: true
+    steps:
+    - checkout
+    - install_python_requests
+    - run:
+        command: mkdir -p /tmp/logs/test/integration/eks
+        name: Create temp dir for logs
+    - run:
+        command: |
+          export NVM_DIR="/opt/circleci/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          nvm install v12
+          npm install
+          export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
+          .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:eks:yaml
+        name: Integration tests EKS
+    - run:
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-eks-integration-tests-${CIRCLE_SHA1}"
+        name: Notify Slack on failure
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/logs/test/integration/eks
+    working_directory: ~/kubernetes-monitor
+  integration_tests:
+    machine:
+      docker_layer_caching: true
+      enabled: true
+    steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        command: mkdir -p /tmp/logs/test/integration/kind
+        name: create temp dir for logs
+    - run:
+        command: |
+          export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
+          npm run test:integration:kind:yaml
+        name: Integration tests
+    - run:
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-integration-tests-${CIRCLE_SHA1}"
+        name: Notify Slack on failure
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/logs/test/integration/kind
+    working_directory: ~/kubernetes-monitor
+  integration_tests_helm:
+    machine:
+      docker_layer_caching: true
+      enabled: true
+    steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        command: mkdir -p /tmp/logs/test/integration/kind-helm
+        name: Create temporary directory for logs
+    - run:
+        command: |
+          export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
+          npm run test:integration:kind:helm
+        name: Integration tests with Helm deployment
+    - run:
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-integration-helm-tests-${CIRCLE_SHA1}"
+        name: Notify Slack on failure
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/logs/test/integration/kind-helm
+    working_directory: ~/kubernetes-monitor
+  integration_tests_proxy:
+    machine:
+      docker_layer_caching: true
+      enabled: true
+    steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        command: mkdir -p /tmp/logs/test/integration/proxy
+        name: Create temporary directory for logs
+    - run:
+        command: |
+          export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
+          npm run test:integration:kind:proxy
+        name: Integration tests with Helm deployment
+    - run:
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-integration-proxy-tests-${CIRCLE_SHA1}"
+        name: Notify Slack on failure
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/logs/test/integration/proxy
+    working_directory: ~/kubernetes-monitor
+  openshift3_integration_tests:
+    machine:
+      docker_layer_caching: true
+      enabled: true
+    steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        command: mkdir -p /tmp/logs/test/integration/openshift3
+        name: Create temporary directory for logs
+    - run:
+        command: |
+          export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
+          npm run test:integration:openshift3:yaml
+        name: Integration tests OpenShift 3
+    - run:
+        command: ./scripts/slack/notify_failure.py "staging-openshift3-integration-tests-${CIRCLE_SHA1}"
+        name: Notify Slack on failure
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/logs/test/integration/openshift3
+    working_directory: ~/kubernetes-monitor
+  openshift4_integration_tests:
+    machine:
+      docker_layer_caching: true
+      enabled: true
+    steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        command: mkdir -p /tmp/logs/test/integration/openshift4
+        name: create temp dir for logs
+    - run:
+        command: |
+          echo "${OPENSHIFT4_ETC_HOSTS_ENTRY}" | sudo tee -a /etc/hosts
+        name: Append an entry to the test environment to /etc/hosts
+    - run:
+        command: |
+          export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
+          .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:openshift4:operator
+        name: Integration tests OpenShift 4
+    - run:
+        command: |
+          ./scripts/operator/delete-operator-from-quay.sh
+        name: Delete Operator from Quay
+        when: always
+    - run:
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-openshift4-integration-tests-${CIRCLE_SHA1}"
+        name: Notify Slack on failure
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/logs/test/integration/openshift4
+    working_directory: ~/kubernetes-monitor
+  publish:
+    docker:
+    - image: circleci/node:12
+    steps:
+    - checkout
+    - setup_remote_docker
+    - install_python_requests
+    - run:
+        command: |
+          LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}` &&
+          LATEST_TAG=${LATEST_TAG_WITH_V:1} &&
+          IMAGE_NAME_APPROVED=snyk/kubernetes-monitor:${LATEST_TAG}-approved &&
+          IMAGE_NAME_PUBLISHED=snyk/kubernetes-monitor:${LATEST_TAG} &&
+          docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} &&
+          docker pull ${IMAGE_NAME_APPROVED} &&
+          docker tag ${IMAGE_NAME_APPROVED} ${IMAGE_NAME_PUBLISHED} &&
+          docker push ${IMAGE_NAME_PUBLISHED} &&
+          ./scripts/slack/notify_push.py ${IMAGE_NAME_PUBLISHED} &&
+          ./scripts/publish-gh-pages.sh ${LATEST_TAG}
+          # Preserve the latest tag for the next steps of this job
+          echo "export LATEST_TAG=${LATEST_TAG}" >> $BASH_ENV
+        name: Publish
+    - run:
+        command: |
+          RELEASE_VERSION=v0.15.1
+          DOWNLOAD_LOCATION=./operator-sdk
+          CURL_FOLLOW_REDIRECTS="-L"
+          curl ${CURL_FOLLOW_REDIRECTS} https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu -o ${DOWNLOAD_LOCATION}
+          chmod +x ${DOWNLOAD_LOCATION}
+        name: Download operator-sdk
+    - run:
+        command: |
+          ./scripts/operator/create-operator-and-push.sh "${LATEST_TAG}"
+        name: Create Operator and push Operator image to DockerHub
+    - run:
+        command: |
+          export SNYK_MONITOR_IMAGE_TAG="${LATEST_TAG}"
+          export SNYK_OPERATOR_VERSION="${LATEST_TAG}"
+          export SNYK_OPERATOR_IMAGE_TAG="${SNYK_MONITOR_IMAGE_TAG}"
+          ./scripts/operator/package-operator.sh "${SNYK_OPERATOR_VERSION}" "${SNYK_OPERATOR_IMAGE_TAG}" "${SNYK_MONITOR_IMAGE_TAG}"
+        name: Package Operator
+    - run:
+        command: |
+          rm -rf snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0
+        name: Remove templated Operator before storing artifacts
+    - store_artifacts:
+        destination: snyk-operator
+        path: snyk-operator/deploy/olm-catalog/snyk-operator
+    - run:
+        command: ./scripts/slack/notify_failure.py "master"
+        name: Notify Slack on failure
+        when: on_fail
+    working_directory: ~/kubernetes-monitor
+  system_tests:
+    machine:
+      docker_layer_caching: true
+      enabled: true
+    steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        command: |
+          npm run build &&
+          npm run test:system
+        name: System tests
+    - run:
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-system-tests-${CIRCLE_SHA1}"
+        name: Notify Slack on failure
+        when: on_fail
+    working_directory: ~/kubernetes-monitor
+  tag_and_push:
+    docker:
+    - image: circleci/node:12
+    steps:
+    - checkout
+    - setup_remote_docker
+    - install_python_requests
+    - run:
+        command: |
+          npm install &&
+          docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} &&
+          unset CIRCLE_PULL_REQUEST &&
+          unset CI_PULL_REQUEST &&
+          unset CI_PULL_REQUESTS &&
+          unset CIRCLE_PULL_REQUESTS &&
+          npx semantic-release &&
+          NEW_VERSION=`cat ./package.json | jq -r '.version'` &&
+          ./scripts/docker/approve-image.sh $NEW_VERSION
+        name: Tag and push
+    - run:
+        command: ./scripts/slack/notify_failure.py "staging-release"
+        name: Notify Slack on failure
+        when: on_fail
+    working_directory: ~/kubernetes-monitor
+  unit_tests:
+    machine:
+      docker_layer_caching: true
+      enabled: true
+    steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        command: |
+          npm run lint &&
+          npm run build &&
+          npm run test:unit
+        name: Unit tests
+    - run:
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-unit-tests-${CIRCLE_SHA1}"
+        name: Notify Slack on failure
+        when: on_fail
+    working_directory: ~/kubernetes-monitor
+  upload_operator:
+    docker:
+    - image: circleci/python:3
+    steps:
+    - attach_workspace:
+        at: snyk-operator
+    - run:
+        command: pip3 install operator-courier
+        name: Install operator-courier
+    - run:
+        command: |
+          export QUAY_TOKEN=$(curl -H "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d "{\"user\": {\"username\": \"${QUAY_USERNAME}\", \"password\": \"${QUAY_PASSWORD}\"}}" | jq -r .token)
+          export OPERATOR_DIR=./snyk-operator/deploy/olm-catalog/snyk-operator/
+          export QUAY_NAMESPACE=snyk-runtime
+          export PACKAGE_NAME=snyk-operator
+          export PACKAGE_VERSION="0.0.1-${CIRCLE_SHA1}"
+          operator-courier push "${OPERATOR_DIR}" "${QUAY_NAMESPACE}" "${PACKAGE_NAME}" "${PACKAGE_VERSION}" "${QUAY_TOKEN}"
+        name: Upload Operator to Quay
+    working_directory: ~/kubernetes-monitor
+main_branches_filter:
+  filters:
+    branches:
+      ignore:
+      - staging
+      - master
+      - RUN-921/chore/automate-operator-testing
+master_branch_only_filter:
+  filters:
+    branches:
+      only:
+      - master
+orbs:
+  redhat-openshift: circleci/redhat-openshift@0.2.0
+staging_branch_only_filter:
+  filters:
+    branches:
+      only:
+      - staging
+version: 2.1
 workflows:
-  version: 2
-  PR_TO_STAGING:
-    jobs:
-      - build_image:
-          <<: *main_branches_filter
-      - build_operator:
-          <<: *main_branches_filter
-      - unit_tests:
-          <<: *main_branches_filter
-      - system_tests:
-          <<: *main_branches_filter
-      - integration_tests:
-          requires:
-            - build_image
-          <<: *main_branches_filter
-      - integration_tests_helm:
-          requires:
-            - build_image
-          <<: *main_branches_filter
-
-  MERGE_TO_STAGING:
-    jobs:
-      - build_image:
-          <<: *staging_branch_only_filter
-      - build_operator:
-          <<: *staging_branch_only_filter
-      - upload_operator:
-          requires:
-            - build_operator
-          <<: *staging_branch_only_filter
-      - unit_tests:
-          <<: *staging_branch_only_filter
-      - system_tests:
-          <<: *staging_branch_only_filter
-      - integration_tests:
-          requires:
-            - build_image
-          <<: *staging_branch_only_filter
-      - integration_tests_helm:
-          requires:
-            - build_image
-          <<: *staging_branch_only_filter
-      - integration_tests_proxy:
-          requires:
-            - build_image
-          <<: *staging_branch_only_filter
-      - eks_integration_tests:
-          requires:
-            - build_image
-          <<: *staging_branch_only_filter
-      - openshift3_integration_tests:
-          requires:
-            - build_image
-          <<: *staging_branch_only_filter
-      - openshift4_integration_tests:
-          requires:
-            - build_image
-            - build_operator
-            - upload_operator
-          <<: *staging_branch_only_filter
-      - tag_and_push:
-          requires:
-            - build_image
-            - build_operator
-            - unit_tests
-            - system_tests
-            - integration_tests
-            - integration_tests_helm
-            - integration_tests_proxy
-          <<: *staging_branch_only_filter
-      - deploy_dev:
-          requires:
-            - tag_and_push
-          <<: *staging_branch_only_filter
-
   MERGE_TO_MASTER:
     jobs:
-      - publish:
-          <<: *master_branch_only_filter
-      - deploy_prod:
-          requires:
-            - publish
-          <<: *master_branch_only_filter
+    - publish:
+        filters:
+          branches:
+            only:
+            - master
+    - deploy_prod:
+        filters:
+          branches:
+            only:
+            - master
+        requires:
+        - publish
+  MERGE_TO_STAGING:
+    jobs:
+    - build_image:
+        filters:
+          branches:
+            only:
+            - staging
+    - build_operator:
+        filters:
+          branches:
+            only:
+            - staging
+    - upload_operator:
+        filters:
+          branches:
+            only:
+            - staging
+        requires:
+        - build_operator
+    - unit_tests:
+        filters:
+          branches:
+            only:
+            - staging
+    - system_tests:
+        filters:
+          branches:
+            only:
+            - staging
+    - integration_tests:
+        filters:
+          branches:
+            only:
+            - staging
+        requires:
+        - build_image
+    - integration_tests_helm:
+        filters:
+          branches:
+            only:
+            - staging
+        requires:
+        - build_image
+    - integration_tests_proxy:
+        filters:
+          branches:
+            only:
+            - staging
+        requires:
+        - build_image
+    - eks_integration_tests:
+        filters:
+          branches:
+            only:
+            - staging
+        requires:
+        - build_image
+    - openshift3_integration_tests:
+        filters:
+          branches:
+            only:
+            - staging
+        requires:
+        - build_image
+    - openshift4_integration_tests:
+        filters:
+          branches:
+            only:
+            - staging
+        requires:
+        - build_image
+        - build_operator
+        - upload_operator
+    - tag_and_push:
+        filters:
+          branches:
+            only:
+            - staging
+        requires:
+        - build_image
+        - build_operator
+        - unit_tests
+        - system_tests
+        - integration_tests
+        - integration_tests_helm
+        - integration_tests_proxy
+    - deploy_dev:
+        filters:
+          branches:
+            only:
+            - staging
+        requires:
+        - tag_and_push
+  PR_TO_STAGING:
+    jobs:
+    - create_local_cluster:
+        filters:
+          branches:
+            only:
+            - RUN-921/chore/automate-operator-testing
+    - build_image:
+        filters:
+          branches:
+            ignore:
+            - staging
+            - master
+            - RUN-921/chore/automate-operator-testing
+    - build_operator:
+        filters:
+          branches:
+            ignore:
+            - staging
+            - master
+            - RUN-921/chore/automate-operator-testing
+    - unit_tests:
+        filters:
+          branches:
+            ignore:
+            - staging
+            - master
+            - RUN-921/chore/automate-operator-testing
+    - system_tests:
+        filters:
+          branches:
+            ignore:
+            - staging
+            - master
+            - RUN-921/chore/automate-operator-testing
+    - integration_tests:
+        filters:
+          branches:
+            ignore:
+            - staging
+            - master
+            - RUN-921/chore/automate-operator-testing
+        requires:
+        - build_image
+    - integration_tests_helm:
+        filters:
+          branches:
+            ignore:
+            - staging
+            - master
+            - RUN-921/chore/automate-operator-testing
+        requires:
+        - build_image
+

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -1,0 +1,110 @@
+version: 2.1
+
+staging_branch_only_filter: &staging_branch_only_filter
+  filters:
+    branches:
+      only:
+        - staging
+
+master_branch_only_filter: &master_branch_only_filter
+  filters:
+    branches:
+      only:
+        - master
+
+main_branches_filter: &main_branches_filter
+  filters:
+    branches:
+      ignore:
+        - staging
+        - master
+        - RUN-921/chore/automate-operator-testing
+
+workflows:
+  PR_TO_STAGING:
+    jobs:
+      - create_local_cluster:
+          filters:
+            branches:
+              only:
+                - RUN-921/chore/automate-operator-testing
+      - build_image:
+          <<: *main_branches_filter
+      - build_operator:
+          <<: *main_branches_filter
+      - unit_tests:
+          <<: *main_branches_filter
+      - system_tests:
+          <<: *main_branches_filter
+      - integration_tests:
+          requires:
+            - build_image
+          <<: *main_branches_filter
+      - integration_tests_helm:
+          requires:
+            - build_image
+          <<: *main_branches_filter
+
+  MERGE_TO_STAGING:
+    jobs:
+      - build_image:
+          <<: *staging_branch_only_filter
+      - build_operator:
+          <<: *staging_branch_only_filter
+      - upload_operator:
+          requires:
+            - build_operator
+          <<: *staging_branch_only_filter
+      - unit_tests:
+          <<: *staging_branch_only_filter
+      - system_tests:
+          <<: *staging_branch_only_filter
+      - integration_tests:
+          requires:
+            - build_image
+          <<: *staging_branch_only_filter
+      - integration_tests_helm:
+          requires:
+            - build_image
+          <<: *staging_branch_only_filter
+      - integration_tests_proxy:
+          requires:
+            - build_image
+          <<: *staging_branch_only_filter
+      - eks_integration_tests:
+          requires:
+            - build_image
+          <<: *staging_branch_only_filter
+      - openshift3_integration_tests:
+          requires:
+            - build_image
+          <<: *staging_branch_only_filter
+      - openshift4_integration_tests:
+          requires:
+            - build_image
+            - build_operator
+            - upload_operator
+          <<: *staging_branch_only_filter
+      - tag_and_push:
+          requires:
+            - build_image
+            - build_operator
+            - unit_tests
+            - system_tests
+            - integration_tests
+            - integration_tests_helm
+            - integration_tests_proxy
+          <<: *staging_branch_only_filter
+      - deploy_dev:
+          requires:
+            - tag_and_push
+          <<: *staging_branch_only_filter
+
+  MERGE_TO_MASTER:
+    jobs:
+      - publish:
+          <<: *master_branch_only_filter
+      - deploy_prod:
+          requires:
+            - publish
+          <<: *master_branch_only_filter

--- a/.circleci/config/commands/install_python_requests.yml
+++ b/.circleci/config/commands/install_python_requests.yml
@@ -1,0 +1,7 @@
+description: Install requests library
+steps:
+  - run:
+      command: |
+        sudo apt update
+        sudo apt install python3-requests
+      when: always

--- a/.circleci/config/commands/setup_node12.yml
+++ b/.circleci/config/commands/setup_node12.yml
@@ -1,0 +1,11 @@
+description: Setup Node 12
+steps:
+  - run:
+      command: |
+        export NVM_DIR="/opt/circleci/.nvm"
+        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+        nvm install v12
+        npm install
+        echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+        echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+        echo 'nvm use 12' >> $BASH_ENV

--- a/.circleci/config/jobs/@jobs.yml
+++ b/.circleci/config/jobs/@jobs.yml
@@ -1,0 +1,426 @@
+build_image:
+  # <<: *default_machine_config
+  machine:
+    enabled: true
+    docker_layer_caching: true
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - install_python_requests
+    - run:
+        name: Build image
+        command: |
+          docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} &&
+          export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable") &&
+          IMAGE_NAME_CANDIDATE=snyk/kubernetes-monitor:${IMAGE_TAG}-${CIRCLE_SHA1} &&
+          ./scripts/docker/build-image.sh ${IMAGE_NAME_CANDIDATE} &&
+          docker push ${IMAGE_NAME_CANDIDATE}
+    - run:
+        name: Notify Slack on failure
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-build-image-${CIRCLE_SHA1}"
+        when: on_fail
+
+build_operator:
+  # <<: *default_machine_config
+  machine:
+    enabled: true
+    docker_layer_caching: true
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - install_python_requests
+    - run:
+        name: Download Operator SDK
+        command: |
+          RELEASE_VERSION=v0.15.1
+          DOWNLOAD_LOCATION=./operator-sdk
+          CURL_FOLLOW_REDIRECTS="-L"
+          curl ${CURL_FOLLOW_REDIRECTS} https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu -o ${DOWNLOAD_LOCATION}
+          chmod +x ${DOWNLOAD_LOCATION}
+    - run:
+        name: Create Operator and push Operator image to DockerHub
+        command: |
+          export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
+          ./scripts/operator/create-operator-and-push.sh "${IMAGE_TAG}-${CIRCLE_SHA1}"
+    - run:
+        name: Package Operator
+        command: |
+          export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
+          export SNYK_MONITOR_IMAGE_TAG="${IMAGE_TAG}-${CIRCLE_SHA1}"
+          export SNYK_OPERATOR_VERSION="0.0.1-${CIRCLE_SHA1}"
+          export SNYK_OPERATOR_IMAGE_TAG="${SNYK_MONITOR_IMAGE_TAG}"
+          ./scripts/operator/package-operator.sh "${SNYK_OPERATOR_VERSION}" "${SNYK_OPERATOR_IMAGE_TAG}" "${SNYK_MONITOR_IMAGE_TAG}"
+    - run:
+        name: Remove templated Operator before persisting to workspace
+        command: |
+          rm -rf snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0
+    - persist_to_workspace:
+        root: snyk-operator
+        paths:
+          - deploy/olm-catalog/snyk-operator
+    - run:
+        name: Notify Slack on failure
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-build-operator-${CIRCLE_SHA1}"
+        when: on_fail
+
+upload_operator:
+  # <<: *python_container_config
+  docker:
+    - image: circleci/python:3
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - attach_workspace:
+        at: snyk-operator
+    - run:
+        name: Install operator-courier
+        command: pip3 install operator-courier
+    - run:
+        name: Upload Operator to Quay
+        command: |
+          export QUAY_TOKEN=$(curl -H "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d "{\"user\": {\"username\": \"${QUAY_USERNAME}\", \"password\": \"${QUAY_PASSWORD}\"}}" | jq -r .token)
+          export OPERATOR_DIR=./snyk-operator/deploy/olm-catalog/snyk-operator/
+          export QUAY_NAMESPACE=snyk-runtime
+          export PACKAGE_NAME=snyk-operator
+          export PACKAGE_VERSION="0.0.1-${CIRCLE_SHA1}"
+          operator-courier push "${OPERATOR_DIR}" "${QUAY_NAMESPACE}" "${PACKAGE_NAME}" "${PACKAGE_VERSION}" "${QUAY_TOKEN}"
+
+unit_tests:
+  # <<: *default_machine_config
+  machine:
+    enabled: true
+    docker_layer_caching: true
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        name: Unit tests
+        command: |
+          npm run lint &&
+          npm run build &&
+          npm run test:unit
+    - run:
+        name: Notify Slack on failure
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-unit-tests-${CIRCLE_SHA1}"
+        when: on_fail
+
+system_tests:
+  # <<: *default_machine_config
+  machine:
+    enabled: true
+    docker_layer_caching: true
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        name: System tests
+        command: |
+          npm run build &&
+          npm run test:system
+    - run:
+        name: Notify Slack on failure
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-system-tests-${CIRCLE_SHA1}"
+        when: on_fail
+
+integration_tests:
+  # <<: *default_machine_config
+  machine:
+    enabled: true
+    docker_layer_caching: true
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        name: create temp dir for logs
+        command: mkdir -p /tmp/logs/test/integration/kind
+    - run:
+        name: Integration tests
+        command: |
+          export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
+          npm run test:integration:kind:yaml
+    - run:
+        name: Notify Slack on failure
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-integration-tests-${CIRCLE_SHA1}"
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/logs/test/integration/kind
+
+integration_tests_helm:
+  # <<: *default_machine_config
+  machine:
+    enabled: true
+    docker_layer_caching: true
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        name: Create temporary directory for logs
+        command: mkdir -p /tmp/logs/test/integration/kind-helm
+    - run:
+        name: Integration tests with Helm deployment
+        command: |
+          export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
+          npm run test:integration:kind:helm
+    - run:
+        name: Notify Slack on failure
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-integration-helm-tests-${CIRCLE_SHA1}"
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/logs/test/integration/kind-helm
+
+integration_tests_proxy:
+  # <<: *default_machine_config
+  machine:
+    enabled: true
+    docker_layer_caching: true
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        name: Create temporary directory for logs
+        command: mkdir -p /tmp/logs/test/integration/proxy
+    - run:
+        name: Integration tests with Helm deployment
+        command: |
+          export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
+          npm run test:integration:kind:proxy
+    - run:
+        name: Notify Slack on failure
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-integration-proxy-tests-${CIRCLE_SHA1}"
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/logs/test/integration/proxy
+
+eks_integration_tests:
+  # <<: *default_machine_config
+  machine:
+    enabled: true
+    docker_layer_caching: true
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - install_python_requests
+    - run:
+        name: Create temp dir for logs
+        command: mkdir -p /tmp/logs/test/integration/eks
+    - run:
+        name: Integration tests EKS
+        # WARNING! Do not use the step "setup_node12" here - the call to "nvm use 12" breaks the tests!
+        command: |
+          export NVM_DIR="/opt/circleci/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          nvm install v12
+          npm install
+          export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
+          .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:eks:yaml
+    - run:
+        name: Notify Slack on failure
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-eks-integration-tests-${CIRCLE_SHA1}"
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/logs/test/integration/eks
+
+openshift3_integration_tests:
+  # <<: *default_machine_config
+  machine:
+    enabled: true
+    docker_layer_caching: true
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        name: Create temporary directory for logs
+        command: mkdir -p /tmp/logs/test/integration/openshift3
+    - run:
+        name: Integration tests OpenShift 3
+        command: |
+          export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
+          npm run test:integration:openshift3:yaml
+    - run:
+        name: Notify Slack on failure
+        command: ./scripts/slack/notify_failure.py "staging-openshift3-integration-tests-${CIRCLE_SHA1}"
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/logs/test/integration/openshift3
+
+openshift4_integration_tests:
+  # <<: *default_machine_config
+  machine:
+    enabled: true
+    docker_layer_caching: true
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - setup_node12
+    - install_python_requests
+    - run:
+        name: create temp dir for logs
+        command: mkdir -p /tmp/logs/test/integration/openshift4
+    - run:
+        name: Append an entry to the test environment to /etc/hosts
+        command: |
+          echo "${OPENSHIFT4_ETC_HOSTS_ENTRY}" | sudo tee -a /etc/hosts
+    - run:
+        name: Integration tests OpenShift 4
+        command: |
+          export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
+          .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:openshift4:operator
+    - run:
+        name: Delete Operator from Quay
+        command: |
+          ./scripts/operator/delete-operator-from-quay.sh
+        when: always
+    - run:
+        name: Notify Slack on failure
+        command: |
+          ./scripts/slack/notify_failure_on_branch.py "staging-openshift4-integration-tests-${CIRCLE_SHA1}"
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/logs/test/integration/openshift4
+
+######################## MERGE TO STAGING ########################
+tag_and_push:
+  # <<: *default_container_config
+  docker:
+    - image: circleci/node:12
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - setup_remote_docker
+    - install_python_requests
+    - run:
+        name: Tag and push
+        command: |
+          npm install &&
+          docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} &&
+          unset CIRCLE_PULL_REQUEST &&
+          unset CI_PULL_REQUEST &&
+          unset CI_PULL_REQUESTS &&
+          unset CIRCLE_PULL_REQUESTS &&
+          npx semantic-release &&
+          NEW_VERSION=`cat ./package.json | jq -r '.version'` &&
+          ./scripts/docker/approve-image.sh $NEW_VERSION
+    - run:
+        name: Notify Slack on failure
+        command: ./scripts/slack/notify_failure.py "staging-release"
+        when: on_fail
+
+deploy_dev:
+  # <<: *default_container_config
+  docker:
+    - image: circleci/node:12
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - install_python_requests
+    - run:
+        name: Deploy to dev
+        command: |
+          LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}` &&
+          LATEST_TAG=${LATEST_TAG_WITH_V:1}-approved &&
+          ./scripts/slack/notify_deploy.py $LATEST_TAG dev &&
+          curl -i -H "Accept: application/json" -H "Content-Type: application/json" \
+              -X POST -d "{\"docker_sha\":\"${LATEST_TAG}\", \
+                            \"commit_hash\":\"${CIRCLE_SHA1}\"}" \
+              https://my.dev.snyk.io/${DEV_DEPLOY_TOKEN}
+    - run:
+        name: Notify Slack on failure
+        command: ./scripts/slack/notify_failure.py "deploy-dev"
+        when: on_fail
+
+######################## MERGE TO MASTER ########################
+publish:
+  # <<: *default_container_config
+  docker:
+    - image: circleci/node:12
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - setup_remote_docker
+    - install_python_requests
+    - run:
+        name: Publish
+        command: |
+          LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}` &&
+          LATEST_TAG=${LATEST_TAG_WITH_V:1} &&
+          IMAGE_NAME_APPROVED=snyk/kubernetes-monitor:${LATEST_TAG}-approved &&
+          IMAGE_NAME_PUBLISHED=snyk/kubernetes-monitor:${LATEST_TAG} &&
+          docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} &&
+          docker pull ${IMAGE_NAME_APPROVED} &&
+          docker tag ${IMAGE_NAME_APPROVED} ${IMAGE_NAME_PUBLISHED} &&
+          docker push ${IMAGE_NAME_PUBLISHED} &&
+          ./scripts/slack/notify_push.py ${IMAGE_NAME_PUBLISHED} &&
+          ./scripts/publish-gh-pages.sh ${LATEST_TAG}
+          # Preserve the latest tag for the next steps of this job
+          echo "export LATEST_TAG=${LATEST_TAG}" >> $BASH_ENV
+    - run:
+        name: Download operator-sdk
+        command: |
+          RELEASE_VERSION=v0.15.1
+          DOWNLOAD_LOCATION=./operator-sdk
+          CURL_FOLLOW_REDIRECTS="-L"
+          curl ${CURL_FOLLOW_REDIRECTS} https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu -o ${DOWNLOAD_LOCATION}
+          chmod +x ${DOWNLOAD_LOCATION}
+    - run:
+        name: Create Operator and push Operator image to DockerHub
+        command: |
+          ./scripts/operator/create-operator-and-push.sh "${LATEST_TAG}"
+    - run:
+        name: Package Operator
+        command: |
+          export SNYK_MONITOR_IMAGE_TAG="${LATEST_TAG}"
+          export SNYK_OPERATOR_VERSION="${LATEST_TAG}"
+          export SNYK_OPERATOR_IMAGE_TAG="${SNYK_MONITOR_IMAGE_TAG}"
+          ./scripts/operator/package-operator.sh "${SNYK_OPERATOR_VERSION}" "${SNYK_OPERATOR_IMAGE_TAG}" "${SNYK_MONITOR_IMAGE_TAG}"
+    - run:
+        name: Remove templated Operator before storing artifacts
+        command: |
+          rm -rf snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0
+    - store_artifacts:
+        path: snyk-operator/deploy/olm-catalog/snyk-operator
+        destination: snyk-operator
+    - run:
+        name: Notify Slack on failure
+        command: ./scripts/slack/notify_failure.py "master"
+        when: on_fail
+
+deploy_prod:
+  # <<: *default_container_config
+  docker:
+    - image: circleci/node:12
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - install_python_requests
+    - run:
+        name: Deploy to prod
+        command: |
+          LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}` &&
+          LATEST_TAG=${LATEST_TAG_WITH_V:1} &&
+          ./scripts/slack/notify_deploy.py $LATEST_TAG prod &&
+          curl -i -H "Accept: application/json" -H "Content-Type: application/json" \
+              -X POST -d "{}" \
+              https://my.prod.snyk.io/${PROD_DEPLOY_TOKEN}
+    - run:
+        name: Notify Slack on failure
+        command: ./scripts/slack/notify_failure.py "deploy-prod"
+        when: on_fail

--- a/.circleci/config/jobs/create_local_cluster.yml
+++ b/.circleci/config/jobs/create_local_cluster.yml
@@ -1,0 +1,202 @@
+description: |
+    Creates an OpenShift instance within CircleCI that allows us to test
+    the the `snyk-monitor` operator upgrade path. The job uses a virutal
+    machine running in CircleCI to start the OpenShift Cluster, and uses
+    various scripts to install the operator, upgrade it, and verify the
+    expected functionality.
+
+executor: redhat-openshift/default
+
+working_directory: ~/kubernetes-monitor
+
+steps:
+  - checkout
+
+  - run:
+      name: Update hosts for test cluster
+      command: echo "${OPENSHIFT4_ETC_HOSTS_ENTRY}" | sudo tee -a /etc/hosts
+
+  - redhat-openshift/login-and-update-kubeconfig:
+      insecure-skip-tls-verify: true
+      openshift-platform-version: 4.x
+      username: $OPENSHIFT4_USER
+      password: $OPENSHIFT4_PASSWORD
+      server-address: $OPENSHIFT4_CLUSTER_URL
+
+  - run:
+      name: Get last released operator version
+      command: |
+        set -xeo pipefail
+
+        # Verify that python exists!
+        if ! which python > /dev/null; then
+          >&2 echo "Failed to find python"
+          exit 1
+        fi
+
+        python -m pip install requests pyyaml
+
+        VERSION=$(python ./scripts/operator/tests/test-operator-upgrade.py)
+
+        echo "Currently released version is: ${VERSION}"
+        echo "export OC_VERSION=${VERSION}" >> $BASH_ENV
+
+  - run:
+      name: Package and deploy last released operator
+      command: |
+        set -xeo pipefail
+
+        if [[ -z $OC_VERSION ]]; then
+          >&2 echo "OC_VERSION variable is not set"
+          exit 1
+        fi
+
+        # Package operator to be uploaded to quay.io
+        ./scripts/operator/package-operator.sh $OC_VERSION $OC_VERSION $OC_VERSION
+
+        # We do not want to include the templating files when we push the operator,
+        # therefore we move the directory to /temp, and restore it later
+        mkdir temp
+        mv ./snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0 ./temp/
+
+  - run:
+      name: Push operator to quay
+      command: |
+        set -eo pipefail
+
+        python -m pip install operator-courier
+
+        export QUAY_TOKEN=$(curl -H "Content-Type: application/json" \
+          -XPOST https://quay.io/cnr/api/v1/users/login \
+          -d "{\"user\": {\"username\": \"${QUAY_USERNAME}\", \"password\": \"${QUAY_PASSWORD}\"}}" \
+          | jq -r .token)
+
+        OPERATOR_DIR=./snyk-operator/deploy/olm-catalog/snyk-operator/
+        QUAY_NAMESPACE=snyk-runtime
+        PACKAGE_NAME=snyk-operator
+
+        operator-courier push "${OPERATOR_DIR}" "${QUAY_NAMESPACE}" "${PACKAGE_NAME}" "${OC_VERSION}" "${QUAY_TOKEN}"
+
+  - run:
+      name: Configure snyk-monitor namespace
+      command: |
+        set -xo pipefail
+        set +e
+
+        ns=$(kubectl get ns snyk-monitor --no-headers --output=go-template={{.metadata.name}} 2>/dev/null)
+
+        if [[ -z "${ns}" ]]; then
+          echo "snyk-monitor namespace not found, creating..."
+          kubectl create ns snyk-monitor
+        fi
+
+        set -e
+        kubectl create secret generic snyk-monitor -n snyk-monitor --from-literal=integrationId=2eb0b704-de07-4280-bab6-a7911153047b --from-literal=dockercfg.json={}
+
+  - run:
+      name: Apply operator installation files
+      command: |
+        set -xe
+
+        kubectl apply -f ./test/fixtures/operator/operator-source.yaml
+
+        set +e
+        opsrc=$(kubectl get operatorsource snyk-operator -n openshift-marketplace --no-headers 2>/dev/null | awk '{print $9}')
+
+        set -e
+        while [[ "${opsrc}" != "Succeeded" ]]; do
+          if [[ -z "${opsrc}" || "${opsrc}" == "Failed" ]]; then
+            >&2 echo "failed to deploy operator source resource"
+            exit 1
+          fi
+          opsrc=$(kubectl get operatorsource snyk-operator -n openshift-marketplace --no-headers 2>/dev/null | awk '{print $9}')
+        done
+
+        kubectl apply -f ./test/fixtures/operator/installation.yaml
+        sleep 60
+        kubectl get pods -n snyk-monitor --no-headers | \
+          grep "snyk-operator" | \
+          awk 'END { if (NR==0) exit 1; else print $1 }' | \
+          xargs -I{} kubectl wait pod/{} -n snyk-monitor --timeout 60s --for condition=Ready
+
+  - run:
+      name: Deploy snyk-monitor resource
+      command: |
+        set -o pipefail
+
+        kubectl apply -f ./test/fixtures/operator/test-resource.yaml
+        # Eventually consistent is fun!
+        sleep 30
+
+        kubectl get pods -n snyk-monitor --no-headers | \
+          grep "snyk-monitor" | \
+          awk 'END { if (NR==0) exit 1; else print $1 }' | \
+          xargs -I{} kubectl wait pod/{} -n snyk-monitor --timeout 60s --for condition=Ready
+
+  - run:
+      name: Upgrade snyk-monitor operator
+      command: |
+        set -xeo pipefail
+
+        curl -XDELETE -H "Accept: application/json" -H "Content-Type: application/json" \
+          -H "Authorization: ${QUAY_DELETE_TOKEN}" "https://quay.io/cnr/api/v1/packages/snyk-runtime/snyk-operator/$OC_VERSION/helm"
+
+        mv ./temp/0.0.0 ./snyk-operator/deploy/olm-catalog/snyk-operator/
+        rm -rf ./snyk-operator/deploy/olm-catalog/snyk-operator/${OC_VERSION}
+
+        LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}` && \
+          LATEST_TAG=${LATEST_TAG_WITH_V:1}
+
+        ./scripts/operator/package-operator.sh ${LATEST_TAG} ${LATEST_TAG} ${LATEST_TAG}
+
+        export QUAY_TOKEN=$(curl -H "Content-Type: application/json" \
+          -XPOST https://quay.io/cnr/api/v1/users/login \
+          -d "{\"user\": {\"username\": \"${QUAY_USERNAME}\", \"password\": \"${QUAY_PASSWORD}\"}}" \
+          | jq -r .token)
+
+        OPERATOR_DIR=./snyk-operator/deploy/olm-catalog/snyk-operator/
+        QUAY_NAMESPACE=snyk-runtime
+        PACKAGE_NAME=snyk-operator
+
+        set +x
+        operator-courier push "${OPERATOR_DIR}" "${QUAY_NAMESPACE}" "${PACKAGE_NAME}" "${LATEST_TAG}" "${QUAY_TOKEN}"
+        set -x
+        echo "export LATEST_TAG=${LATEST_TAG}" >> $BASH_ENV
+
+        kubectl delete -f ./test/fixtures/operator/operator-source.yaml
+        kubectl apply -f ./test/fixtures/operator/operator-source.yaml
+        sleep 60
+
+        VERSION=$(kubectl get pods -n snyk-monitor --no-headers | \
+          grep "snyk-monitor" | \
+          awk 'END { if (NR==0) exit 1; else print $1 }' | \
+          xargs -I{} kubectl get pod {} -n snyk-monitor -o jsonpath={..image} | \
+          awk '{print $1}' | grep -oE "[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,3}$")
+
+        if [[ "${VERSION}" != "${LATEST_TAG}" ]]; then
+          &>2 echo "versions (${VERSION}) does not match expected (${LATEST_TAG})!"
+          exit 1
+        fi
+
+        echo "Update complete!"
+
+  - run:
+      name: Cleanup
+      command: |
+        set +e
+        curl -XDELETE -H "Accept: application/json" -H "Content-Type: application/json" \
+          -H "Authorization: ${QUAY_DELETE_TOKEN}" "https://quay.io/cnr/api/v1/packages/snyk-runtime/snyk-operator/${OC_VERSION}/helm"
+        curl -XDELETE -H "Accept: application/json" -H "Content-Type: application/json" \
+          -H "Authorization: ${QUAY_DELETE_TOKEN}" "https://quay.io/cnr/api/v1/packages/snyk-runtime/snyk-operator/${LATEST_TAG}/helm"
+
+        kubectl delete -f ./test/fixtures/operator/operator-source.yaml
+        kubectl delete -f ./test/fixtures/operator/installation.yaml
+
+        kubectl patch customresourcedefinition snykmonitors.charts.helm.k8s.io -p '{"metadata":{"finalizers":[]}}' --type=merge -n snyk-monitor
+        kubectl patch snykmonitors.charts.helm.k8s.io snyk-monitor -p '{"metadata":{"finalizers":[]}}' --type=merge -n snyk-monitor
+        kubectl delete -f ./test/fixtures/operator/test-resource.yaml
+        kubectl delete clusterrolebinding snyk-monitor
+        kubectl delete clusterrole snyk-monitor
+
+        kubectl delete ns snyk-monitor
+      when: always

--- a/.circleci/config/orbs/@redhat-openshift.yml
+++ b/.circleci/config/orbs/@redhat-openshift.yml
@@ -1,0 +1,1 @@
+redhat-openshift: circleci/redhat-openshift@0.2.0

--- a/scripts/operator/tests/poetry.lock
+++ b/scripts/operator/tests/poetry.lock
@@ -1,0 +1,320 @@
+[[package]]
+category = "dev"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+name = "appdirs"
+optional = false
+python-versions = "*"
+version = "1.4.4"
+
+[[package]]
+category = "dev"
+description = "Classes Without Boilerplate"
+name = "attrs"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "19.3.0"
+
+[package.extras]
+azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
+dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
+docs = ["sphinx", "zope.interface"]
+tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+
+[[package]]
+category = "dev"
+description = "The uncompromising code formatter."
+name = "black"
+optional = false
+python-versions = ">=3.6"
+version = "19.10b0"
+
+[package.dependencies]
+appdirs = "*"
+attrs = ">=18.1.0"
+click = ">=6.5"
+pathspec = ">=0.6,<1"
+regex = "*"
+toml = ">=0.9.4"
+typed-ast = ">=1.4.0"
+
+[package.extras]
+d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+
+[[package]]
+category = "main"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
+optional = false
+python-versions = "*"
+version = "2020.4.5.1"
+
+[[package]]
+category = "main"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
+optional = false
+python-versions = "*"
+version = "3.0.4"
+
+[[package]]
+category = "dev"
+description = "Composable command line interface toolkit"
+name = "click"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.2"
+
+[[package]]
+category = "dev"
+description = "Discover and load entry points from installed packages."
+name = "entrypoints"
+optional = false
+python-versions = ">=2.7"
+version = "0.3"
+
+[[package]]
+category = "dev"
+description = "the modular source code checker: pep8, pyflakes and co"
+name = "flake8"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.7.9"
+
+[package.dependencies]
+entrypoints = ">=0.3.0,<0.4.0"
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.5.0,<2.6.0"
+pyflakes = ">=2.1.0,<2.2.0"
+
+[[package]]
+category = "main"
+description = "Internationalized Domain Names in Applications (IDNA)"
+name = "idna"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.9"
+
+[[package]]
+category = "dev"
+description = "McCabe checker, plugin for flake8"
+name = "mccabe"
+optional = false
+python-versions = "*"
+version = "0.6.1"
+
+[[package]]
+category = "dev"
+description = "Utility library for gitignore style pattern matching of file paths."
+name = "pathspec"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.8.0"
+
+[[package]]
+category = "dev"
+description = "Python style guide checker"
+name = "pycodestyle"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.5.0"
+
+[[package]]
+category = "dev"
+description = "passive checker of Python programs"
+name = "pyflakes"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.1.1"
+
+[[package]]
+category = "main"
+description = "YAML parser and emitter for Python"
+name = "pyyaml"
+optional = false
+python-versions = "*"
+version = "5.3.1"
+
+[[package]]
+category = "dev"
+description = "Alternative regular expression module, to replace re."
+name = "regex"
+optional = false
+python-versions = "*"
+version = "2020.5.7"
+
+[[package]]
+category = "main"
+description = "Python HTTP for Humans."
+name = "requests"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.23.0"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<4"
+idna = ">=2.5,<3"
+urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+
+[package.extras]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+
+[[package]]
+category = "dev"
+description = "Python Library for Tom's Obvious, Minimal Language"
+name = "toml"
+optional = false
+python-versions = "*"
+version = "0.10.0"
+
+[[package]]
+category = "dev"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+name = "typed-ast"
+optional = false
+python-versions = "*"
+version = "1.4.1"
+
+[[package]]
+category = "main"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "1.25.9"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+
+[metadata]
+content-hash = "c7c907691c9d53814d05b6223d32ee65c4ebb4921a79696b0935a52abbca92b4"
+python-versions = "^3.6"
+
+[metadata.files]
+appdirs = [
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+attrs = [
+    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
+    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
+]
+black = [
+    {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
+    {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
+]
+certifi = [
+    {file = "certifi-2020.4.5.1-py2.py3-none-any.whl", hash = "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304"},
+    {file = "certifi-2020.4.5.1.tar.gz", hash = "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"},
+]
+chardet = [
+    {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
+    {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
+]
+click = [
+    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
+    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+]
+entrypoints = [
+    {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
+    {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
+]
+flake8 = [
+    {file = "flake8-3.7.9-py2.py3-none-any.whl", hash = "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"},
+    {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
+]
+idna = [
+    {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
+    {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+pathspec = [
+    {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
+    {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.5.0-py2.py3-none-any.whl", hash = "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56"},
+    {file = "pycodestyle-2.5.0.tar.gz", hash = "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"},
+]
+pyflakes = [
+    {file = "pyflakes-2.1.1-py2.py3-none-any.whl", hash = "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0"},
+    {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
+]
+pyyaml = [
+    {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
+    {file = "PyYAML-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win32.whl", hash = "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win_amd64.whl", hash = "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win32.whl", hash = "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win32.whl", hash = "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
+    {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
+]
+regex = [
+    {file = "regex-2020.5.7-cp27-cp27m-win32.whl", hash = "sha256:5493a02c1882d2acaaf17be81a3b65408ff541c922bfd002535c5f148aa29f74"},
+    {file = "regex-2020.5.7-cp27-cp27m-win_amd64.whl", hash = "sha256:021a0ae4d2baeeb60a3014805a2096cb329bd6d9f30669b7ad0da51a9cb73349"},
+    {file = "regex-2020.5.7-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:4df91094ced6f53e71f695c909d9bad1cca8761d96fd9f23db12245b5521136e"},
+    {file = "regex-2020.5.7-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:7ce4a213a96d6c25eeae2f7d60d4dad89ac2b8134ec3e69db9bc522e2c0f9388"},
+    {file = "regex-2020.5.7-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b059e2476b327b9794c792c855aa05531a3f3044737e455d283c7539bd7534d"},
+    {file = "regex-2020.5.7-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:652ab4836cd5531d64a34403c00ada4077bb91112e8bcdae933e2eae232cf4a8"},
+    {file = "regex-2020.5.7-cp36-cp36m-win32.whl", hash = "sha256:1e2255ae938a36e9bd7db3b93618796d90c07e5f64dd6a6750c55f51f8b76918"},
+    {file = "regex-2020.5.7-cp36-cp36m-win_amd64.whl", hash = "sha256:8127ca2bf9539d6a64d03686fd9e789e8c194fc19af49b69b081f8c7e6ecb1bc"},
+    {file = "regex-2020.5.7-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f7f2f4226db6acd1da228adf433c5c3792858474e49d80668ea82ac87cf74a03"},
+    {file = "regex-2020.5.7-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:2bc6a17a7fa8afd33c02d51b6f417fc271538990297167f68a98cae1c9e5c945"},
+    {file = "regex-2020.5.7-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b7c9f65524ff06bf70c945cd8d8d1fd90853e27ccf86026af2afb4d9a63d06b1"},
+    {file = "regex-2020.5.7-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:fa09da4af4e5b15c0e8b4986a083f3fd159302ea115a6cc0649cd163435538b8"},
+    {file = "regex-2020.5.7-cp37-cp37m-win32.whl", hash = "sha256:669a8d46764a09f198f2e91fc0d5acdac8e6b620376757a04682846ae28879c4"},
+    {file = "regex-2020.5.7-cp37-cp37m-win_amd64.whl", hash = "sha256:b5b5b2e95f761a88d4c93691716ce01dc55f288a153face1654f868a8034f494"},
+    {file = "regex-2020.5.7-cp38-cp38-manylinux1_i686.whl", hash = "sha256:0ff50843535593ee93acab662663cb2f52af8e31c3f525f630f1dc6156247938"},
+    {file = "regex-2020.5.7-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:1b17bf37c2aefc4cac8436971fe6ee52542ae4225cfc7762017f7e97a63ca998"},
+    {file = "regex-2020.5.7-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:04d6e948ef34d3eac133bedc0098364a9e635a7914f050edb61272d2ddae3608"},
+    {file = "regex-2020.5.7-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:5b741ecc3ad3e463d2ba32dce512b412c319993c1bb3d999be49e6092a769fb2"},
+    {file = "regex-2020.5.7-cp38-cp38-win32.whl", hash = "sha256:099568b372bda492be09c4f291b398475587d49937c659824f891182df728cdf"},
+    {file = "regex-2020.5.7-cp38-cp38-win_amd64.whl", hash = "sha256:3ab5e41c4ed7cd4fa426c50add2892eb0f04ae4e73162155cd668257d02259dd"},
+    {file = "regex-2020.5.7.tar.gz", hash = "sha256:73a10404867b835f1b8a64253e4621908f0d71150eb4e97ab2e7e441b53e9451"},
+]
+requests = [
+    {file = "requests-2.23.0-py2.py3-none-any.whl", hash = "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"},
+    {file = "requests-2.23.0.tar.gz", hash = "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"},
+]
+toml = [
+    {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},
+    {file = "toml-0.10.0-py2.py3-none-any.whl", hash = "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"},
+    {file = "toml-0.10.0.tar.gz", hash = "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
+    {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
+    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
+    {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+]
+urllib3 = [
+    {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
+    {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
+]

--- a/scripts/operator/tests/pyproject.toml
+++ b/scripts/operator/tests/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "openshift-upgrade"
+version = "0.1.0"
+description = ""
+authors = ["Josh Michielsen <github@mickey.dev>"]
+
+[tool.poetry.dependencies]
+python = "^3.6"
+requests = "^2.23.0"
+pyyaml = "^5.3.1"
+
+[tool.poetry.dev-dependencies]
+flake8 = "^3.7.9"
+black = "^19.10b0"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/scripts/operator/tests/test-operator-upgrade.py
+++ b/scripts/operator/tests/test-operator-upgrade.py
@@ -1,0 +1,24 @@
+import yaml
+import requests
+import re
+import sys
+import os
+
+
+PACAKGE_URL = "https://raw.githubusercontent.com/operator-framework/community-operators/master/community-operators/snyk-operator/snyk-operator.package.yaml"  # noqa: E501
+
+resp = requests.get(PACAKGE_URL)
+yml = yaml.load(resp.text, Loader=yaml.SafeLoader)
+
+re_compile = re.compile("([1]\\.[0-9]{1,3}\\.[0-9]{1,3})")
+try:
+    version = re_compile.search(yml["channels"][0]["currentCSV"]).group(0)
+except Exception as ex:
+    print(
+        "error: couldn't find version number for operator:",
+        ex,
+        file=sys.stderr,
+    )
+    os.exit(1)
+
+print(version)

--- a/snyk-operator/deploy/olm-catalog/snyk-operator/snyk-operator.package.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/snyk-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: snyk-operator.v0.0.0
+- currentCSV: snyk-operator.v1.25.0
   name: stable
 defaultChannel: stable
 packageName: snyk-operator

--- a/test/fixtures/operator/test-resource.yaml
+++ b/test/fixtures/operator/test-resource.yaml
@@ -1,0 +1,7 @@
+apiVersion: charts.helm.k8s.io/v1alpha1
+kind: SnykMonitor
+metadata:
+  name: snyk-monitor
+  namespace: snyk-monitor
+spec:
+  clusterName: TESTING OPERATOR UPGRADE


### PR DESCRIPTION
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

NOTE: This PR is still a work in progress.

### What this does

Begins the steps required to automate the testing of the OpenShift 4.x Operator upgrade process. The majority of the work for this can be found in this file:

https://github.com/snyk/kubernetes-monitor/blob/b1da250aba492f7c86c821821107d46af73a9eb8/.circleci/config/jobs/create_local_cluster.yml

The job utilises the existing OS4.x test cluster to install the Operator resources. The previous operator version is retreived via a python script found [here](https://github.com/snyk/kubernetes-monitor/blob/b1da250aba492f7c86c821821107d46af73a9eb8/scripts/operator/tests/test-operator-upgrade.py)

Once the last released version is retrieved the operator package for the previous version is built and pushed to Quay, then installed in the cluster. Once the operator is confirmed to be running, a new version is packaged and pushed to Quay and the `OperatorSource` is deleted and re-created. This should prompt an upgrade of the operator and `snyk-monitor` deployment.

### Notes for the reviewer

I have split out the CircleCI config while working on this ticket, as it was difficult to grok in its current form. The config source-of-truth is stored within the `.circleci/config` folder, with sub-folders for jobs and commands. 

It generate the `.circleci/config.yml` file you need to run:

```sh
cd kubernetes-monitor
circleci config pack .circleci/config > .circleci/config.yml
circleci config validate .circleci/config.yml
```
