### PR TITLE
Chore/validate required env at test start

### DIFF
--- a/test/setup/index.ts
+++ b/test/setup/index.ts
@@ -106,6 +106,8 @@ export async function deployMonitor(): Promise<string> {
   console.log('Begin deploying the snyk-monitor...');
 
   try {
+    await platforms[testPlatform].validateRequiredEnvironment();
+
     const imageNameAndTag = getEnvVariableOrDefault(
       'KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG',
       // the default, determined by ./script/build-image.sh

--- a/test/setup/platforms/eks.ts
+++ b/test/setup/platforms/eks.ts
@@ -1,5 +1,16 @@
 import { exec } from 'child-process-promise';
+
+import { throwIfEnvironmentVariableUnset } from './helpers';
 import * as kubectl from '../../helpers/kubectl';
+
+export async function validateRequiredEnvironment(): Promise<void> {
+  console.log(
+    'Checking for the required environment variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION',
+  );
+  throwIfEnvironmentVariableUnset('AWS_ACCESS_KEY_ID');
+  throwIfEnvironmentVariableUnset('AWS_SECRET_ACCESS_KEY');
+  throwIfEnvironmentVariableUnset('AWS_REGION');
+}
 
 export async function setupTester(): Promise<void> {
   // update the `aws` CLI, the one in CircleCI's default image is outdated and doens't support eks

--- a/test/setup/platforms/helpers.ts
+++ b/test/setup/platforms/helpers.ts
@@ -1,0 +1,5 @@
+export function throwIfEnvironmentVariableUnset(variableName: string) {
+  if (!process.env[variableName]) {
+    throw new Error(`Missing required environment variable ${variableName}`);
+  }
+}

--- a/test/setup/platforms/index.ts
+++ b/test/setup/platforms/index.ts
@@ -14,6 +14,8 @@ interface IPlatformSetup {
   config: () => Promise<void>;
   // clean up whatever we littered an existing cluster with
   clean: () => Promise<void>;
+  // ensure the environment is configured properly for the platform setup; can throw
+  validateRequiredEnvironment: () => Promise<void>;
   // set up host requirements specific to this platform
   setupTester: () => Promise<void>;
 }
@@ -25,6 +27,7 @@ const kindSetup: IPlatformSetup = {
   config: kind.exportKubeConfig,
   clean: kind.clean,
   setupTester: kind.setupTester,
+  validateRequiredEnvironment: () => Promise.resolve(),
 };
 
 const eksSetup: IPlatformSetup = {
@@ -34,6 +37,7 @@ const eksSetup: IPlatformSetup = {
   config: eks.exportKubeConfig,
   clean: eks.clean,
   setupTester: eks.setupTester,
+  validateRequiredEnvironment: eks.validateRequiredEnvironment,
 };
 
 // Use a kind cluster pinned to a specific Kubernetes version to mimic OS3.
@@ -44,6 +48,7 @@ const openshift3Setup: IPlatformSetup = {
   config: kind.exportKubeConfig,
   clean: kind.clean,
   setupTester: openshift3.setupTester,
+  validateRequiredEnvironment: () => Promise.resolve(),
 };
 
 const openshift4Setup: IPlatformSetup = {
@@ -53,6 +58,7 @@ const openshift4Setup: IPlatformSetup = {
   config: openshift4.exportKubeConfig,
   clean: openshift4.clean,
   setupTester: openshift4.setupTester,
+  validateRequiredEnvironment: openshift4.validateRequiredEnvironment,
 };
 
 export function getKubernetesVersionForPlatform(testPlatform: string): string {

--- a/test/setup/platforms/index.ts
+++ b/test/setup/platforms/index.ts
@@ -69,4 +69,6 @@ export default {
   eks: eksSetup,
   openshift3: openshift3Setup,
   openshift4: openshift4Setup,
+} as {
+  [key: string]: IPlatformSetup;
 };

--- a/test/setup/platforms/openshift4.ts
+++ b/test/setup/platforms/openshift4.ts
@@ -5,9 +5,19 @@ import { platform, tmpdir } from 'os';
 import { resolve } from 'path';
 import * as needle from 'needle';
 
+import { throwIfEnvironmentVariableUnset } from './helpers';
 import * as kubectl from '../../helpers/kubectl';
 
 const OPENSHIFT_CLI_VERSION = '4.3.0';
+
+export async function validateRequiredEnvironment(): Promise<void> {
+  console.log(
+    'Checking for the required environment variables: OPENSHIFT4_USER, OPENSHIFT4_PASSWORD, OPENSHIFT4_CLUSTER_URL',
+  );
+  throwIfEnvironmentVariableUnset('OPENSHIFT4_USER');
+  throwIfEnvironmentVariableUnset('OPENSHIFT4_PASSWORD');
+  throwIfEnvironmentVariableUnset('OPENSHIFT4_CLUSTER_URL');
+}
 
 export async function setupTester(): Promise<void> {
   if (existsSync(resolve(process.cwd(), 'oc'))) {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add function to test for required environment variables in tests.

### Additional information

What it looks like:

```shell
$ npm run test:integration:openshift4:operator

> @snyk/kubernetes-monitor@ test:integration:openshift4:operator /Users/ivan/repos/kubernetes-monitor
> DEPLOYMENT_TYPE=Operator TEST_PLATFORM=openshift4 CREATE_CLUSTER=false tap test/integration/kubernetes.test.ts --timeout=900

test/integration/kubernetes.test.ts 1> Begin deploying the snyk-monitor...
test/integration/kubernetes.test.ts 1> Checking for the required environment variables: OPENSHIFT4_USER, OPENSHIFT4_PASSWORD, OPENSHIFT4_CLUSTER_URL
test/integration/kubernetes.test.ts 2> Error: Missing required environment variable OPENSHIFT4_USER
test/integration/kubernetes.test.ts 2>     at Object.throwIfEnvironmentVariableUnset (/Users/ivan/repos/kubernetes-monitor/test/setup/platforms/helpers.ts:3:11)
````
