### PR TITLE
fix: skip k8s jobs processing behind FF for debug purpose

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -75,6 +75,8 @@ spec:
             value: {{ .Values.no_proxy }}
           - name: LOG_LEVEL
             value: {{ .Values.log_level }}
+          - name: SKIP_K8S_JOBS
+            value: {{ .Values.skip_k8s_jobs }}
           {{- with .Values.envs }}
           {{- toYaml . | trim | nindent 10 -}}
           {{ end }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -62,6 +62,7 @@ limits:
 http_proxy:
 https_proxy:
 no_proxy:
+skip_k8s_jobs:
 
 # Override default (INFO) log level if less verbosity needed
 log_level:

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -21,4 +21,6 @@ delete process.env['HTTPS_PROXY'];
 delete process.env['HTTP_PROXY'];
 delete process.env['NO_PROXY'];
 
+config.SKIP_K8S_JOBS = process.env.SKIP_K8S_JOBS === 'true';
+
 export { config };

--- a/src/supervisor/watchers/index.ts
+++ b/src/supervisor/watchers/index.ts
@@ -26,6 +26,11 @@ function setupWatchesForNamespace(namespace: string): void {
   logger.info({namespace}, 'setting up namespace watch');
 
   for (const workloadKind of Object.values(WorkloadKind)) {
+    // Disable handling events for k8s Jobs for debug purposes
+    if (config.SKIP_K8S_JOBS === true && workloadKind === WorkloadKind.Job) {
+      continue;
+    }
+
     try {
       setupInformer(namespace, workloadKind);
     } catch (error) {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Skip k8s jobs processing behind FF for debug purpose
