### PR TITLE
feat: load user-defined Rego rules for workload auto-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepare": "npm run build",
     "build": "tsc",
     "dev": "tsc-watch --project tsconfig.json --onSuccess 'node --inspect .'",
-    "debug": "tsc-watch --project tsconfig.json --onSuccess 'node --inspect --debug-brk .'",
+    "debug": "tsc-watch --project tsconfig.json --onSuccess 'node --inspect-brk .'",
     "lint": "eslint \"src/**/*.ts\" && (cd test && eslint \"**/*.ts\")"
   },
   "author": "snyk.io",

--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -34,6 +34,8 @@ spec:
           mountPath: "/srv/app/certs"
         - name: registries-conf
           mountPath: "/srv/app/.config/containers"
+        - name: workload-policies
+          mountPath: "/var/tmp/policies"
         env:
           - name: SNYK_INTEGRATION_ID
             valueFrom:
@@ -114,5 +116,9 @@ spec:
       - name: registries-conf
         configMap:
           name: snyk-monitor-registries-conf
+          optional: true
+      - name: workload-policies
+        configMap:
+          name: snyk-monitor-workload-policies
           optional: true
       serviceAccountName: snyk-monitor

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -49,6 +49,9 @@ spec:
             mountPath: "/var/tmp"
           - name: ssl-certs
             mountPath: "/srv/app/certs"
+          - name: workload-policies
+            mountPath: "/var/tmp/policies"
+            readOnly: true
           - name: registries-conf
             mountPath: "/srv/app/.config/containers"
           env:
@@ -113,6 +116,10 @@ spec:
         - name: ssl-certs
           configMap:
             name: {{ .Values.certsConfigMap }}
+            optional: true
+        - name: workload-policies
+          configMap:
+            name: {{ .Values.workloadPoliciesMap }}
             optional: true
         - name: registries-conf
           configMap:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -7,6 +7,7 @@
 monitorSecrets: snyk-monitor
 certsConfigMap: snyk-monitor-certs
 registriesConfConfigMap: snyk-monitor-registries-conf
+workloadPoliciesMap: snyk-monitor-workload-policies
 
 # One of: Cluster, Namespaced
 # Cluster - creates a ClusterRole and ClusterRoleBinding with the ServiceAccount

