### PR TITLE
fix: Revert Operator image upgrade to reduce vulnerabilities

### DIFF
--- a/snyk-operator/build/Dockerfile
+++ b/snyk-operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/helm-operator:v1.1.0
+FROM quay.io/operator-framework/helm-operator:v0.15.1
 
 LABEL name="Snyk Operator" \
       maintainer="support@snyk.io" \
@@ -8,6 +8,5 @@ LABEL name="Snyk Operator" \
 
 COPY LICENSE /licenses/LICENSE
 
-ENV HOME=/opt/helm
 COPY watches.yaml ${HOME}/watches.yaml
 COPY helm-charts/ ${HOME}/helm-charts/


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This reverts commit 1a4ff32bf1026d80acfb3a1299571c043fb34174, reversing
changes made to bba76d57a6674621f9aeaf91518ad55d57b4f536.

The base image introduces a breaking change and makes the Operator not work any more.
