### PR TITLE
chore: use Ubuntu 2004 for CircleCI machines to use latest pkgs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -714,6 +714,17 @@ jobs:
             - install_python_requests
             - run:
                 command: |
+                    export DEBIAN_FRONTEND=noninteractive
+                    sudo apt-get update
+                    sudo apt-get install -y wget gnupg
+                    . /etc/os-release
+                    sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+                    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O- | sudo apt-key add -
+                    sudo apt-get update -qq
+                    sudo apt-get install skopeo
+                name: Install Skopeo
+            - run:
+                command: |
                     npm run build &&
                     npm run test:system
                 name: System tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ jobs:
         machine:
             docker_layer_caching: true
             enabled: true
+            image: ubuntu-2004:202010-01
         steps:
             - checkout
             - install_python_requests
@@ -147,6 +148,7 @@ jobs:
         machine:
             docker_layer_caching: true
             enabled: true
+            image: ubuntu-2004:202010-01
         steps:
             - checkout
             - install_python_requests
@@ -174,6 +176,7 @@ jobs:
         machine:
             docker_layer_caching: true
             enabled: true
+            image: ubuntu-2004:202010-01
         steps:
             - checkout
             - setup_node12
@@ -198,6 +201,7 @@ jobs:
         machine:
             docker_layer_caching: true
             enabled: true
+            image: ubuntu-2004:202010-01
         steps:
             - checkout
             - setup_node12
@@ -222,6 +226,7 @@ jobs:
         machine:
             docker_layer_caching: true
             enabled: true
+            image: ubuntu-2004:202010-01
         steps:
             - checkout
             - setup_node12
@@ -251,6 +256,7 @@ jobs:
         machine:
             docker_layer_caching: true
             enabled: true
+            image: ubuntu-2004:202010-01
         steps:
             - checkout
             - setup_node12
@@ -275,6 +281,7 @@ jobs:
         machine:
             docker_layer_caching: true
             enabled: true
+            image: ubuntu-2004:202010-01
         steps:
             - checkout
             - setup_node12
@@ -298,6 +305,7 @@ jobs:
         machine:
             docker_layer_caching: true
             enabled: true
+            image: ubuntu-2004:202010-01
         steps:
             - checkout
             - setup_node12
@@ -699,6 +707,7 @@ jobs:
         machine:
             docker_layer_caching: true
             enabled: true
+            image: ubuntu-2004:202010-01
         steps:
             - checkout
             - setup_node12
@@ -745,6 +754,7 @@ jobs:
         machine:
             docker_layer_caching: true
             enabled: true
+            image: ubuntu-2004:202010-01
         steps:
             - checkout
             - setup_node12

--- a/.circleci/config/jobs/@jobs.yml
+++ b/.circleci/config/jobs/@jobs.yml
@@ -1,5 +1,6 @@
 build_image:
   machine:
+    image: ubuntu-2004:202010-01
     enabled: true
     docker_layer_caching: true
   working_directory: ~/kubernetes-monitor
@@ -78,6 +79,7 @@ build_and_upload_operator:
 
 unit_tests:
   machine:
+    image: ubuntu-2004:202010-01
     enabled: true
     docker_layer_caching: true
   working_directory: ~/kubernetes-monitor
@@ -99,6 +101,7 @@ unit_tests:
 
 system_tests:
   machine:
+    image: ubuntu-2004:202010-01
     enabled: true
     docker_layer_caching: true
   working_directory: ~/kubernetes-monitor
@@ -119,6 +122,7 @@ system_tests:
 
 integration_tests:
   machine:
+    image: ubuntu-2004:202010-01
     enabled: true
     docker_layer_caching: true
   working_directory: ~/kubernetes-monitor
@@ -144,6 +148,7 @@ integration_tests:
 
 integration_tests_helm:
   machine:
+    image: ubuntu-2004:202010-01
     enabled: true
     docker_layer_caching: true
   working_directory: ~/kubernetes-monitor
@@ -169,6 +174,7 @@ integration_tests_helm:
 
 integration_tests_proxy:
   machine:
+    image: ubuntu-2004:202010-01
     enabled: true
     docker_layer_caching: true
   working_directory: ~/kubernetes-monitor
@@ -194,6 +200,7 @@ integration_tests_proxy:
 
 eks_integration_tests:
   machine:
+    image: ubuntu-2004:202010-01
     enabled: true
     docker_layer_caching: true
   working_directory: ~/kubernetes-monitor
@@ -223,6 +230,7 @@ eks_integration_tests:
 
 openshift3_integration_tests:
   machine:
+    image: ubuntu-2004:202010-01
     enabled: true
     docker_layer_caching: true
   working_directory: ~/kubernetes-monitor
@@ -247,6 +255,7 @@ openshift3_integration_tests:
 
 openshift4_integration_tests:
   machine:
+    image: ubuntu-2004:202010-01
     enabled: true
     docker_layer_caching: true
   working_directory: ~/kubernetes-monitor

--- a/.circleci/config/jobs/@jobs.yml
+++ b/.circleci/config/jobs/@jobs.yml
@@ -110,6 +110,17 @@ system_tests:
     - setup_node12
     - install_python_requests
     - run:
+        name: Install Skopeo
+        command: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y wget gnupg
+          . /etc/os-release
+          sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+          wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O- | sudo apt-key add -
+          sudo apt-get update -qq
+          sudo apt-get install skopeo
+    - run:
         name: System tests
         command: |
           npm run build &&

--- a/.circleci/config/jobs/integration_tests_operator_on_k8s.yml
+++ b/.circleci/config/jobs/integration_tests_operator_on_k8s.yml
@@ -1,4 +1,5 @@
 machine:
+  image: ubuntu-2004:202010-01
   docker_layer_caching: true
   enabled: true
 steps:

--- a/test/system/kind.test.ts
+++ b/test/system/kind.test.ts
@@ -26,23 +26,11 @@ tap.test('Kubernetes-Monitor with KinD', async (t) => {
     console.log(`could not start with a clean environment: ${error.message}`);
   }
 
-  // install Skopeo
-  // TODO: this thing should probably be in a setup test environment script
-  // not in this file
   try {
     await exec('which skopeo');
     console.log('Skopeo already installed :tada:');
   } catch (err) {
-    // linux-oriented, not mac
-    // for mac, install skopeo with brew
-    console.log('installing Skopeo');
-    await exec('git clone --depth 1 -b "v0.2.0" https://github.com/containers/skopeo');
-    await exec('(cd skopeo && make binary-static DISABLE_CGO=1)');
-    await exec('sudo mkdir -p /etc/containers');
-    await exec('sudo chown circleci:circleci /etc/containers');
-    await exec('cp ./skopeo/default-policy.json /etc/containers/policy.json');
-
-    process.env['PATH'] = process.env['PATH'] + ':./skopeo';
+    throw new Error('Please install skopeo on your machine');
   }
 
   const kubernetesVersion = 'latest';


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Use Ubuntu 2004 to make use of latest packages (e.g. more modern Python3).

