### PR TITLE
chore: skip Operator upgrade tests if no new version can be published

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,6 +319,21 @@ jobs:
         name: Get last released Operator version
     - run:
         command: |
+          LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}`
+          LATEST_TAG=${LATEST_TAG_WITH_V:1}
+          echo "export LATEST_TAG=${LATEST_TAG}" >> $BASH_ENV
+        description: |
+          This tag is used to identify the Operator version we are going to upgrade to.
+        name: Get latest snyk-monitor tag
+    - run:
+        command: |
+          if [[ "${LATEST_TAG}" == "${OPERATOR_VERSION}" ]]; then
+            echo "export NOTHING_TO_TEST=true" >> $BASH_ENV
+            exit 1
+          fi
+        name: End tests early if no new Operator is to be released
+    - run:
+        command: |
           set -xeo pipefail
 
           # Package Operator to be uploaded to Quay.io
@@ -415,9 +430,6 @@ jobs:
         command: |
           set -eo pipefail
 
-          LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}`
-          LATEST_TAG=${LATEST_TAG_WITH_V:1}
-
           REPLACES_VERSION=${OPERATOR_VERSION}
 
           CSV_LOCATION="./snyk-operator/deploy/olm-catalog/snyk-operator"
@@ -489,7 +501,10 @@ jobs:
         name: Cleanup
         when: always
     - run:
-        command: ./scripts/slack/notify_failure.py "nightly-operator-upgrade-tests"
+        command: |
+          if [[ "${NOTHING_TO_TEST}" != "true" ]]; then
+            ./scripts/slack/notify_failure.py "nightly-operator-upgrade-tests"
+          fi
         name: Notify Slack on failure
         when: on_fail
     working_directory: ~/kubernetes-monitor
@@ -576,6 +591,13 @@ jobs:
         name: Get new Operator version
     - run:
         command: |
+          if [[ "${NEW_OPERATOR_VERSION}" == "${LAST_OPERATOR_VERSION}" ]]; then
+            echo "export NOTHING_TO_TEST=true" >> $BASH_ENV
+            exit 1
+          fi
+        name: End tests early if no new Operator is to be released
+    - run:
+        command: |
           ./scripts/operator/package-operator.sh "${NEW_OPERATOR_VERSION}" "${NEW_OPERATOR_VERSION}" "${NEW_OPERATOR_VERSION}" "${LAST_OPERATOR_VERSION}"
         name: Package Operator
     - run:
@@ -613,7 +635,10 @@ jobs:
           ./scripts/slack/notify_success_operator_push.py "${NEW_OPERATOR_VERSION}"
         name: Notify Slack on new branch in snyk/community-operators
     - run:
-        command: ./scripts/slack/notify_failure.py "push-new-operator"
+        command: |
+          if [[ "${NOTHING_TO_TEST}" != "true" ]]; then
+            ./scripts/slack/notify_failure.py "push-new-operator"
+          fi
         name: Notify Slack on failure
         when: on_fail
     working_directory: ~/kubernetes-monitor

--- a/.circleci/config/jobs/operator_upgrade_tests.yml
+++ b/.circleci/config/jobs/operator_upgrade_tests.yml
@@ -17,7 +17,7 @@ steps:
         sudo apt install -y uuid-runtime
         python -m pip install requests pyyaml
         python -m pip install operator-courier
-  
+
   - install_python_requests
 
   - run:
@@ -44,6 +44,23 @@ steps:
 
         echo "Currently released version is: ${OPERATOR_VERSION}"
         echo "export OPERATOR_VERSION=${OPERATOR_VERSION}" >> $BASH_ENV
+
+  - run:
+      name: Get latest snyk-monitor tag
+      description: |
+        This tag is used to identify the Operator version we are going to upgrade to.
+      command: |
+        LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}`
+        LATEST_TAG=${LATEST_TAG_WITH_V:1}
+        echo "export LATEST_TAG=${LATEST_TAG}" >> $BASH_ENV
+
+  - run:
+      name: End tests early if no new Operator is to be released
+      command: |
+        if [[ "${LATEST_TAG}" == "${OPERATOR_VERSION}" ]]; then
+          echo "export NOTHING_TO_TEST=true" >> $BASH_ENV
+          exit 1
+        fi
 
   - run:
       name: Package and deploy last released Operator
@@ -150,9 +167,6 @@ steps:
       command: |
         set -eo pipefail
 
-        LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}`
-        LATEST_TAG=${LATEST_TAG_WITH_V:1}
-
         REPLACES_VERSION=${OPERATOR_VERSION}
 
         CSV_LOCATION="./snyk-operator/deploy/olm-catalog/snyk-operator"
@@ -228,5 +242,8 @@ steps:
 
   - run:
       name: Notify Slack on failure
-      command: ./scripts/slack/notify_failure.py "nightly-operator-upgrade-tests"
+      command: |
+        if [[ "${NOTHING_TO_TEST}" != "true" ]]; then
+          ./scripts/slack/notify_failure.py "nightly-operator-upgrade-tests"
+        fi
       when: on_fail

--- a/.circleci/config/jobs/push_operator_to_community_operators.yml
+++ b/.circleci/config/jobs/push_operator_to_community_operators.yml
@@ -36,6 +36,14 @@ steps:
         echo "export NEW_OPERATOR_VERSION=${NEW_OPERATOR_VERSION}" >> $BASH_ENV
 
   - run:
+      name: End tests early if no new Operator is to be released
+      command: |
+        if [[ "${NEW_OPERATOR_VERSION}" == "${LAST_OPERATOR_VERSION}" ]]; then
+          echo "export NOTHING_TO_TEST=true" >> $BASH_ENV
+          exit 1
+        fi
+
+  - run:
       name: Package Operator
       command: |
         ./scripts/operator/package-operator.sh "${NEW_OPERATOR_VERSION}" "${NEW_OPERATOR_VERSION}" "${NEW_OPERATOR_VERSION}" "${LAST_OPERATOR_VERSION}"
@@ -78,5 +86,8 @@ steps:
 
   - run:
       name: Notify Slack on failure
-      command: ./scripts/slack/notify_failure.py "push-new-operator"
+      command: |
+        if [[ "${NOTHING_TO_TEST}" != "true" ]]; then
+          ./scripts/slack/notify_failure.py "push-new-operator"
+        fi
       when: on_fail


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Avoid testing Operator upgrades and pushing to a branch in https://github.com/snyk/community-operators if no new version was released.

### More information

- [Jira ticket RUN-989](https://snyksec.atlassian.net/browse/RUN-989)
