### PR TITLE
fix: improve image metadata information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,13 @@ RUN cd $GOPATH/src/github.com/containers/skopeo \
 #---------------------------------------------------------------------
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
-LABEL maintainer="Snyk Ltd"
+LABEL name="Snyk Controller" \
+      maintainer="support@snyk.io" \
+      vendor="Snyk Ltd" \
+      summary="Snyk integration for Kubernetes" \
+      description="Snyk Controller enables you to import and test your running workloads and identify vulnerabilities in their associated images and configurations that might make those workloads less secure."
+
+COPY LICENSE /licenses/LICENSE
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Included a few labels and a license folder in the Dockerfile.

### Notes for the reviewer

It's related to the Operator certification process. We got a **PASSED** status on the image scan. Once it's merged, we can do the same for the production image.

### More information

- [RUN-1120](https://snyksec.atlassian.net/browse/RUN-1120)

### Screenshots

![Screenshot 2020-08-19 at 15 26 15](https://user-images.githubusercontent.com/838518/90648220-29c0d680-e231-11ea-83a0-3c5aff8f6fb5.png)

