### PR TITLE
chore: do not delete Quay Operators before CI tests start

### DIFF
--- a/scripts/test-openshift4.sh
+++ b/scripts/test-openshift4.sh
@@ -41,6 +41,7 @@ validateEnvVar OPENSHIFT4_PASSWORD "$OPENSHIFT4_PASSWORD"
 validateEnvVar OPENSHIFT4_CLUSTER_URL "$OPENSHIFT4_CLUSTER_URL"
 
 if [ "${CI}" != "true" ]; then
+  # Ensure any left-over Operators don't interfere with this test run
   python3 scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
   
   if [ "$KUBERNETES_MONITOR_IMAGE_TAG" == "" ]; then
@@ -63,8 +64,6 @@ if [ "${CI}" != "true" ]; then
   oc login -u "${OPENSHIFT4_USER}" -p "${OPENSHIFT4_PASSWORD}" "${OPENSHIFT4_CLUSTER_URL}" --insecure-skip-tls-verify=true
   
   python3 scripts/operator/main.py
-else
-  scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
 fi
 
 DEPLOYMENT_TYPE=OperatorOS TEST_PLATFORM=openshift4 CREATE_CLUSTER=false tap test/integration/kubernetes.test.ts --timeout=900


### PR DESCRIPTION
This is a mistake that ensures Operators can never be deployed.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

