### PR TITLE
chore: increase sleep timeout in Operator tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,7 +409,7 @@ jobs:
                     set -o pipefail
 
                     kubectl apply -f ./test/fixtures/operator/custom-resource.yaml
-                    sleep 30
+                    sleep 60
 
                     kubectl get pods -n snyk-monitor --no-headers | \
                       grep "snyk-monitor" | \

--- a/.circleci/config/jobs/operator_upgrade_tests.yml
+++ b/.circleci/config/jobs/operator_upgrade_tests.yml
@@ -147,7 +147,7 @@ steps:
         set -o pipefail
 
         kubectl apply -f ./test/fixtures/operator/custom-resource.yaml
-        sleep 30
+        sleep 60
 
         kubectl get pods -n snyk-monitor --no-headers | \
           grep "snyk-monitor" | \


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This is a temporary fix to help reduce flakiness. Sometimes this sleep amount is enough but in others the cluster is working a bit slower and causes the test to fail.

This is a debt that we should address in a better way in the future!

### More information

- [Slack thread](https://snyk.slack.com/archives/CLW30N31V/p1595984555016700)
