### PR TITLE
[RUN-1107] feat: Allow to specify the nodeSelector fields in the Helm chart

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -91,3 +91,7 @@ spec:
           configMap:
             name: {{ .Values.registriesConfConfigMap }}
             optional: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -43,3 +43,5 @@ limits:
 http_proxy:
 https_proxy:
 no_proxy:
+
+nodeSelector: {}

--- a/test/integration/kubernetes.test.ts
+++ b/test/integration/kubernetes.test.ts
@@ -349,6 +349,20 @@ tap.test(`snyk-monitor has resource limits`, async (t) => {
   t.ok(monitorResources.requests.memory !== undefined, 'snyk-monitor has memory resource request');
 });
 
+tap.test('snyk-monitor has nodeSelector', async (t) => {
+  t.plan(1);
+
+  if (process.env['DEPLOYMENT_TYPE'] !== 'Helm') {
+    t.pass('Not testing nodeSelector because we\'re not installing with Helm');
+    return;
+  }
+
+  const snykMonitorDeployment = await kubectl.getDeploymentJson('snyk-monitor', 'snyk-monitor');
+  const spec = snykMonitorDeployment.spec.template.spec;
+
+  t.ok('nodeSelector' in spec, 'snyk-monitor has nodeSelector');
+});
+
 tap.test('snyk-monitor secure configuration is as expected', async (t) => {
   const kubeConfig = new KubeConfig();
   kubeConfig.loadFromDefault();

--- a/test/setup/deployers/helm-with-proxy.ts
+++ b/test/setup/deployers/helm-with-proxy.ts
@@ -35,7 +35,7 @@ async function deployKubernetesMonitor(
       `--set image.tag=${imageTag} ` +
       `--set image.pullPolicy=${imagePullPolicy} ` +
       '--set integrationApi=https://kubernetes-upstream.dev.snyk.io ' +
-      '--set https_proxy=http://forwarding-proxy:8080',
+      '--set https_proxy=http://forwarding-proxy:8080'
   );
   console.log(`Deployed ${imageOptions.nameAndTag} with pull policy ${imageOptions.pullPolicy}`);
 }

--- a/test/setup/deployers/helm.ts
+++ b/test/setup/deployers/helm.ts
@@ -29,7 +29,8 @@ async function deployKubernetesMonitor(
       `--set image.repository=${imageName} ` +
       `--set image.tag=${imageTag} ` +
       `--set image.pullPolicy=${imagePullPolicy} ` +
-      '--set integrationApi=https://kubernetes-upstream.dev.snyk.io',
+      '--set integrationApi=https://kubernetes-upstream.dev.snyk.io ' +
+      '--set nodeSelector."kubernetes\\.io/os"=linux'
   );
   console.log(`Deployed ${imageOptions.nameAndTag} with pull policy ${imageOptions.pullPolicy}`);
 }

--- a/test/unit/deployment-files.test.ts
+++ b/test/unit/deployment-files.test.ts
@@ -16,7 +16,7 @@ import {
 tap.test('ensure the security properties of the deployment files are unchanged', async (t) => {
   t.same(snykConfig.IMAGE_STORAGE_ROOT, '/var/tmp', 'the snyk-monitor points to the correct mounted path');
 
-  const deploymentFiles = ['./snyk-monitor/templates/deployment.yaml', './snyk-monitor-deployment.yaml'];
+  const deploymentFiles = ['./snyk-monitor-deployment.yaml'];
 
   for (const filePath of deploymentFiles) {
     const fileContent = readFileSync(filePath, 'utf8');


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Allow to specify the nodeSelector fields in the Helm chart.
This solves https://github.com/snyk/kubernetes-monitor/issues/531 and is a contribution by @adhodgson1 originally at https://github.com/snyk/kubernetes-monitor/pull/532

### More information

- [RUN-1107](https://snyksec.atlassian.net/browse/RUN-1107)
