### PR TITLE
fix: cache workloads using uid instead of name as caching key

### DIFF
--- a/src/supervisor/watchers/handlers/pod.ts
+++ b/src/supervisor/watchers/handlers/pod.ts
@@ -69,7 +69,7 @@ function handleReadyPod(workloadMetadata: IWorkload[]): void {
   const imagesToScan: IWorkload[] = [];
   const imageKeys: string[] = [];
   for (const image of workloadMetadata) {
-    const imageKey = `${image.namespace}/${image.type}/${image.name}/${image.imageId}`;
+    const imageKey = `${image.namespace}/${image.type}/${image.uid}/${image.imageId}`;
     if (state.imagesAlreadyScanned.get(imageKey) !== undefined) {
       continue;
     }
@@ -110,7 +110,7 @@ export async function podWatchHandler(pod: V1Pod): Promise<void> {
     const workloadMember = workloadMetadata[0];
     const workloadMetadataPayload = constructWorkloadMetadata(workloadMember);
     const workloadLocator = workloadMetadataPayload.workloadLocator;
-    const workloadKey = `${workloadLocator.namespace}/${workloadLocator.type}/${workloadLocator.name}`;
+    const workloadKey = `${workloadLocator.namespace}/${workloadLocator.type}/${workloadMember.uid}`;
     const workloadRevision = workloadMember.revision ? workloadMember.revision.toString() : ''; // this is actually the observed generation
     if (state.workloadsAlreadyScanned.get(workloadKey) !== workloadRevision) { // either not exists or different
       state.workloadsAlreadyScanned.set(workloadKey, workloadRevision); // empty string takes zero bytes and is !== undefined


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This solves the case where a workload is added, deleted, and then added again. Snyk-monitor thinks the image for this workload has already been scanned (because we cache this internally by name), however, this is a completely new workload and needs to be re-scanned so the generated Project can be visible for import in Snyk. So use uid in the caching key instead of name, which ensures a completely new instance of the new workload will result in a new cache key.

### More information

- [Slack thread](https://snyk.slack.com/archives/C85H8Q12Q/p1612381109115500)
