### PR TITLE
chore: add missing closing brace to script and add quotes around params

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,7 +465,7 @@ jobs:
 
                     REPLACES_VERSION=${OPERATOR_VERSION}
 
-                    OPERATOR_DIR=$(python scripts/operator/package_operator_bundle.py ${LATEST_TAG} ${LATEST_TAG} ${LATEST_TAG} ${REPLACES_VERSION}
+                    OPERATOR_DIR=$(python scripts/operator/package_operator_bundle.py "${LATEST_TAG}" "${LATEST_TAG}" "${LATEST_TAG}" "${REPLACES_VERSION}")
 
                     export QUAY_TOKEN=$(python ./scripts/operator/get_quay_token.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}")
 

--- a/.circleci/config/jobs/operator_upgrade_tests.yml
+++ b/.circleci/config/jobs/operator_upgrade_tests.yml
@@ -147,7 +147,7 @@ steps:
 
         REPLACES_VERSION=${OPERATOR_VERSION}
 
-        OPERATOR_DIR=$(python scripts/operator/package_operator_bundle.py ${LATEST_TAG} ${LATEST_TAG} ${LATEST_TAG} ${REPLACES_VERSION}
+        OPERATOR_DIR=$(python scripts/operator/package_operator_bundle.py "${LATEST_TAG}" "${LATEST_TAG}" "${LATEST_TAG}" "${REPLACES_VERSION}")
 
         export QUAY_TOKEN=$(python ./scripts/operator/get_quay_token.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}")
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The missing closing brace `)` was causing CI failures

