### PR TITLE
feat: add quotes for .Values.skip_k8s_jobs, add tolerations

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
           - name: LOG_LEVEL
             value: {{ .Values.log_level }}
           - name: SKIP_K8S_JOBS
-            value: {{ .Values.skip_k8s_jobs }}
+            value: {{ quote .Values.skip_k8s_jobs }}
           {{- with .Values.envs }}
           {{- toYaml . | trim | nindent 10 -}}
           {{ end }}
@@ -120,5 +120,9 @@ spec:
             optional: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
adds quotes for the `.Values.skip_k8s_jobs` to avoid yaml `true`. 

Adds option for `tolerations` to handle preemtible nodes.