### PR TITLE
Feat/podspec from pods

### DIFF
--- a/src/supervisor/watchers/internal-namespaces.ts
+++ b/src/supervisor/watchers/internal-namespaces.ts
@@ -2,6 +2,7 @@ export const kubernetesInternalNamespaces = [
   'kube-node-lease',
   'kube-public',
   'kube-system',
+  'local-path-storage',
   'openshift',
   'openshift-apiserver',
   'openshift-apiserver-operator',

--- a/src/supervisor/workload-reader.ts
+++ b/src/supervisor/workload-reader.ts
@@ -5,10 +5,11 @@ import { k8sApi } from './cluster';
 import { IKubeObjectMetadata, WorkloadKind } from './types';
 import logger = require('../common/logger');
 
+type IKubeObjectMetadataWithoutPodSpec = Omit<IKubeObjectMetadata, 'podSpec'>;
 type IWorkloadReaderFunc = (
   workloadName: string,
   namespace: string,
-) => Promise<IKubeObjectMetadata | undefined>;
+) => Promise<IKubeObjectMetadataWithoutPodSpec | undefined>;
 
 const deploymentReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
   const deploymentResult = await kubernetesApiWrappers.retryKubernetesApiRequest(
@@ -22,14 +23,14 @@ const deploymentReader: IWorkloadReaderFunc = async (workloadName, namespace) =>
     return undefined;
   }
 
-  return {
+  const metadata: IKubeObjectMetadataWithoutPodSpec = {
     kind: WorkloadKind.Deployment,
     objectMeta: deployment.metadata,
     specMeta: deployment.spec.template.metadata,
     ownerRefs: deployment.metadata.ownerReferences,
     revision: deployment.status.observedGeneration,
-    podSpec: deployment.spec.template.spec,
   };
+  return metadata;
 };
 
 const replicaSetReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
@@ -44,14 +45,14 @@ const replicaSetReader: IWorkloadReaderFunc = async (workloadName, namespace) =>
     return undefined;
   }
 
-  return {
+  const metadata: IKubeObjectMetadataWithoutPodSpec = {
     kind: WorkloadKind.ReplicaSet,
     objectMeta: replicaSet.metadata,
     specMeta: replicaSet.spec.template.metadata,
     ownerRefs: replicaSet.metadata.ownerReferences,
     revision: replicaSet.status.observedGeneration,
-    podSpec: replicaSet.spec.template.spec,
   };
+  return metadata;
 };
 
 const statefulSetReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
@@ -66,14 +67,14 @@ const statefulSetReader: IWorkloadReaderFunc = async (workloadName, namespace) =
     return undefined;
   }
 
-  return {
+  const metadata: IKubeObjectMetadataWithoutPodSpec = {
     kind: WorkloadKind.StatefulSet,
     objectMeta: statefulSet.metadata,
     specMeta: statefulSet.spec.template.metadata,
     ownerRefs: statefulSet.metadata.ownerReferences,
     revision: statefulSet.status.observedGeneration,
-    podSpec: statefulSet.spec.template.spec,
   };
+  return metadata;
 };
 
 const daemonSetReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
@@ -88,14 +89,14 @@ const daemonSetReader: IWorkloadReaderFunc = async (workloadName, namespace) => 
     return undefined;
   }
 
-  return {
+  const metadata: IKubeObjectMetadataWithoutPodSpec = {
     kind: WorkloadKind.DaemonSet,
     objectMeta: daemonSet.metadata,
     specMeta: daemonSet.spec.template.metadata,
     ownerRefs: daemonSet.metadata.ownerReferences,
     revision: daemonSet.status.observedGeneration,
-    podSpec: daemonSet.spec.template.spec,
   };
+  return metadata;
 };
 
 const jobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
@@ -109,13 +110,13 @@ const jobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
     return undefined;
   }
 
-  return {
+  const metadata: IKubeObjectMetadataWithoutPodSpec = {
     kind: WorkloadKind.Job,
     objectMeta: job.metadata,
     specMeta: job.spec.template.metadata,
     ownerRefs: job.metadata.ownerReferences,
-    podSpec: job.spec.template.spec,
   };
+  return metadata;
 };
 
 // Keep an eye on this! We need v1beta1 API for CronJobs.
@@ -133,13 +134,13 @@ const cronJobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
     return undefined;
   }
 
