### PR TITLE
fix: use debug level when logging queue size

### DIFF
--- a/src/supervisor/watchers/handlers/pod.ts
+++ b/src/supervisor/watchers/handlers/pod.ts
@@ -47,9 +47,9 @@ setInterval(() => {
   try {
     const queueDataToReport: {[key: string]: any} = {};
     queueDataToReport.workloadsToScanLength = workloadsToScanQueue.length();
-    logger.info(queueDataToReport, 'queue sizes report');
+    logger.debug(queueDataToReport, 'queue sizes report');
   } catch (err) {
-    logger.warn({err}, 'failed logging queue sizes');
+    logger.debug({err}, 'failed logging queue sizes');
   }
 }, config.QUEUE_LENGTH_LOG_FREQUENCY_MINUTES * 60 * 1000).unref();
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This is mostly used for diagnostic purposes, we are normally not interested in this message and it pollutes the logs.
