### PR TITLE
docs: Remove invalid command

### DIFF
--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -87,12 +87,6 @@ helm upgrade --install snyk-monitor snyk-charts/snyk-monitor --namespace snyk-mo
 To better organise the data scanned inside your cluster, the monitor requires a cluster name to be set.
 Replace the value of `clusterName` with the name of your cluster.
 
-
-For Helm 3, you may run the following:
-```shell
-helm upgrade --generate-name --install snyk-monitor snyk-charts/snyk-monitor --namespace snyk-monitor --set clusterName="Production cluster"
-```
-
 ## Setting up proxying ##
 
 Proxying traffic through a forwarding proxy can be achieved by setting the following values in the Helm chart:


### PR DESCRIPTION
In v3.4, --generate-name is a valid flag for `helm install` but not for `helm upgrade --install`. Running the v2 version of the command, as in the previous paragraph, still seems to work in v3.

![Screenshot 2020-11-25 at 12 18 01](https://user-images.githubusercontent.com/73909150/100226894-43e90f80-2f18-11eb-9fc8-29e5bf679879.png)
