### PR TITLE
chore: install helm from package manager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,16 @@
 commands:
+    install_helm:
+        description: Install requests library
+        steps:
+            - run:
+                command: |
+                    export DEBIAN_FRONTEND=noninteractive
+                    curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+                    sudo apt-get install -y apt-transport-https
+                    echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+                    sudo apt-get update -qq
+                    sudo apt-get install -y helm
+                name: Install Helm
     install_python_requests:
         description: Install requests library
         steps:
@@ -556,6 +568,7 @@ jobs:
             - checkout
             - setup_remote_docker
             - install_python_requests
+            - install_helm
             - run:
                 command: |
                     LATEST_TAG_WITH_V=`git describe --abbrev=0 --tags ${CIRCLE_SHA1}` &&

--- a/.circleci/config/commands/install_helm.yml
+++ b/.circleci/config/commands/install_helm.yml
@@ -1,0 +1,11 @@
+description: Install requests library
+steps:
+  - run:
+      name: Install Helm
+      command: |
+        export DEBIAN_FRONTEND=noninteractive
+        curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+        sudo apt-get install -y apt-transport-https
+        echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+        sudo apt-get update -qq
+        sudo apt-get install -y helm

--- a/.circleci/config/jobs/@jobs.yml
+++ b/.circleci/config/jobs/@jobs.yml
@@ -365,6 +365,7 @@ publish:
     - checkout
     - setup_remote_docker
     - install_python_requests
+    - install_helm
     - run:
         name: Publish
         command: |

--- a/scripts/publish-gh-pages.sh
+++ b/scripts/publish-gh-pages.sh
@@ -28,9 +28,9 @@ sed -i "s/IMAGE_TAG_OVERRIDE_WHEN_PUBLISHING/${NEW_TAG}/g" ./snyk-monitor/values
 sed -i "s/IMAGE_TAG_OVERRIDE_WHEN_PUBLISHING/${NEW_TAG}/g" ./snyk-monitor-deployment.yaml
 
 echo building new helm release
-./helm init --client-only
-./helm package snyk-monitor --version ${NEW_TAG}
-./helm repo index .
+helm init --client-only
+helm package snyk-monitor --version ${NEW_TAG}
+helm repo index .
 
 echo publishing to gh-pages
 git add index.yaml


### PR DESCRIPTION
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Install Helm during the release process and stop being dependant on a very outdated version of helm that was mysteriously living in `gh-pages` branch as a committed to SCM binary