### PR TITLE
Fix/image name chopped for local registries

### DIFF
--- a/test/integration/kubernetes.test.ts
+++ b/test/integration/kubernetes.test.ts
@@ -258,13 +258,13 @@ tap.test('snyk-monitor pulls images from a local registry and sends data to kube
     t.pass('Not testing local container registry because we\'re not running in KinD');
     return;
   }
-  t.plan(4);
+  t.plan(3);
 
   const deploymentName = 'python-local';
   const namespace = 'services';
   const clusterName = 'Default cluster';
   const deploymentType = WorkloadKind.Deployment;
-  const imageName = 'kind-registry:5000/python:rc-buster';
+  const imageName = 'kind-registry:5000/python';
 
   await kubectl.waitForJob('push-to-local-registry', 'default');
   
@@ -288,13 +288,8 @@ tap.test('snyk-monitor pulls images from a local registry and sends data to kube
   
   t.ok('dependencyGraphResults' in depGraphResult,
   'expected dependencyGraphResults field to exist in /dependency-graphs response');
-
-  /* Because of a bug in removeTagFromImage() func in src/scanner/images/index.ts, 
-  which chops off everything after ':' from the image name, we store a wrong image name 
-  and the result does not exist in the object referred below */
-  t.same(depGraphResult.dependencyGraphResults[imageName], null,
-  'expected result for image kind-registry:5000/python:rc-buster does not exist');
-  t.ok('kind-registry' in depGraphResult.dependencyGraphResults, 'BUG: the full image name is not stored in kubernetes-upstream');
+  t.ok('imageMetadata' in JSON.parse(depGraphResult.dependencyGraphResults[imageName]),
+    'snyk-monitor sent expected data to upstream in the expected time frame');
 });
 
 tap.test('snyk-monitor sends deleted workload to kubernetes-upstream', async (t) => {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

When image name was coming from a local registry eg. kind-registry:5000/python:rc-buster, everything after the first `:` was getting removed, this PR fixes that issue.

### More information

- [Jira ticket RUN-1019](https://snyksec.atlassian.net/browse/RUN-1019)

### Screenshots

![image](https://user-images.githubusercontent.com/6079732/87009828-a20d9400-c1bd-11ea-9db8-6cb35e32f762.png)

