### PR TITLE
fix: improve operator image metadata

### DIFF
--- a/scripts/operator/create-operator.sh
+++ b/scripts/operator/create-operator.sh
@@ -29,6 +29,11 @@ HELM_CHART_NAME="snyk-monitor"
 OPERATOR_NAME="snyk-operator"
 OPERATOR_LOCATION="${PWD}/${OPERATOR_NAME}"
 HELM_CHART_LOCATION="${PWD}/${HELM_CHART_NAME}"
+
+# Copy the license to operator location to be included in the Operator image
+LICENSE_LOCATION="${PWD}/LICENSE"
+cp "${LICENSE_LOCATION}" "${OPERATOR_LOCATION}"
+
 # The location of this Helm chart's copy must match what the Dockerfile of the Operator.
 # Also, the end location should be "helm-charts", as this is what the operator-sdk expects when building the Operator image!
 OPERATOR_HELM_CHARTS_LOCATION="${OPERATOR_LOCATION}/helm-charts"

--- a/snyk-operator/build/Dockerfile
+++ b/snyk-operator/build/Dockerfile
@@ -1,4 +1,12 @@
 FROM quay.io/operator-framework/helm-operator:v0.15.1
 
+LABEL name="Snyk Operator" \
+      maintainer="support@snyk.io" \
+      vendor="Snyk Ltd" \
+      summary="Snyk Operator for Snyk Controller" \
+      description="Snyk Controller enables you to import and test your running workloads and identify vulnerabilities in their associated images and configurations that might make those workloads less secure."
+
+COPY LICENSE /licenses/LICENSE
+
 COPY watches.yaml ${HOME}/watches.yaml
 COPY helm-charts/ ${HOME}/helm-charts/


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Included a few labels and a license folder in the Dockerfile.

### Notes for the reviewer

It's related to the Operator certification process. We got a **PASSED** status on the image scan. Once it's merged, we can do the same for the production image.

### More information

- [Jira ticket RUN-1052](https://snyksec.atlassian.net/browse/RUN-1052)

### Screenshots
![Screenshot 2020-08-21 at 17 46 55](https://user-images.githubusercontent.com/838518/90914780-5a8e4080-e3d6-11ea-90e5-948a7a58ee89.png)

