### PR TITLE
fix: increase CPU limits from 1 to 2

### DIFF
--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -90,7 +90,7 @@ spec:
             cpu: '250m'
             memory: '400Mi'
           limits:
-            cpu: '1'
+            cpu: '2'
             memory: '2Gi'
         securityContext:
           privileged: false

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -65,7 +65,7 @@ requests:
   memory: '400Mi'
 
 limits:
-  cpu: '1'
+  cpu: '2'
   memory: '2Gi'
 
 http_proxy:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Based on some prior research in https://github.com/snyk/ops/commit/66686e7106f3d88fd8040a2b2fc6aad302c84b8e we believe some performance problems are caused by kubernetes limiting the CPU when Node.js needs more. The theory is because of GC. It's also possible because we shell out to other processes (skopeo). The snyk-monitor also runs as Burstable instead of Guaranteed.

Raising the limit doesn't affect kubernetes' placement rules, and (because cpu is inherently overcommittable) shouldn't cause any new exciting death cases.

### More information

- [Slack thread](https://snyk.slack.com/archives/CGSNWAE76/p1615363773057800)
