### PR TITLE
feat: Add OpenShift configuration for supporting PVC storage

### DIFF
--- a/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
@@ -20,7 +20,15 @@ metadata:
             "integrationApi": "",
             "monitorSecrets": "snyk-monitor",
             "scope": "Cluster",
-            "temporaryStorageSize": "50Gi"
+            "temporaryStorageSize": "50Gi",
+            "pvc": {
+              "enabled": false,
+              "name": "snyk-monitor-pvc"
+            },
+            "initContainerImage": {
+              "repository": "busybox",
+              "tag": "latest"
+            }
           }
         }
       ]
@@ -50,6 +58,9 @@ spec:
             version: v1
           - kind: Secret
             name: snyk-monitor
+            version: v1
+          - kind: PersistentVolumeClaim
+            name: snyk-monitor-pvc
             version: v1
         specDescriptors:
           - description: >-
@@ -103,6 +114,30 @@ spec:
             path: image.tag
             x-descriptors:
             - 'urn:alm:descriptor:text'
+          - description: >-
+              True to use a PVC for temporary storage, false to use emptyDir.
+            displayName: PVC enabled
+            path: pvc.enabled
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+          - description: >-
+              The name of the PVC, when enabled.
+            displayName: PVC name
+            path: pvc.name
+            x-descriptors:
+              - 'urn:alm:descriptor:text'
+          - description: >-
+              The repo to use for initContainer, if overriding.
+            displayName: InitContainer image repo
+            path: initContainerImage.repository
+            x-descriptors:
+              - 'urn:alm:descriptor:text'
+          - description: >-
+              The tag for the initContainer's image.
+            displayName: InitContainer image tag
+            path: initContainerImage.tag
+            x-descriptors:
+              - 'urn:alm:descriptor:text'
   description: |-
     A Kubernetes Operator for creating and managing Snyk Kubernetes controller instances.
 
@@ -142,6 +177,7 @@ spec:
           - secrets
           - services
           - pods
+          - persistentvolumeclaims
           verbs:
           - '*'
         - apiGroups:

--- a/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snykmonitors.charts.helm.k8s.io.crd.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snykmonitors.charts.helm.k8s.io.crd.yaml
@@ -46,6 +46,20 @@ spec:
               type: string
             temporaryStorageSize:
               type: string
+            pvc:
+              properties:
+                enabled:
+                  type: boolean
+                name:
+                  type: string
+              type: object
+            initContainerImage:
+              properties:
+                repository:
+                  type: string
+                tag:
+                  type: string
+              type: object
   # "version" will be deprecated in apiextensions.k8s.io/v1
   version: v1alpha1
   versions:

--- a/test/fixtures/operator/custom-resource-k8s.yaml
+++ b/test/fixtures/operator/custom-resource-k8s.yaml
@@ -6,3 +6,5 @@ metadata:
 spec:
   integrationApi: https://kubernetes-upstream.dev.snyk.io
   temporaryStorageSize: 20Gi
+  pvc:
+    enabled: true

--- a/test/fixtures/operator/custom-resource.yaml
+++ b/test/fixtures/operator/custom-resource.yaml
@@ -6,3 +6,5 @@ metadata:
 spec:
   integrationApi: https://kubernetes-upstream.dev.snyk.io
   temporaryStorageSize: 20Gi
+  pvc:
+    enabled: true


### PR DESCRIPTION
feat: Add OpenShift configuration for supporting PVC storage

This was previously exposed via Helm, now making it available for the Operator installation as well.

This change allows both the PVC storage to be enabled and the initContainer image to be configured.