### PR TITLE
chore: pin semantic-release to unblock releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -752,7 +752,7 @@ jobs:
                     unset CI_PULL_REQUEST &&
                     unset CI_PULL_REQUESTS &&
                     unset CIRCLE_PULL_REQUESTS &&
-                    npx semantic-release &&
+                    npx semantic-release@17.2.2 &&
                     NEW_VERSION=`cat ./package.json | jq -r '.version'` &&
                     ./scripts/docker/approve-image.sh $NEW_VERSION
                 name: Tag and push

--- a/.circleci/config/jobs/@jobs.yml
+++ b/.circleci/config/jobs/@jobs.yml
@@ -320,7 +320,7 @@ tag_and_push:
           unset CI_PULL_REQUEST &&
           unset CI_PULL_REQUESTS &&
           unset CIRCLE_PULL_REQUESTS &&
-          npx semantic-release &&
+          npx semantic-release@17.2.2 &&
           NEW_VERSION=`cat ./package.json | jq -r '.version'` &&
           ./scripts/docker/approve-image.sh $NEW_VERSION
     - run:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The recent 17.2.3 release has a bug and cannot process credentials with symbols like ( or * and breaks our builds. Pin to an earlier version just to unblock the pipeline.

### More information

- [Slack thread](https://snyk.slack.com/archives/CLW30N31V/p1605775915070700)
