### PR TITLE
chore: pass process.env when calling child_process.exec()

### DIFF
--- a/test/helpers/exec.ts
+++ b/test/helpers/exec.ts
@@ -1,0 +1,13 @@
+import { exec, PromiseResult } from 'child-process-promise';
+
+/**
+ * It seems like there is an issue with Jest where changes to process.env are not persisted through
+ * calls to child_process.exec(). This causes env vars like KUBECONFIG to be lost and to fail our tests.
+ * For now use this wrapper to explicitly pass process.env as a workaround.
+ * https://github.com/facebook/jest/issues/9341
+ * https://github.com/facebook/jest/issues/9264
+ * https://snyk.slack.com/archives/CLW30N31V/p1612860708027800?thread_ts=1612856703.026500&cid=CLW30N31V
+ */
+export async function execWrapper(command: string): Promise<PromiseResult<string>> {
+  return await exec(command, { env: process.env });
+}

--- a/test/helpers/kubectl.ts
+++ b/test/helpers/kubectl.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child-process-promise';
+import { execWrapper as exec } from './exec';
 import { chmodSync, writeFileSync, existsSync, unlinkSync } from 'fs';
 import { platform } from 'os';
 import { resolve } from 'path';

--- a/test/integration/kubernetes.spec.ts
+++ b/test/integration/kubernetes.spec.ts
@@ -1,5 +1,4 @@
 import { CoreV1Api, KubeConfig, AppsV1Api } from '@kubernetes/client-node';
-import { exec } from 'child-process-promise';
 import { Fact, ScanResult } from 'snyk-docker-plugin';
 import * as setup from '../setup';
 import { WorkloadKind } from '../../src/supervisor/types';
@@ -11,6 +10,7 @@ import {
   validateUpstreamStoredScanResults,
 } from '../helpers/kubernetes-upstream';
 import * as kubectl from '../helpers/kubectl';
+import { execWrapper as exec } from '../helpers/exec';
 
 let integrationId: string;
 let namespace: string;

--- a/test/setup/deployers/helm-with-proxy.ts
+++ b/test/setup/deployers/helm-with-proxy.ts
@@ -1,9 +1,9 @@
-import { exec } from 'child-process-promise';
 import { platform } from 'os';
 import { existsSync, chmodSync } from 'fs';
 
 import { IDeployer, IImageOptions } from './types';
 import * as kubectl from '../../helpers/kubectl';
+import { execWrapper as exec } from '../../helpers/exec';
 
 const helmVersion = '3.0.0';
 const helmPath = './helm';

--- a/test/setup/deployers/helm.ts
+++ b/test/setup/deployers/helm.ts
@@ -1,8 +1,8 @@
-import { exec } from 'child-process-promise';
 import { platform } from 'os';
+import { existsSync, chmodSync } from 'fs';
 
 import { IDeployer, IImageOptions } from './types';
-import { existsSync, chmodSync } from 'fs';
+import { execWrapper as exec } from '../../helpers/exec';
 
 const helmVersion = '3.0.0';
 const helmPath = './helm';

--- a/test/setup/index.ts
+++ b/test/setup/index.ts
@@ -1,12 +1,12 @@
 import * as fs from 'fs';
 import * as sleep from 'sleep-promise';
 import * as uuidv4 from 'uuid/v4';
-import { exec } from 'child-process-promise';
 
 import platforms, { getKubernetesVersionForPlatform } from './platforms';
 import deployers from './deployers';
 import { IImageOptions } from './deployers/types';
 import * as kubectl from '../helpers/kubectl';
+import { execWrapper as exec } from '../helpers/exec';
 
 const testPlatform = process.env['TEST_PLATFORM'] || 'kind';
 const createCluster = process.env['CREATE_CLUSTER'] === 'true';

--- a/test/setup/platforms/eks.ts
+++ b/test/setup/platforms/eks.ts
@@ -1,7 +1,6 @@
-import { exec } from 'child-process-promise';
-
 import { throwIfEnvironmentVariableUnset } from './helpers';
 import * as kubectl from '../../helpers/kubectl';
+import { execWrapper as exec } from '../../helpers/exec';
 
 export async function validateRequiredEnvironment(): Promise<void> {
   console.log(

--- a/test/setup/platforms/kind.ts
+++ b/test/setup/platforms/kind.ts
@@ -1,7 +1,7 @@
-import { exec } from 'child-process-promise';
 import { accessSync, chmodSync, constants, writeFileSync } from 'fs';
 import { platform } from 'os';
 import { resolve } from 'path';
+import { execWrapper as exec } from '../../helpers/exec';
 
 const clusterName = 'kind';
 

--- a/test/setup/platforms/openshift4.ts
+++ b/test/setup/platforms/openshift4.ts
@@ -1,5 +1,4 @@
 import { Writable } from 'stream';
-import { exec } from 'child-process-promise';
 import { chmodSync, writeFileSync, existsSync } from 'fs';
 import { platform, tmpdir } from 'os';
 import { resolve } from 'path';
@@ -7,6 +6,7 @@ import * as needle from 'needle';
 
 import { throwIfEnvironmentVariableUnset } from './helpers';
 import * as kubectl from '../../helpers/kubectl';
+import { execWrapper as exec } from '../../helpers/exec';
 
 const OPENSHIFT_CLI_VERSION = '4.3.0';
 

--- a/test/system/kind.spec.ts
+++ b/test/system/kind.spec.ts
@@ -1,10 +1,11 @@
 import * as fsExtra from 'fs-extra';
 import * as nock from 'nock';
-import { exec } from 'child-process-promise';
 
 import * as kubectl from '../helpers/kubectl';
 import * as kind from '../setup/platforms/kind';
 import * as transmitterTypes from '../../src/transmitter/types';
+import { execWrapper as exec } from '../helpers/exec';
+
 /**
  * TODO graceful shutdown
  * We abruptly close the connection to the K8s API server during shutdown, which can result in exceptions.


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

It seems like there is an issue with Jest where changes to process.env are not persisted through calls to child_process.exec(). This causes env vars like KUBECONFIG to be lost and to fail our tests. For now use a wrapper to explicitly pass process.env as a workaround.

### More information

- [Investigation notes](https://snyk.slack.com/archives/CLW30N31V/p1612860708027800?thread_ts=1612856703.026500&cid=CLW30N31V)

