### PR TITLE
feat:support storage in PVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ To lower `snyk-monitor`'s logging verbosity `log_level` value could be set to on
 
 By default, `log_level` is `'INFO'`.
 
+## Using a PVC ##
+
+By default, `snyk-monitor` uses an emptyDir for temporary storage. If you prefer to have a PVC that uses a statically or
+ dynamically provisioned PV that you have created, then set the following value
+* `pvc.enabled` `true`
+
+The PVC's name defaults to `snyk-monitor-pvc`. If you prefer to override this, then use the following value:
+* `pvc.name`
+
 ## Terms and conditions ##
 
 *The Snyk Container Kubernetes integration uses Red Hat UBI (Universal Base Image).*

--- a/package-lock.json
+++ b/package-lock.json
@@ -591,6 +591,11 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+    },
     "aws-sdk": {
       "version": "2.797.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.797.0.tgz",
@@ -1659,6 +1664,17 @@
       "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=",
       "dev": true
     },
+    "fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      }
+    },
     "fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -1776,8 +1792,7 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -2277,6 +2292,22 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
+      }
     },
     "jsonpath-plus": {
       "version": "0.19.0",
@@ -5263,6 +5294,11 @@
           }
         }
       }
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
     },
     "uri-js": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "aws-sdk": "^2.633.0",
     "bunyan": "^1.8.13",
     "child-process-promise": "^2.2.1",
+    "fs-extra": "^9.0.1",
     "lru-cache": "^5.1.1",
     "needle": "^2.5.0",
     "sleep-promise": "^8.0.1",

--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -142,6 +142,15 @@ helm upgrade --install snyk-monitor snyk-charts/snyk-monitor \
   --set log_level="WARN"
 ```
 
+## Using a PVC ##
+
+By default, `snyk-monitor` uses an emptyDir for temporary storage. If you prefer to have a PVC that uses a statically or
+ dynamically provisioned PV that you have created, then set the following value
+* `pvc.enabled` `true`
+
+The PVC's name defaults to `snyk-monitor-pvc`. If you prefer to override this, then use the following value:
+* `pvc.name`
+
 ## PodSecurityPolicies
 **This should not be used when installing on OpenShift.**
 

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -20,6 +20,13 @@ spec:
     spec:
       serviceAccountName: {{ include "snyk-monitor.name" . }}
       restartPolicy: Always
+      initContainers:
+        - name: volume-permissions
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          command : ['sh', '-c', 'chmod -R 777 /var/tmp']
+          volumeMounts:
+            - name: temporary-storage
+              mountPath: "/var/tmp"
       containers:
         - name: {{ include "snyk-monitor.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -83,8 +90,13 @@ spec:
               - key: dockercfg.json
                 path: config.json
         - name: temporary-storage
+          {{- if .Values.pvc.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.pvc.name }}
+          {{- else }}
           emptyDir:
             sizeLimit: {{ .Values.temporaryStorageSize }}
+          {{- end }}
         - name: ssl-certs
           configMap:
             name: {{ .Values.certsConfigMap }}

--- a/snyk-monitor/templates/pvc.yaml
+++ b/snyk-monitor/templates/pvc.yaml
@@ -1,0 +1,13 @@
+{{ if .Values.pvc.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.pvc.name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: {{ .Values.temporaryStorageSize }}
+{{ end }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -22,14 +22,24 @@ image:
   tag: IMAGE_TAG_OVERRIDE_WHEN_PUBLISHING
   pullPolicy: Always
 
+# If deploying in an air-gapped environment that can't pull from DockerHub, override the initContainer's image here for one that is accessible to your environment.
+initContainerImage:
+  repository: busybox
+  tag: latest
+
 # The snyk-monitor requires knowing the cluster name so that it can organise
 # scanned workloads. The Kubernetes API does not provide an API to query this.
 # Set the name of the cluster, otherwise the snyk-monitor will set this to a default value.
 clusterName: ""
 
 # The snyk-monitor requires disk storage to temporarily pull container images and to scan them for vulnerabilities.
-# This value controls how much disk storage _at most_ may be allocated for the snyk-monitor. The snyk-monitor mounts an emptyDir for storage.
-temporaryStorageSize: 50Gi
+# This value controls how much disk storage _at most_ may be allocated for the snyk-monitor. Unless overridden by the `pvc` value, the snyk-monitor mounts an emptyDir for storage.
+temporaryStorageSize: 50Gi #  Applies to PVC too
+
+# Change to true to use a PVC instead of emptyDir for local storage
+pvc:
+  enabled: false
+  name: 'snyk-monitor-pvc'
 
 # CPU/Mem requests and limits for snyk-monitor
 requests:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
+import { emptyDirSync } from 'fs-extra';
+
 import * as SourceMapSupport from 'source-map-support';
 
 import * as state from './state';
+import * as config from './common/config';
 import logger = require('./common/logger');
 import { currentClusterName } from './supervisor/cluster';
 import { beginWatchingWorkloads } from './supervisor/watchers';
@@ -33,6 +36,16 @@ process.on('unhandledRejection', (reason) => {
   }
 });
 
+function cleanUpTempStorage() {
+  const { IMAGE_STORAGE_ROOT } = config;
+  try {
+    emptyDirSync(IMAGE_STORAGE_ROOT);
+    logger.info({}, 'Cleaned temp storage');
+  } catch (err) {
+    logger.error({ err }, 'Error deleting files');
+  }
+};
+
 function monitor(): void {
   try {
     logger.info({cluster: currentClusterName}, 'starting to monitor');
@@ -44,4 +57,5 @@ function monitor(): void {
 }
 
 SourceMapSupport.install();
+cleanUpTempStorage();
 monitor();

--- a/test/system/kind.test.ts
+++ b/test/system/kind.test.ts
@@ -1,3 +1,5 @@
+import * as sinon from 'sinon';
+import * as fsExtra from 'fs-extra';
 import * as tap from 'tap';
 import * as nock from 'nock';
 import * as sleep from 'sleep-promise';
@@ -18,6 +20,8 @@ async function tearDown() {
 tap.tearDown(tearDown);
 
 tap.test('Kubernetes-Monitor with KinD', async (t) => {
+
+  const emptyDirSyncStub = sinon.stub(fsExtra, 'emptyDirSync').returns({});
 
   // Start fresh
   try {
@@ -161,6 +165,8 @@ tap.test('Kubernetes-Monitor with KinD', async (t) => {
 
   // Start the monitor
   require('../../src');
+
+  sinon.assert.called(emptyDirSyncStub);
 
   // TODO: replace with being event driven?
   // will still need SOME timeout 


### PR DESCRIPTION
[RUN-1250] Update helm templates to allow for a `pvc` value. When set, this replaces emptyDir with a PVC, backed by a PV whose provsiioning is handled separately

- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation) (inline docs done, rest to follow)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Allows users to store temporary files in custom storage via a PVC, rather than needing an empty node.

### Notes for the reviewer

see slack channel # run-1250-demo

### More information

[RUN-1250]

### Screenshots

see slack channel # run-1250-demo



[RUN-1250]: https://snyksec.atlassian.net/browse/RUN-1250
[RUN-1250]: https://snyksec.atlassian.net/browse/RUN-1250