### PR TITLE
feat: upgrade needle (redirect bug)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3404,9 +3404,9 @@
       "optional": true
     },
     "needle": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
+      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bunyan": "^1.8.12",
     "child-process-promise": "^2.2.1",
     "lru-cache": "^5.1.1",
-    "needle": "^2.4.0",
+    "needle": "^2.5.0",
     "sleep-promise": "^8.0.1",
     "snyk-config": "3.0.0",
     "snyk-docker-plugin": "2.8.0",


### PR DESCRIPTION
needle has a bug with sockets on newer node 12,
we're currently avoiding this newer node 12 to
evade the problem. This bug is fixed in needle
2.5.0, so let's upgrade to that.

https://github.com/tomas/needle/issues/312
