### PR TITLE
docs: Update helm installation command

### DIFF
--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -72,10 +72,10 @@ kubectl create configmap snyk-monitor-registries-conf -n snyk-monitor --from-fil
 
 ## Installation from Helm repo ##
 
-Add Snyk's Helm repo:
+Add the latest version of Snyk's Helm repo:
 
 ```shell
-helm repo add snyk-charts https://snyk.github.io/kubernetes-monitor/
+helm repo add snyk-charts https://snyk.github.io/kubernetes-monitor/ --force-update
 ```
 
 Run the following command to launch the Snyk monitor in your cluster:


### PR DESCRIPTION
If any older version of the snyk helm repo is already present on the local machine, the current `helm repo add` command will not modify it, meaning the subsequent call to `helm upgrade --install` will use the latest _local_ chart, which may not be the latest _actual_ release. Adding `--force-update` as per this PR will ensure that the local repo is updated to include the latest actual release.
