### PR TITLE
feat: restart k8s informers on error event (e.g idle connection)

### DIFF
--- a/src/supervisor/watchers/types.ts
+++ b/src/supervisor/watchers/types.ts
@@ -10,3 +10,5 @@ export enum PodPhase {
   // For some reason the state of the pod could not be obtained.
   Unknown = 'Unknown',
 }
+
+export const ECONNRESET_ERROR_CODE = 'ECONNRESET';


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Restart k8s informers on error event (e.g idle connection)