### PR TITLE
chore: add missing npm script to fix `npm t`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "scripts": {
     "pretest": "./scripts/docker/build-image.sh",
-    "test": "npm run lint && npm run build && npm run test:unit && npm run test:integration",
+    "test": "npm run lint && npm run build && npm run test:unit && npm run test:integration:kind:helm",
     "test:unit": "NODE_ENV=test tap test/unit --timeout=300",
     "test:system": "tap test/system --timeout=600",
     "test:integration:kind:yaml": "DEPLOYMENT_TYPE=YAML TEST_PLATFORM=kind CREATE_CLUSTER=true tap test/integration/kubernetes.test.ts --timeout=900",


### PR DESCRIPTION
`test:integration` was missing; this redirects it to most useful fast integration test for convenience of testing via `npm t`. This is a benefit to local dev, since `npm t` isn't currently used in CI

- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

