### PR TITLE
fix: fix permissions for registries.conf file in OpenShift 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,11 @@ COPY --chown=snyk:snyk --from=skopeo-build /etc/containers/policy.json /etc/cont
 # Add manifest files and install before adding anything else to take advantage of layer caching
 ADD --chown=snyk:snyk package.json package-lock.json .snyk ./
 
+# The `.config` directory is used by `snyk protect` and we also mount a K8s volume there at runtime.
+# This clashes with OpenShift 3 which mounts things differently and prevents access to the directory.
+# TODO: Remove this line once OpenShift 3 comes out of support.
+RUN mkdir -p .config
+
 RUN npm install
 
 # add the rest of the app files


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The .config directory in the product is shared between several entities:
- snyk protect creates it as part of storing metadata
- we mount registries.conf to override some image pulling properties

On OpenShift the mounting over an existing directory acts weird and makes the .config directory completely inaccessible to our user and breaking the registries.conf support that we have.
This fix pre-creates the directory with the right permissions in the Dockerfile so the OpenShift 3 behaviour is fixed.

### More information

- [Slack thread](https://snyk.slack.com/archives/CDSMEJ29E/p1596116581242200)
