### PR TITLE
Add support for PodSecurityPolicies in snyk-monitor Helm chart

### DIFF
--- a/snyk-monitor/Chart.yaml
+++ b/snyk-monitor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for the Snyk Monitor
 name: snyk-monitor
-version: 0.1.0
+version: 0.2.0
 icon: https://res.cloudinary.com/snyk/image/upload/v1533761770/logo-1_wtob68.svg

--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -78,7 +78,7 @@ Add Snyk's Helm repo:
 helm repo add snyk-charts https://snyk.github.io/kubernetes-monitor/
 ```
 
-Run the following command to launch the Snyk monitor in your cluster. If your Kubernetes cluster uses PodSecurityPolicies you will also need to set `use_psp` to `true`.
+Run the following command to launch the Snyk monitor in your cluster. If your Kubernetes cluster uses PodSecurityPolicies you will also need to set `psp.enabled` to `true`. To specify an existing PodSecurityPolicy rather than creating a new one, specify the name of that PSP in `psp.name`.
 
 ```shell
 helm upgrade --install snyk-monitor snyk-charts/snyk-monitor --namespace snyk-monitor --set clusterName="Production cluster"

--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -78,7 +78,7 @@ Add Snyk's Helm repo:
 helm repo add snyk-charts https://snyk.github.io/kubernetes-monitor/
 ```
 
-Run the following command to launch the Snyk monitor in your cluster:
+Run the following command to launch the Snyk monitor in your cluster. If your Kubernetes cluster uses PodSecurityPolicies you will also need to set `use_psp` to `true`.
 
 ```shell
 helm upgrade --install snyk-monitor snyk-charts/snyk-monitor --namespace snyk-monitor --set clusterName="Production cluster"

--- a/snyk-monitor/templates/clusterrole.yaml
+++ b/snyk-monitor/templates/clusterrole.yaml
@@ -53,4 +53,16 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.use_psp }}
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - get
+  - list
+  - use
+  resourceNames:
+  - {{ include "snyk-monitor.name" . }}
+{{- end }}
 {{- end }}

--- a/snyk-monitor/templates/clusterrole.yaml
+++ b/snyk-monitor/templates/clusterrole.yaml
@@ -53,7 +53,7 @@ rules:
   - get
   - list
   - watch
-{{- if .Values.use_psp }}
+{{- if .Values.psp.enabled }}
 - apiGroups:
   - policy
   resources:
@@ -63,6 +63,6 @@ rules:
   - list
   - use
   resourceNames:
-  - {{ include "snyk-monitor.name" . }}
+  - {{ if eq .Values.psp.name "" }}{{ include "snyk-monitor.name" . }}{{ else }}{{ .Values.psp.name }}{{- end }}
 {{- end }}
 {{- end }}

--- a/snyk-monitor/templates/psp.yaml
+++ b/snyk-monitor/templates/psp.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.use_psp }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "snyk-monitor.name" . }}
+spec:
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+  - ALL
+  fsGroup:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
+  seLinux:
+    rule: RunAsAny
+  runAsUser:
+    rule: MustRunAsNonRoot
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  readOnlyRootFilesystem: true
+  volumes:
+    - secret
+    - configMap
+    - emptyDir
+{{- end }}

--- a/snyk-monitor/templates/psp.yaml
+++ b/snyk-monitor/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.use_psp }}
+{{- if .Values.psp.enabled }}{{- if eq .Values.psp.name "" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -29,4 +29,4 @@ spec:
     - secret
     - configMap
     - emptyDir
-{{- end }}
+{{- end }}{{- end }}

--- a/snyk-monitor/templates/role.yaml
+++ b/snyk-monitor/templates/role.yaml
@@ -51,7 +51,7 @@ rules:
   - get
   - list
   - watch
-{{- if .Values.use_psp }}
+{{- if .Values.psp.enabled }}
 - apiGroups:
   - policy
   resources:
@@ -61,6 +61,6 @@ rules:
   - list
   - use
   resourceNames:
-  - {{ include "snyk-monitor.name" . }}
+  - {{ if eq .Values.psp.name "" }}{{ include "snyk-monitor.name" . }}{{ else }}{{ .Values.psp.name }}{{- end }}
 {{- end }}
 {{- end }}

--- a/snyk-monitor/templates/role.yaml
+++ b/snyk-monitor/templates/role.yaml
@@ -51,4 +51,16 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.use_psp }}
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - get
+  - list
+  - use
+  resourceNames:
+  - {{ include "snyk-monitor.name" . }}
+{{- end }}
 {{- end }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -40,6 +40,8 @@ limits:
   cpu: '1'
   memory: '2Gi'
 
+use_psp:
+
 http_proxy:
 https_proxy:
 no_proxy:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -40,10 +40,12 @@ limits:
   cpu: '1'
   memory: '2Gi'
 
-use_psp:
-
 http_proxy:
 https_proxy:
 no_proxy:
 
 nodeSelector: {}
+
+psp:
+  enabled: false
+  name: ""


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

When attempting to deploy the `snyk-monitor` Helm chart to a Kubernetes cluster that requires the use of PodSecurityPolicies, it currently fails because the RBAC in the chart does not allow for their use. This adds support to bind the Role or ClusterRole to an existing PSP, or to generate a new PSP with the minimum permissions needed for the `snyk-monitor` agent to run.

### Notes for the reviewer

I'm not familiar with your CircleCI testing infrastructure so I didn't write any tests, but I have manually tested with `helm template` and then checking the resources with `kubeval` and I have also deployed to a test cluster and it works as expected.

### More information

https://kubernetes.io/docs/concepts/policy/pod-security-policy/

### Screenshots

N/A