### PR TITLE
test: fix platform test configuration that was not following interface

### DIFF
--- a/test/setup/platforms/index.ts
+++ b/test/setup/platforms/index.ts
@@ -38,6 +38,7 @@ const kindOlmSetup: IPlatformSetup = {
   config: kind.exportKubeConfig,
   clean: kind.clean,
   setupTester: kind.setupTester,
+  validateRequiredEnvironment: () => Promise.resolve(),
 };
 
 const eksSetup: IPlatformSetup = {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

It missed a rebase and because of that it got a miss match in a new function to platform test configuration interface.

### Notes for the reviewer

Look at the KindOLM platform interface. It was missing the new interface method validateRequiredEnvironment that checks if the Env Var to access external clusters are available. For Kind OLM we don't need Env Var and we can just resolve it.
