### PR TITLE
Allow ability to specify the nodeSelector field for the Snyk-Monitor deployment

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -91,3 +91,7 @@ spec:
           configMap:
             name: {{ .Values.registriesConfConfigMap }}
             optional: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -43,3 +43,5 @@ limits:
 http_proxy:
 https_proxy:
 no_proxy:
+
+nodeSelector: {}


### PR DESCRIPTION
This PR allows the ability to specify the nodeSelector field when deploying the Snyk-Monitor Helm chart.

Closes #531