-  return {
+  const metadata: IKubeObjectMetadataWithoutPodSpec = {
     kind: WorkloadKind.CronJob,
     objectMeta: cronJob.metadata,
     specMeta: cronJob.spec.jobTemplate.metadata,
     ownerRefs: cronJob.metadata.ownerReferences,
-    podSpec: cronJob.spec.jobTemplate.spec.template.spec,
   };
+  return metadata;
 };
 
 const replicationControllerReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
@@ -155,14 +156,14 @@ const replicationControllerReader: IWorkloadReaderFunc = async (workloadName, na
     return undefined;
   }
 
-  return {
+  const metadata: IKubeObjectMetadataWithoutPodSpec = {
     kind: WorkloadKind.ReplicationController,
     objectMeta: replicationController.metadata,
     specMeta: replicationController.spec.template.metadata,
     ownerRefs: replicationController.metadata.ownerReferences,
     revision: replicationController.status.observedGeneration,
-    podSpec: replicationController.spec.template.spec,
   };
+  return metadata;
 };
 
 function logIncompleteWorkload(workloadName: string, namespace: string): void {

--- a/test/fixtures/java-deployment.yaml
+++ b/test/fixtures/java-deployment.yaml
@@ -21,4 +21,12 @@ spec:
         name: java
         command: ['/bin/sleep']
         args: ['9999999']
-      securityContext: {}
+        securityContext:
+          privileged: false
+          capabilities:
+            drop:
+              - ALL
+        resources:
+            limits:
+              cpu: '1'
+              memory: '1Gi'

--- a/test/system/kind.test.ts
+++ b/test/system/kind.test.ts
@@ -105,6 +105,14 @@ tap.test('Kubernetes-Monitor with KinD', async (t) => {
         'all properties are present in the workload metadata',
       );
       t.ok('agentId' in requestBody, 'agent ID is present in workload payload');
+      
+      const podSpec = requestBody.workloadMetadata.podSpec;
+      const resources = podSpec.containers[0].resources;
+      t.same(resources?.limits, { cpu: '1', memory: '1Gi' });
+
+      const securityContext = podSpec.containers[0].securityContext;
+      t.same(securityContext?.privileged, false);
+      t.same(securityContext?.capabilities?.drop, ['ALL']);
     });
 
   nock('https://kubernetes-upstream.snyk.io')

--- a/test/unit/supervisor/watchers.test.ts
+++ b/test/unit/supervisor/watchers.test.ts
@@ -32,6 +32,8 @@ tap.test('isKubernetesInternalNamespace', async (t) => {
     'kube-public is a k8s internal namespace');
   t.ok(watchers.isKubernetesInternalNamespace('kube-system'),
     'kube-system is a k8s internal namespace');
+  t.ok(watchers.isKubernetesInternalNamespace('local-path-storage'),
+    'local-path-storage is a k8s internal namespace');
   t.ok(watchers.isKubernetesInternalNamespace('openshift-apiserver'),
     'openshift-apiserver is a k8s internal namespace');
   t.ok(watchers.isKubernetesInternalNamespace('openshift-apiserver-operator'),


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

PodSpec is now read from Pods instead of the workloads.

This is a workaround for cases where the workload is a Custom Resource, which snyk-monitor today does not support and cannot read them.
There are situations where we will misreport the securityContext because we tried to read it from the wrong workload.

The Pod's spec is an identical copy to the one defined in the workload, so we can use it for collecting the workload information that we need - this way we can track workload security configuration even if the Pods are managed by a Custom Resource.

### More information

- [ZenDesk #7587](https://snyk.zendesk.com/agent/tickets/7587)

**Working example**
Normally if there is a Deployment we will have the following chain of resources:
```
Deployment -> ReplicaSet -> Pod
```
snyk-monitor inspects the Pod and then starts walking up the parent references (ReplicaSet and then Deployment) to try and understand the actual workload. Since the Deployment is last, we choose it to be the workload. We then read the Deployment's configuration (resources, securityContext, etc.).

If we have a Custom Resource, there can be a chain like this:
```
CustomResource -> ReplicaSet -> Pod
```
snyk-monitor does not support custom resources so when inspecting the parents it will stop at the ReplicaSet. The problem is that the ReplicaSet configuration (resources, securityContext) may be empty/wrong/incomplete so we would be reading the _wrong_ data.
