### PR TITLE
[RUN-965] Feat/add registries conf to kubernetes-monitor installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM golang:1.13.1-alpine3.10 AS skopeo-build
 
 RUN apk --no-cache add git make gcc musl-dev ostree-dev go-md2man
-RUN git clone --depth 1 -b 'v0.1.39' https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo
+RUN git clone --depth 1 -b 'v0.2.0' https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo
 RUN cd $GOPATH/src/github.com/containers/skopeo \
   && make binary-local-static DISABLE_CGO=1 \
   && make install

--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ kubectl create secret generic snyk-monitor -n snyk-monitor --from-file=./dockerc
 kubectl create configmap snyk-monitor-certs -n snyk-monitor --from-file=<path_to_certs_folder>
 ```
 
+5. If you are using an insecure registry or your registry is using unqualified images, you can provide a `registries.conf` file. See [the documentation](https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md) for information on the format and examples.
+
+Create a file named `registries.conf`, see example adding an insecure registry: 
+
+```
+[[registry]]
+location = "internal-registry-for-example.net/bar"
+insecure = true
+```
+
+Once you've created the file, you can use it to create the following ConfigMap:
+```shell
+kubectl create configmap snyk-monitor-registries-conf -n snyk-monitor --from-file=<path_to_registries_conf_file>
+```
+
 ## Installation from YAML files ##
 
 The `kubernetes-monitor` can run in one of two modes: constrained to a single namespace, or with access to the whole cluster.

--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -32,6 +32,8 @@ spec:
           mountPath: "/var/tmp"
         - name: ssl-certs
           mountPath: "/srv/app/certs"
+        - name: registries-conf
+          mountPath: "/srv/app/.config/containers"
         env:
           - name: SNYK_INTEGRATION_ID
             valueFrom:
@@ -106,5 +108,9 @@ spec:
       - name: ssl-certs
         configMap:
           name: snyk-monitor-certs
+          optional: true
+      - name: registries-conf
+        configMap:
+          name: snyk-monitor-registries-conf
           optional: true
       serviceAccountName: snyk-monitor

--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -55,6 +55,21 @@ kubectl create secret generic snyk-monitor -n snyk-monitor --from-file=./dockerc
 kubectl create configmap snyk-monitor-certs -n snyk-monitor --from-file=<path_to_certs_folder>
 ```
 
+5. If you are using an insecure registry or your registry is using unqualified images, you can provide a `registries.conf` file. See [the documentation](https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md) for information on the format and examples.
+
+Create a file named `registries.conf`, see example adding an insecure registry: 
+
+```
+[[registry]]
+location = "internal-registry-for-example.net/bar"
+insecure = true
+```
+
+Once you've created the file, you can use it to create the following ConfigMap:
+```shell
+kubectl create configmap snyk-monitor-registries-conf -n snyk-monitor --from-file=<path_to_registries_conf_file>
+```
+
 ## Installation from Helm repo ##
 
 Add Snyk's Helm repo:

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
             mountPath: "/var/tmp"
           - name: ssl-certs
             mountPath: "/srv/app/certs"
+          - name: registries-conf
+            mountPath: "/srv/app/.config/containers"
           env:
           - name: SNYK_INTEGRATION_ID
             valueFrom:
@@ -84,4 +86,8 @@ spec:
         - name: ssl-certs
           configMap:
             name: {{ .Values.certsConfigMap }}
+            optional: true
+        - name: registries-conf
+          configMap:
+            name: {{ .Values.registriesConfConfigMap }}
             optional: true

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -6,6 +6,7 @@
 # The currently used keys within the secret are: "dockercfg.json", "integrationId".
 monitorSecrets: snyk-monitor
 certsConfigMap: snyk-monitor-certs
+registriesConfConfigMap: snyk-monitor-registries-conf
 
 # One of: Cluster, Namespaced
 # Cluster - creates a ClusterRole and ClusterRoleBinding with the ServiceAccount


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

We're adding support for insecure registries or using unqualified images in scanned containers.
To achieve that we've implemented support for `registries.conf` file, which is a system-wide configuration file for container image registries. The file format is TOML. 
For more information on how to format and examples: https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md

### Notes for the reviewer

There is two commits, the first one is mounting `registries.conf` and the second one is updating docs.

### More information

- [Jira ticket RUN-965](https://snyksec.atlassian.net/browse/RUN-965)
