### PR TITLE
    fix: Pinning KinD version to 0.7.0 for OS3 tests

### DIFF
--- a/test/setup/index.ts
+++ b/test/setup/index.ts
@@ -133,7 +133,7 @@ export async function deployMonitor(): Promise<string> {
     await predeploy(integrationId);
 
     // TODO: hack, rewrite this
-    const imagePullPolicy = testPlatform === 'kind' ? 'Never' : 'Always';
+    const imagePullPolicy = testPlatform === 'kind' || testPlatform === 'openshift3' ? 'Never' : 'Always';
     const deploymentImageOptions: IImageOptions = {
       nameAndTag: remoteImageName,
       pullPolicy: imagePullPolicy,

--- a/test/setup/platforms/index.ts
+++ b/test/setup/platforms/index.ts
@@ -1,5 +1,6 @@
 import * as kind from './kind';
 import * as eks from './eks';
+import * as openshift3 from './openshift3';
 import * as openshift4 from './openshift4';
 
 interface IPlatformSetup {
@@ -42,7 +43,7 @@ const openshift3Setup: IPlatformSetup = {
   delete: kind.deleteCluster,
   config: kind.exportKubeConfig,
   clean: kind.clean,
-  setupTester: kind.setupTester,
+  setupTester: openshift3.setupTester,
 };
 
 const openshift4Setup: IPlatformSetup = {

--- a/test/setup/platforms/kind.ts
+++ b/test/setup/platforms/kind.ts
@@ -7,7 +7,7 @@ const clusterName = 'kind';
 
 export async function setupTester(): Promise<void> {
   const osDistro = platform();
-  await download(osDistro);
+  await download(osDistro, 'v0.8.1');
 }
 
 export async function createCluster(version: string): Promise<void> {
@@ -55,13 +55,13 @@ export async function clean(): Promise<void> {
   throw new Error('Not implemented');
 }
 
-async function download(osDistro: string): Promise<void> {
+export async function download(osDistro: string, kindVersion: string): Promise<void> {
   try {
     accessSync(resolve(process.cwd(), 'kind'), constants.R_OK);
   } catch (error) {
-    console.log('Downloading KinD...');
+    console.log(`Downloading KinD ${kindVersion}...`);
 
-    const url = `https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-${osDistro}-amd64`;
+    const url = `https://github.com/kubernetes-sigs/kind/releases/download/${kindVersion}/kind-${osDistro}-amd64`;
     await exec(`curl -Lo ./kind ${url}`);
     chmodSync('kind', 0o755); // rwxr-xr-x
 

--- a/test/setup/platforms/openshift3.ts
+++ b/test/setup/platforms/openshift3.ts
@@ -1,0 +1,7 @@
+import { platform } from 'os';
+import { download } from '../platforms/kind'; 
+
+export async function setupTester(): Promise<void> {
+  const osDistro = platform();
+  await download(osDistro, 'v0.7.0');
+}


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Pinning KinD binary version to 0.7.0, compatible with Kubernetes v1.11. We're using that specific version to mimic an OS3 cluster in our integration tests.
