### PR TITLE
fix: introduce pvc.create flag in Helm chart

### DIFF
--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -140,10 +140,19 @@ helm upgrade --install snyk-monitor snyk-charts/snyk-monitor \
 
 By default, `snyk-monitor` uses an emptyDir for temporary storage. If you prefer to have a PVC that uses a statically or
  dynamically provisioned PV that you have created, then set the following value
-* `pvc.enabled` `true`
+* `pvc.enabled`=`true`
+
+If you would also like to create the PVC (if not using an existing one) then set the following value
+* `pvc.create`=`true`
 
 The PVC's name defaults to `snyk-monitor-pvc`. If you prefer to override this, then use the following value:
 * `pvc.name`
+
+For example, run the following for first-time setup:
+`--set pvc.enabled=true --pvc.create=true`
+
+And run the following for subsequent upgrades:
+`--set pvc.enabled=true`
 
 ## PodSecurityPolicies
 **This should not be used when installing on OpenShift.**

--- a/snyk-monitor/templates/pvc.yaml
+++ b/snyk-monitor/templates/pvc.yaml
@@ -1,7 +1,5 @@
-# We create a PVC only if the default PVC name has not changed.
-# If the name has changed, it means our users want to use their own pre-provisioned PVC.
-# In such cases it would be an error to create a PVC as it would result in a conflict - the PVC already exists.
-{{- if .Values.pvc.enabled }}{{- if eq .Values.pvc.name "snyk-monitor-pvc" }}
+# We create a PVC only if requested.
+{{- if .Values.pvc.enabled }}{{- if .Values.pvc.create }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -37,10 +37,12 @@ clusterName: ""
 # This value controls how much disk storage _at most_ may be allocated for the snyk-monitor. Unless overridden by the `pvc` value, the snyk-monitor mounts an emptyDir for storage.
 temporaryStorageSize: 50Gi #  Applies to PVC too
 
-# Change to true to use a PVC instead of emptyDir for local storage
+# Change "enabled" to true to use a PVC instead of emptyDir for local storage.
+# Change "create" to true if you want to create the PVC (useful for first time run).
 pvc:
   enabled: false
   name: snyk-monitor-pvc
+  create: false
   ## snyk-monitor data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning

--- a/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
@@ -23,6 +23,7 @@ metadata:
             "temporaryStorageSize": "50Gi",
             "pvc": {
               "enabled": false,
+              "create": false,
               "name": "snyk-monitor-pvc",
               "storageClassName": null
             },
@@ -119,6 +120,12 @@ spec:
               True to use a PVC for temporary storage, false to use emptyDir.
             displayName: PVC enabled
             path: pvc.enabled
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+          - description: >-
+              True to create the PVC, false to reference it (in cases it already exists).
+            displayName: Create PVC
+            path: pvc.create
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
           - description: >-

--- a/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snykmonitors.charts.helm.k8s.io.crd.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snykmonitors.charts.helm.k8s.io.crd.yaml
@@ -50,6 +50,8 @@ spec:
               properties:
                 enabled:
                   type: boolean
+                create:
+                  type: boolean
                 name:
                   type: string
                 storageClassName:

--- a/test/fixtures/operator/custom-resource-k8s.yaml
+++ b/test/fixtures/operator/custom-resource-k8s.yaml
@@ -8,3 +8,4 @@ spec:
   temporaryStorageSize: 20Gi
   pvc:
     enabled: true
+    create: true

--- a/test/fixtures/operator/custom-resource.yaml
+++ b/test/fixtures/operator/custom-resource.yaml
@@ -8,3 +8,4 @@ spec:
   temporaryStorageSize: 20Gi
   pvc:
     enabled: true
+    create: true

--- a/test/setup/deployers/helm.ts
+++ b/test/setup/deployers/helm.ts
@@ -33,6 +33,7 @@ async function deployKubernetesMonitor(
       '--set nodeSelector."kubernetes\\.io/os"=linux ' +
       '--set psp.enabled=true ' + 
       '--set pvc.enabled=true ' +
+      '--set pvc.create=true ' +
       '--set log_level="INFO"'
   );
   console.log(`Deployed ${imageOptions.nameAndTag} with pull policy ${imageOptions.pullPolicy}`);


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This fixes a conflict where the PVC cannot be re-created because it already exists.
Add a flag `pvc.create` to control whether or not the PVC should be created or an existing one should be used.

```json
{
  "level": "error",
  "ts": 1617036694.7158043,
  "logger": "controller-runtime.controller",
  "msg": "Reconciler error",
  "controller": "snykmonitor-controller",
  "request": "snyk-monitor/snyk-monitor",
  "error": "failed to get candidate release: rendered manifests contain a new resource that already exists. Unable to continue with update: existing resource conflict: kind: PersistentVolumeClaim, namespace: snyk-monitor, name: snyk-monitor-pvc",
  "stacktrace": "github.com/go-logr/zapr.(*zapLogger).Error\n\tpkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:258\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\tpkg/mod/k8s.io/apimachinery@v0.0.0-20191004115801-a2eda9f80ab8/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\tpkg/mod/k8s.io/apimachinery@v0.0.0-20191004115801-a2eda9f80ab8/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\tpkg/mod/k8s.io/apimachinery@v0.0.0-20191004115801-a2eda9f80ab8/pkg/util/wait/wait.go:88"
}

```