### PR TITLE
Chore/ci fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,6 +407,18 @@ jobs:
                 name: Package Operator Bundle and push to Quay
             - run:
                 command: |
+                    set +e
+                    kubectl patch customresourcedefinition snykmonitors.charts.helm.k8s.io -p '{"metadata":{"finalizers":[]}}' --type=merge -n snyk-monitor
+                    kubectl patch snykmonitors.charts.helm.k8s.io snyk-monitor -p '{"metadata":{"finalizers":[]}}' --type=merge -n snyk-monitor
+                    kubectl delete customresourcedefinition snykmonitors.charts.helm.k8s.io
+                    kubectl delete operatorsource snyk-operator -n openshift-marketplace
+                    kubectl delete clusterrolebinding snyk-monitor
+                    kubectl delete clusterrole snyk-monitor
+                    kubectl delete namespace services
+                    kubectl delete namespace snyk-monitor
+                name: Remove existing cluster resources if present
+            - run:
+                command: |
                     set -xo pipefail
                     set +e
 

--- a/.circleci/config/jobs/operator_upgrade_tests.yml
+++ b/.circleci/config/jobs/operator_upgrade_tests.yml
@@ -84,6 +84,19 @@ steps:
         operator-courier push "${OPERATOR_DIR}" "${QUAY_NAMESPACE}" "${PACKAGE_NAME}" "${OPERATOR_VERSION}" "${QUAY_TOKEN}"
 
   - run:
+      name: Remove existing cluster resources if present
+      command: |
+        set +e
+        kubectl patch customresourcedefinition snykmonitors.charts.helm.k8s.io -p '{"metadata":{"finalizers":[]}}' --type=merge -n snyk-monitor
+        kubectl patch snykmonitors.charts.helm.k8s.io snyk-monitor -p '{"metadata":{"finalizers":[]}}' --type=merge -n snyk-monitor
+        kubectl delete customresourcedefinition snykmonitors.charts.helm.k8s.io
+        kubectl delete operatorsource snyk-operator -n openshift-marketplace
+        kubectl delete clusterrolebinding snyk-monitor
+        kubectl delete clusterrole snyk-monitor
+        kubectl delete namespace services
+        kubectl delete namespace snyk-monitor
+
+  - run:
       name: Configure snyk-monitor namespace
       command: |
         set -xo pipefail

--- a/test/setup/index.ts
+++ b/test/setup/index.ts
@@ -35,7 +35,10 @@ export function snykMonitorNamespace(): string {
 }
 
 export async function removeMonitor(): Promise<void> {
-  await dumpLogs();
+  // Credentials may have expired on certain platforms (OpenShift 4), try to regenerate them.
+  await platforms[testPlatform].config().catch(() => undefined);
+  await dumpLogs().catch(() => undefined);
+
   try {
     if (createCluster) {
       await platforms[testPlatform].delete();


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Try to workaround an unknown issue with OpenShift where we do the following on test teardown:

- we get the snyk-monitor pod name
- we get the logs of that pod

The first command succeeds, the second one fails. No apparent reason or context... yet we want to avoid throwing which just results in an unhandled promise rejection.

Also, try to clean up cluster resources before doing OpenShift 4 upgrade tests.

### More information

- [CircleCI job: see "Integration tests OpenShift 4" step](https://app.circleci.com/pipelines/github/snyk/kubernetes-monitor/2434/workflows/1b9558e8-8197-4691-bbbf-5473be4ff677/jobs/12930)
