### PR TITLE
chore: delete Operators from Quay after tests complete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,21 @@ jobs:
                 name: Notify Slack on failure
                 when: on_fail
         working_directory: ~/kubernetes-monitor
+    delete_operators_from_quay:
+        docker:
+            - auth:
+                password: $DOCKERHUB_PASSWORD
+                username: $DOCKERHUB_USER
+              image: circleci/python:3.9
+        steps:
+            - checkout
+            - install_python_requests
+            - run:
+                command: |
+                    python3 scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
+                name: Delete Operators from Quay
+                when: always
+        working_directory: ~/kubernetes-monitor
     deploy_dev:
         docker:
             - auth:
@@ -334,11 +349,6 @@ jobs:
                     export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
                     .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:openshift4:operator
                 name: Integration tests OpenShift 4
-            - run:
-                command: |
-                    scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
-                name: Delete Operators from Quay
-                when: always
             - run:
                 command: |
                     ./scripts/slack/notify_failure_on_branch.py "${CIRCLE_BRANCH}" "${CIRCLE_JOB}" "${CIRCLE_BUILD_URL}" "${CIRCLE_PULL_REQUEST}" "${SLACK_WEBHOOK}"
@@ -946,6 +956,14 @@ workflows:
                 requires:
                     - build_image
                     - build_and_upload_operator
+            - delete_operators_from_quay:
+                filters:
+                    branches:
+                        only:
+                            - staging
+                requires:
+                    - integration_tests_operator_on_k8s
+                    - openshift4_integration_tests
             - tag_and_push:
                 filters:
                     branches:

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -79,6 +79,11 @@ workflows:
             - build_image
             - build_and_upload_operator
           <<: *staging_branch_only_filter
+      - delete_operators_from_quay:
+          requires:
+            - integration_tests_operator_on_k8s
+            - openshift4_integration_tests
+          <<: *staging_branch_only_filter
       - tag_and_push:
           requires:
             - build_image

--- a/.circleci/config/jobs/@jobs.yml
+++ b/.circleci/config/jobs/@jobs.yml
@@ -287,17 +287,28 @@ openshift4_integration_tests:
           export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
           .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:openshift4:operator
     - run:
-        name: Delete Operators from Quay
-        command: |
-          scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
-        when: always
-    - run:
         name: Notify Slack on failure
         command: |
           ./scripts/slack/notify_failure_on_branch.py "${CIRCLE_BRANCH}" "${CIRCLE_JOB}" "${CIRCLE_BUILD_URL}" "${CIRCLE_PULL_REQUEST}" "${SLACK_WEBHOOK}"
         when: on_fail
     - store_artifacts:
         path: /tmp/logs/test/integration/openshift4
+
+delete_operators_from_quay:
+  docker:
+    - image: circleci/python:3.9
+      auth:
+        username: $DOCKERHUB_USER
+        password: $DOCKERHUB_PASSWORD
+  working_directory: ~/kubernetes-monitor
+  steps:
+    - checkout
+    - install_python_requests
+    - run:
+        name: Delete Operators from Quay
+        command: |
+          python3 scripts/operator/delete_operators_from_quay.py "${QUAY_USERNAME}" "${QUAY_PASSWORD}"
+        when: always
 
 ######################## MERGE TO STAGING ########################
 tag_and_push:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Right now both the Operator on OpenShift and Operator on OLM tests depend on the same Operator being pushed to our Quay repository. Unfortunately the OpenShift tests delete the Operators from Quay once the test finishes, which interferes with the other test.

This ensures that the Operators are deleted only after both tests that depend on it complete.

