### PR TITLE
chore: pass credentials when deleting operator from quay

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ jobs:
                 name: Operator integration tests on plain k8s
             - run:
                 command: |
-                    scripts/operator/delete_operators_from_quay.py
+                    scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
                 name: Delete Operators from Quay
                 when: always
             - run:

--- a/.circleci/config/jobs/integration_tests_operator_on_k8s.yml
+++ b/.circleci/config/jobs/integration_tests_operator_on_k8s.yml
@@ -17,7 +17,7 @@ steps:
 - run:
     name: Delete Operators from Quay
     command: |
-      scripts/operator/delete_operators_from_quay.py
+      scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
     when: always
 - run:
     command: |


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Pass credentials when deleting Operator from Quay, this was forgotten and was causing the CircleCI job to fail even on successful tests.

