### PR TITLE
feat: allow configuring PVC StorageClass name

### DIFF
--- a/snyk-monitor/templates/pvc.yaml
+++ b/snyk-monitor/templates/pvc.yaml
@@ -1,4 +1,7 @@
-{{ if .Values.pvc.enabled }}
+# We create a PVC only if the default PVC name has not changed.
+# If the name has changed, it means our users want to use their own pre-provisioned PVC.
+# In such cases it would be an error to create a PVC as it would result in a conflict - the PVC already exists.
+{{- if .Values.pvc.enabled }}{{- if eq .Values.pvc.name "snyk-monitor-pvc" }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -11,4 +14,4 @@ spec:
     requests:
       storage: {{ .Values.temporaryStorageSize }}
   storageClassName: {{ .Values.pvc.storageClassName }}
-{{ end }}
+{{- end }}{{- end }}

--- a/snyk-monitor/templates/pvc.yaml
+++ b/snyk-monitor/templates/pvc.yaml
@@ -10,4 +10,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.temporaryStorageSize }}
+  storageClassName: {{ .Values.pvc.storageClassName }}
 {{ end }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -39,7 +39,7 @@ temporaryStorageSize: 50Gi #  Applies to PVC too
 # Change to true to use a PVC instead of emptyDir for local storage
 pvc:
   enabled: false
-  name: 'snyk-monitor-pvc'
+  name: snyk-monitor-pvc
   storageClassName: null
 
 # Node.js in-container process memory enhancements

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -40,6 +40,7 @@ temporaryStorageSize: 50Gi #  Applies to PVC too
 pvc:
   enabled: false
   name: 'snyk-monitor-pvc'
+  storageClassName: null
 
 # Node.js in-container process memory enhancements
 envs:

--- a/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
@@ -23,7 +23,8 @@ metadata:
             "temporaryStorageSize": "50Gi",
             "pvc": {
               "enabled": false,
-              "name": "snyk-monitor-pvc"
+              "name": "snyk-monitor-pvc",
+              "storageClassName": null
             },
             "initContainerImage": {
               "repository": "busybox",
@@ -124,6 +125,12 @@ spec:
               The name of the PVC, when enabled.
             displayName: PVC name
             path: pvc.name
+            x-descriptors:
+              - 'urn:alm:descriptor:text'
+          - description: >-
+              The name of the StorageClass to use for the PVC, when enabled.
+            displayName: PVC StorageClass name
+            path: pvc.storageClassName
             x-descriptors:
               - 'urn:alm:descriptor:text'
           - description: >-

--- a/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snykmonitors.charts.helm.k8s.io.crd.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snykmonitors.charts.helm.k8s.io.crd.yaml
@@ -52,6 +52,8 @@ spec:
                   type: boolean
                 name:
                   type: string
+                storageClassName:
+                  type: string
               type: object
             initContainerImage:
               properties:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

For some users it is important to be able to configure the StorageClass of the PersistentVolumeClaim, as the default is not always the preferred option.

### More information

- [Jira ticket RUN-1377](https://snyksec.atlassian.net/browse/RUN-1377)
