### PR TITLE
chore: pin python executable in CI/CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
                     export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
                     OPERATOR_TAG="${IMAGE_TAG}-${CIRCLE_SHA1}"
                     MONITOR_TAG="${IMAGE_TAG}-${CIRCLE_SHA1}"
-                    python3 scripts/operator/create_operator_and_push.py "${OPERATOR_TAG}" "${MONITOR_TAG}" "${DOCKERHUB_USER}" "${DOCKERHUB_PASSWORD}"
+                    scripts/operator/create_operator_and_push.py "${OPERATOR_TAG}" "${MONITOR_TAG}" "${DOCKERHUB_USER}" "${DOCKERHUB_PASSWORD}"
                 name: Create Operator and push Operator image to DockerHub
             - run:
                 command: |
@@ -54,7 +54,7 @@ jobs:
                     export SNYK_MONITOR_IMAGE_TAG="${IMAGE_TAG}-${CIRCLE_SHA1}"
                     export SNYK_OPERATOR_VERSION="0.0.1-${CIRCLE_SHA1}"
                     export SNYK_OPERATOR_IMAGE_TAG="${SNYK_MONITOR_IMAGE_TAG}"
-                    OPERATOR_PATH=$(python3 scripts/operator/package_operator_bundle.py "${SNYK_OPERATOR_VERSION}" "${SNYK_OPERATOR_IMAGE_TAG}" "${SNYK_MONITOR_IMAGE_TAG}")
+                    OPERATOR_PATH=$(scripts/operator/package_operator_bundle.py "${SNYK_OPERATOR_VERSION}" "${SNYK_OPERATOR_IMAGE_TAG}" "${SNYK_MONITOR_IMAGE_TAG}")
                     echo "export OPERATOR_PATH=$OPERATOR_PATH" >> $BASH_ENV
                 name: Package Operator Bundle
             - run:
@@ -62,7 +62,7 @@ jobs:
                     if [ "$CIRCLE_BRANCH" != "staging" ]; then
                       exit 0
                     fi
-                    export QUAY_TOKEN=$(python3 ./scripts/operator/get_quay_token.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}")
+                    export QUAY_TOKEN=$(scripts/operator/get_quay_token.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}")
                     export OPERATOR_DIR=$OPERATOR_PATH
                     export QUAY_NAMESPACE=snyk-runtime
                     export PACKAGE_NAME=snyk-operator
@@ -236,7 +236,7 @@ jobs:
                 name: Operator integration tests on plain k8s
             - run:
                 command: |
-                    python3 scripts/operator/delete_operators_from_quay.py
+                    scripts/operator/delete_operators_from_quay.py
                 name: Delete Operators from Quay
                 when: always
             - run:
@@ -316,7 +316,7 @@ jobs:
                 name: Integration tests OpenShift 4
             - run:
                 command: |
-                    python3 scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
+                    scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
                 name: Delete Operators from Quay
                 when: always
             - run:

--- a/.circleci/config/jobs/@jobs.yml
+++ b/.circleci/config/jobs/@jobs.yml
@@ -48,7 +48,7 @@ build_and_upload_operator:
           export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
           OPERATOR_TAG="${IMAGE_TAG}-${CIRCLE_SHA1}"
           MONITOR_TAG="${IMAGE_TAG}-${CIRCLE_SHA1}"
-          python3 scripts/operator/create_operator_and_push.py "${OPERATOR_TAG}" "${MONITOR_TAG}" "${DOCKERHUB_USER}" "${DOCKERHUB_PASSWORD}"
+          scripts/operator/create_operator_and_push.py "${OPERATOR_TAG}" "${MONITOR_TAG}" "${DOCKERHUB_USER}" "${DOCKERHUB_PASSWORD}"
     - run:
         name: Package Operator Bundle
         command: |
@@ -56,7 +56,7 @@ build_and_upload_operator:
           export SNYK_MONITOR_IMAGE_TAG="${IMAGE_TAG}-${CIRCLE_SHA1}"
           export SNYK_OPERATOR_VERSION="0.0.1-${CIRCLE_SHA1}"
           export SNYK_OPERATOR_IMAGE_TAG="${SNYK_MONITOR_IMAGE_TAG}"
-          OPERATOR_PATH=$(python3 scripts/operator/package_operator_bundle.py "${SNYK_OPERATOR_VERSION}" "${SNYK_OPERATOR_IMAGE_TAG}" "${SNYK_MONITOR_IMAGE_TAG}")
+          OPERATOR_PATH=$(scripts/operator/package_operator_bundle.py "${SNYK_OPERATOR_VERSION}" "${SNYK_OPERATOR_IMAGE_TAG}" "${SNYK_MONITOR_IMAGE_TAG}")
           echo "export OPERATOR_PATH=$OPERATOR_PATH" >> $BASH_ENV
     - run:
         name: Upload Operator to Quay
