### PR TITLE
chore: update dep-graph lib to remove lodash vulns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1665,17 +1665,46 @@
       "dev": true
     },
     "@snyk/dep-graph": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.21.0.tgz",
-      "integrity": "sha512-+xwiU1zw+Z1V6RaIL7oWUqZo8jDIpoKfzvv8xGiq0hYxsiP9tGSUNuFXwQzAFEP60kJyD2a/nptdRPjsKD0jPw==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.27.1.tgz",
+      "integrity": "sha512-YevGMdKdmiybrpISvkp8qk84elAxr0vmLuHyB3ijHlhSZVhRtCBmDeHmavHc4E9Xv4RWZF+oT5PfcuNvnmph/w==",
       "requires": {
-        "graphlib": "^2.1.8",
+        "event-loop-spinner": "^2.1.0",
+        "lodash.clone": "^4.5.0",
+        "lodash.constant": "^3.0.0",
+        "lodash.filter": "^4.6.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
         "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.keys": "^4.2.0",
+        "lodash.map": "^4.6.0",
+        "lodash.reduce": "^4.6.0",
+        "lodash.size": "^4.2.0",
+        "lodash.transform": "^4.6.0",
+        "lodash.union": "^4.6.0",
+        "lodash.values": "^4.3.0",
         "object-hash": "^2.0.3",
         "semver": "^6.0.0",
         "tslib": "^1.13.0"
       },
       "dependencies": {
+        "event-loop-spinner": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/event-loop-spinner/-/event-loop-spinner-2.1.0.tgz",
+          "integrity": "sha512-RJ10wL8/F9AlfBgRCvYctJIXSb9XkVmSCK3GGUvPD3dJrvTjDeDT0tmhcbEC6I2NEjNM9xD38HQJ4F/f/gb4VQ==",
+          "requires": {
+            "tslib": "^2.1.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+              "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+            }
+          }
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -4286,14 +4315,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
-    "graphlib": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
-      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
-      "requires": {
-        "lodash": "^4.17.15"
-      }
-    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -6811,7 +6832,8 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "lodash.clone": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "private": true,
   "dependencies": {
     "@kubernetes/client-node": "^0.14.0",
-    "@snyk/dep-graph": "^1.21.0",
+    "@snyk/dep-graph": "^1.27.1",
     "@types/child-process-promise": "^2.2.1",
     "@types/lru-cache": "^5.1.0",
     "@types/needle": "^2.0.4",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Update `@snyk/dep-graph` to 1.27.1 to remove lodash vulns


Same as https://github.com/snyk/kubernetes-monitor/pull/682, but contains `package.json` change