### PR TITLE
fix: load Rego policy from a different location

### DIFF
--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -35,7 +35,8 @@ spec:
         - name: registries-conf
           mountPath: "/srv/app/.config/containers"
         - name: workload-policies
-          mountPath: "/var/tmp/policies"
+          mountPath: "/tmp/policies"
+          readOnly: true
         env:
           - name: SNYK_INTEGRATION_ID
             valueFrom:

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           - name: ssl-certs
             mountPath: "/srv/app/certs"
           - name: workload-policies
-            mountPath: "/var/tmp/policies"
+            mountPath: "/tmp/policies"
             readOnly: true
           - name: registries-conf
             mountPath: "/srv/app/.config/containers"

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -9,6 +9,7 @@ config.AGENT_ID = uuidv4();
 config.INTEGRATION_ID = config.INTEGRATION_ID.trim();
 config.CLUSTER_NAME = config.CLUSTER_NAME || 'Default cluster';
 config.IMAGE_STORAGE_ROOT = '/var/tmp';
+config.POLICIES_STORAGE_ROOT = '/tmp/policies';
 
 /**
  * Important: we delete the following env vars because we don't want to proxy requests to the Kubernetes API server.

--- a/src/common/policy.ts
+++ b/src/common/policy.ts
@@ -13,8 +13,7 @@ export async function loadAndSendWorkloadAutoImportPolicy(): Promise<void> {
   try {
     /** This path is set in snyk-monitor during installation/deployment and is defined in the Helm chart. */
     const userProvidedRegoPolicyPath = resolvePath(
-      config.IMAGE_STORAGE_ROOT,
-      'policies',
+      config.POLICIES_STORAGE_ROOT,
       'workload-auto-import.rego',
     );
     if (!existsSync(userProvidedRegoPolicyPath)) {

--- a/test/integration/kubernetes.spec.ts
+++ b/test/integration/kubernetes.spec.ts
@@ -516,6 +516,11 @@ test('snyk-monitor secure configuration is as expected', async () => {
           mountPath: '/srv/app/.docker',
           readOnly: true,
         }),
+        expect.objectContaining({
+          name: 'workload-policies',
+          mountPath: '/tmp/policies',
+          readOnly: true,
+        }),
       ]),
       env: expect.arrayContaining([{ name: 'HOME', value: '/srv/app' }]),
     }),

--- a/test/system/kind.spec.ts
+++ b/test/system/kind.spec.ts
@@ -25,6 +25,7 @@ const existsAsync = promisify(exists);
  *   Error: Client network socket disconnected before secure TLS connection was established
  */
 import { state as kubernetesMonitorState } from '../../src/state';
+import { tmpdir } from 'os';
 
 async function tearDown() {
   console.log('Begin removing the snyk-monitor...');
@@ -75,7 +76,7 @@ test('Kubernetes-Monitor with KinD', async (jestDoneCallback) => {
 
   // Create a copy of the policy file fixture in the location that snyk-monitor is expecting to load it from.
   const regoPolicyFixturePath = resolvePath('./test/fixtures/workload-auto-import.rego');
-  const expectedPoliciesPath = resolvePath('/var/tmp/policies');
+  const expectedPoliciesPath = resolvePath('/tmp/policies');
   if (!(await existsAsync(expectedPoliciesPath))) {
     await mkdirAsync(expectedPoliciesPath);
   }


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The Rego policy was mounted in the same location as the image temporary storage. Snyk Monitor tries to clean up this directory on start up (for the case where we get storage mounted with a bunch of extra files in it), so it also tried to delete the policies location. This resulted in an error and is also a mistake.

Swap the location from /var/tmp to /tmp.
