### PR TITLE
fix: helm upgrade failed with pvc.enabled

### DIFF
--- a/snyk-monitor/templates/pvc.yaml
+++ b/snyk-monitor/templates/pvc.yaml
@@ -13,5 +13,11 @@ spec:
   resources:
     requests:
       storage: {{ .Values.temporaryStorageSize }}
-  storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- if .Values.pvc.storageClassName }}
+  {{- if (eq "-" .Values.pvc.storageClassName) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.pvc.storageClassName }}"
+  {{- end }}
+  {{- end }}
 {{- end }}{{- end }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -40,7 +40,14 @@ temporaryStorageSize: 50Gi #  Applies to PVC too
 pvc:
   enabled: false
   name: snyk-monitor-pvc
-  storageClassName: null
+  ## snyk-monitor data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClassName: "-"
 
 # Node.js in-container process memory enhancements
 envs:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

fix: helm upgrade failed with pvc.enabled but without pvc.storageClassName
related to Issue: #667 

### Notes for the reviewer

to test locally:
```bash
# set env variable ClusterName to name of you cluster:
export ClusterName=my-kubernetes-cluster
helm upgrade -i --namespace snyk-monitor snyk-monitor snyk-charts/snyk-monitor --set clusterName="$ClusterName" --set pvc.enabled=true
# and after installation trigger it again
helm upgrade -i --namespace snyk-monitor snyk-monitor snyk-charts/snyk-monitor --set clusterName="$ClusterName" --set pvc.enabled=true
```
without this fix, you will face with error:
```bash
# Error: UPGRADE FAILED: cannot patch "snyk-monitor-pvc" with kind PersistentVolumeClaim: PersistentVolumeClaim "snyk-monitor-pvc" is invalid: spec: Forbidden: is immutable after creation except resources.requests for bound claims
```

after this change all should work fine

### More information

- #667
- https://github.com/helm/charts/issues/20389#issuecomment-583854511
