### PR TITLE
fix: identify correclty image names that contains dashes

### DIFF
--- a/src/scanner/images/index.ts
+++ b/src/scanner/images/index.ts
@@ -43,7 +43,7 @@ export async function removePulledImages(images: IPullableImage[]): Promise<void
 // Exported for testing
 export function getImageParts(imageWithTag: string) : {imageName: string, imageTag: string} {
   // we're matching pattern: <registry:port_number>(optional)/<image_name>(mandatory)@<tag_identifier>(optional):<image_tag>(optional)
-  const regex = /((?:.*(:\d{4})?\/)?(?:[a-z0-9]+))([@|:].+)?/ig;
+  const regex = /((?:.*(:\d{4})?\/)?(?:[a-z0-9-]+))([@|:].+)?/ig;
   const groups  = regex.exec(imageWithTag);
   
   if(!groups){

--- a/test/unit/scanner/images.test.ts
+++ b/test/unit/scanner/images.test.ts
@@ -85,10 +85,12 @@ tap.test('extracted image tag tests', async (t) => {
 });
 
 tap.test('extracted image name tests', async (t) => {
-  t.plan(4);
+  t.plan(5);
 
   t.same(scannerImages.getImageParts('nginx:latest').imageName, 'nginx', 'removed image:tag');
   t.same(scannerImages.getImageParts('nginx:@sha256:1234567890abcdef').imageName, 'nginx', 'removed malformed image:@sha:hex');
   t.same(scannerImages.getImageParts('node@sha256:215a9fbef4df2c1ceb7c79481d3cfd94ad8f1f0105bade39f3be907bf386c5e1').imageName, 'node', 'removed image@sha:hex');
   t.same(scannerImages.getImageParts('kind-registry:5000/python:rc-buster').imageName, 'kind-registry:5000/python', 'removed repository/image:tag');
+  // Verify support on image names that contain dashes
+  t.same(scannerImages.getImageParts('kind-registry:5000/python-27:rc-buster').imageName, 'kind-registry:5000/python-27', 'removed repository/image:tag');
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

before this fixes image names we show in the UI will chop everything after the first dash
