### PR TITLE
chore: avoid job conflict between nightly and monthly jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -946,7 +946,7 @@ workflows:
         - operator_upgrade_tests
     triggers:
     - schedule:
-        cron: 0 1 1 * *
+        cron: 0 5 3 * *
         filters:
           branches:
             only:

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -123,7 +123,7 @@ workflows:
   MONTHLY:
     triggers:
       - schedule:
-          cron: "0 1 1 * *"
+          cron: "0 5 3 * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Change the crontab for the monthly job to **"0 5 3 * *"**, to avoid it conflicts with the nightly job.
