### PR TITLE
chore: run nightly jobs at 1AM to avoid clashes with cluster restart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -859,7 +859,7 @@ workflows:
         - operator_upgrade_tests
     triggers:
     - schedule:
-        cron: 0 0 * * *
+        cron: 0 1 * * *
         filters:
           branches:
             only:

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -106,7 +106,7 @@ workflows:
   NIGHTLY:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 1 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
The nightly job currently runs at midnight, which may collide with the periodic cluster restarting that we do for OpenShift (it happens once every 4 hours) and may explain occassional flakiness of the tests.

Push the tests to an hour that may not collide.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### More information

- [Slack discussion](https://snyk.slack.com/archives/CLW30N31V/p1595227713004000)