@@ -64,7 +64,7 @@ build_and_upload_operator:
           if [ "$CIRCLE_BRANCH" != "staging" ]; then
             exit 0
           fi
-          export QUAY_TOKEN=$(python3 ./scripts/operator/get_quay_token.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}")
+          export QUAY_TOKEN=$(scripts/operator/get_quay_token.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}")
           export OPERATOR_DIR=$OPERATOR_PATH
           export QUAY_NAMESPACE=snyk-runtime
           export PACKAGE_NAME=snyk-operator
@@ -269,7 +269,7 @@ openshift4_integration_tests:
     - run:
         name: Delete Operators from Quay
         command: |
-          python3 scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
+          scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
         when: always
     - run:
         name: Notify Slack on failure

--- a/.circleci/config/jobs/integration_tests_operator_on_k8s.yml
+++ b/.circleci/config/jobs/integration_tests_operator_on_k8s.yml
@@ -16,7 +16,7 @@ steps:
 - run:
     name: Delete Operators from Quay
     command: |
-      python3 scripts/operator/delete_operators_from_quay.py
+      scripts/operator/delete_operators_from_quay.py
     when: always
 - run:
     command: |

--- a/scripts/operator/create_operator.py
+++ b/scripts/operator/create_operator.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3
+
 """ Creates an Operator using Operator template files in this repository.
 
 Inputs:

--- a/scripts/operator/create_operator_and_push.py
+++ b/scripts/operator/create_operator_and_push.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3
+
 from sys import argv
 from create_operator import createOperatorAndBuildOperatorImage
 from subprocess import call

--- a/scripts/operator/delete_operators_from_quay.py
+++ b/scripts/operator/delete_operators_from_quay.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3
+
 """Delete all Operators from the Quay Snyk Operator repository
 
 Args:

--- a/scripts/operator/download_operator_sdk.py
+++ b/scripts/operator/download_operator_sdk.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3
+
 from tempfile import mkdtemp
 from os import chmod, getcwd
 from os.path import isfile

--- a/scripts/operator/get_last_published_operator_version.py
+++ b/scripts/operator/get_last_published_operator_version.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3
+
 import yaml
 import requests
 import re

--- a/scripts/operator/get_quay_token.py
+++ b/scripts/operator/get_quay_token.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3
+
 from requests import post
 from json import loads, dumps
 from sys import argv

--- a/scripts/operator/main.py
+++ b/scripts/operator/main.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3
+
 """Set up a local OpenShift environment
 
 Does the following steps:

--- a/scripts/operator/package_operator_bundle.py
+++ b/scripts/operator/package_operator_bundle.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3
+
 from tempfile import mkdtemp
 from os import mkdir
 from datetime import datetime

--- a/scripts/operator/raise_pr_to_community_operators_from_our_fork.py
+++ b/scripts/operator/raise_pr_to_community_operators_from_our_fork.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3
+
 import os
 import sys
 from github import Github

--- a/scripts/operator/upload_operator_bundle_to_quay.py
+++ b/scripts/operator/upload_operator_bundle_to_quay.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3
+
 from subprocess import call
 from sys import argv
 

--- a/scripts/test-openshift4.sh
+++ b/scripts/test-openshift4.sh
@@ -40,9 +40,9 @@ validateEnvVar OPENSHIFT4_USER "$OPENSHIFT4_USER"
 validateEnvVar OPENSHIFT4_PASSWORD "$OPENSHIFT4_PASSWORD"
 validateEnvVar OPENSHIFT4_CLUSTER_URL "$OPENSHIFT4_CLUSTER_URL"
 
-python3 scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
-
 if [ "${CI}" != "true" ]; then
+  python3 scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
+  
   if [ "$KUBERNETES_MONITOR_IMAGE_TAG" == "" ]; then
     RED_COLOR='\033[0;31m'
     NO_COLOR='\033[0m'
@@ -63,6 +63,8 @@ if [ "${CI}" != "true" ]; then
   oc login -u "${OPENSHIFT4_USER}" -p "${OPENSHIFT4_PASSWORD}" "${OPENSHIFT4_CLUSTER_URL}" --insecure-skip-tls-verify=true
   
   python3 scripts/operator/main.py
+else
+  scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
 fi
 
 DEPLOYMENT_TYPE=OperatorOS TEST_PLATFORM=openshift4 CREATE_CLUSTER=false tap test/integration/kubernetes.test.ts --timeout=900


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

On some CircleCI jobs the python executable resolves to "/opt/circleci/.pyenv/shims/python3" which causes errors with our scripts. Make sure we always run the /usr/bin/python3 version.

### More information

- [CircleCI run](https://app.circleci.com/pipelines/github/snyk/kubernetes-monitor/2291/workflows/a4254f9d-4f3c-4adf-bb98-cae7acfecfd5)