--- a/src/common/policy.ts
+++ b/src/common/policy.ts
@@ -1,0 +1,31 @@
+import { existsSync, readFile } from 'fs';
+import { resolve as resolvePath } from 'path';
+import { promisify } from 'util';
+
+import { logger } from './logger';
+import { constructWorkloadAutoImportPolicy } from '../transmitter/payload';
+import { sendWorkloadAutoImportPolicy } from '../transmitter';
+import { config } from './config';
+
+const readFileAsync = promisify(readFile);
+
+export async function loadAndSendWorkloadAutoImportPolicy(): Promise<void> {
+  try {
+    /** This path is set in snyk-monitor during installation/deployment and is defined in the Helm chart. */
+    const userProvidedRegoPolicyPath = resolvePath(
+      config.IMAGE_STORAGE_ROOT,
+      'policies',
+      'workload-auto-import.rego',
+    );
+    if (!existsSync(userProvidedRegoPolicyPath)) {
+      logger.info({}, 'Rego policy file does not exist, skipping loading');
+      return;
+    }
+
+    const regoPolicy = await readFileAsync(userProvidedRegoPolicyPath, 'utf8');
+    const payload = constructWorkloadAutoImportPolicy(regoPolicy);
+    await sendWorkloadAutoImportPolicy(payload);
+  } catch (err) {
+    logger.error({ err }, 'Unexpected error occurred while loading workload auto-import policy');
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { config } from './common/config';
 import { logger } from './common/logger';
 import { currentClusterName } from './supervisor/cluster';
 import { beginWatchingWorkloads } from './supervisor/watchers';
+import { loadAndSendWorkloadAutoImportPolicy } from './common/policy';
 
 process.on('uncaughtException', (err) => {
   if (state.shutdownInProgress) {
@@ -58,4 +59,9 @@ function monitor(): void {
 
 SourceMapSupport.install();
 cleanUpTempStorage();
-monitor();
+
+// Allow running in an async context
+setImmediate(async function setUpAndMonitor(): Promise<void> {
+  await loadAndSendWorkloadAutoImportPolicy();
+  monitor();
+});

--- a/src/transmitter/index.ts
+++ b/src/transmitter/index.ts
@@ -10,6 +10,7 @@ import {
   IRequestError,
   ScanResultsPayload,
   IDependencyGraphPayload,
+  WorkloadAutoImportPolicyPayload,
 } from './types';
 import { getProxyAgent } from './proxy';
 
@@ -67,6 +68,30 @@ export async function sendWorkloadMetadata(payload: IWorkloadMetadataPayload): P
     } catch (error) {
       logger.error({error, workloadLocator: payload.workloadLocator}, 'could not send workload metadata upstream');
     }
+}
+
+export async function sendWorkloadAutoImportPolicy(payload: WorkloadAutoImportPolicyPayload): Promise<void> {
+  try {
+    logger.info(
+      { userLocator: payload.userLocator, cluster: payload.cluster, agentId: payload.agentId },
+      'attempting to send workload auto-import policy',
+    );
+
+    const { response, attempt } = await retryRequest('post', `${upstreamUrl}/api/v1/policy`, payload);
+    if (!isSuccessStatusCode(response.statusCode)) {
+      throw new Error(`${response.statusCode} ${response.statusMessage}`);
+    }
+
+    logger.info(
+      { userLocator: payload.userLocator, cluster: payload.cluster, agentId: payload.agentId, attempt },
+      'workload auto-import policy sent upstream successfully',
+    );
+  } catch (error) {
+    logger.error(
+      { error, userLocator: payload.userLocator, cluster: payload.cluster, agentId: payload.agentId },
+      'could not send workload auto-import policy',
+    );
+  }
 }
 
 export async function deleteWorkload(payload: IDeleteWorkloadPayload): Promise<void> {

--- a/src/transmitter/payload.ts
+++ b/src/transmitter/payload.ts
@@ -12,6 +12,7 @@ import {
   IKubernetesMonitorMetadata,
   ScanResultsPayload,
   IDependencyGraphPayload,
+  WorkloadAutoImportPolicyPayload,
 } from './types';
 
 export function constructDepGraph(
@@ -122,6 +123,17 @@ export function constructDeleteWorkload(
       userLocator: config.INTEGRATION_ID,
       cluster: currentClusterName,
     },
+    agentId: config.AGENT_ID,
+  };
+}
+
+export function constructWorkloadAutoImportPolicy(
+  policy: string,
+): WorkloadAutoImportPolicyPayload {
+  return {
+    policy,
+    userLocator: config.INTEGRATION_ID,
+    cluster: currentClusterName,
     agentId: config.AGENT_ID,
   };
 }

--- a/src/transmitter/types.ts
+++ b/src/transmitter/types.ts
@@ -61,6 +61,13 @@ export interface IDeleteWorkloadPayload {
   agentId: string;
 }
 
+export interface WorkloadAutoImportPolicyPayload {
+  userLocator: string;
+  cluster: string;
+  agentId: string;
+  policy: string;
+}
+
 export interface IWorkload {
   type: string;
   name: string;

--- a/test/fixtures/workload-auto-import.rego
+++ b/test/fixtures/workload-auto-import.rego
@@ -1,0 +1,3 @@
+package snyk
+
+default workload_auto_import = false


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The Rego rules are loaded by snyk-monitor at the start of the application, the rules are verified, and finally they are transmitted to upstream.
We want the rules to be compiled and processed client-side but any choice whether workloads should be imported or deleted happens in the upstream.
Test coverage provided in system tests to ensure the policy is being transmitted first thing on start up of the application.

### Notes for the reviewer

Not updating the docs yet since the feature is not ready to be used (needs backend support).

### More information

- [Jira ticket RUN-1404](https://snyksec.atlassian.net/browse/RUN-1404)
