### PR TITLE
fix: upgrade K8s client library to add Keep Alive to watches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN chmod 755 /usr/bin/dumb-init
 RUN groupadd -g 10001 snyk
 RUN useradd -g snyk -d /srv/app -u 10001 snyk
 
+# @kubernetes/client-node@0.14.2 started using net-keepalive, which requires the following packages to build modules
+RUN yum --disableplugin=subscription-manager install -y make gcc gcc-c++
+
 WORKDIR /srv/app
 
 COPY --chown=snyk:snyk --from=skopeo-build /usr/bin/skopeo /usr/bin/skopeo
@@ -49,6 +52,8 @@ ADD --chown=snyk:snyk package.json package-lock.json ./
 RUN mkdir -p .config
 
 RUN npm install
+
+RUN yum remove -y make gcc gcc-c++
 
 # add the rest of the app files
 ADD --chown=snyk:snyk . .

--- a/package-lock.json
+++ b/package-lock.json
@@ -1581,9 +1581,9 @@
       }
     },
     "@kubernetes/client-node": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.14.0.tgz",
-      "integrity": "sha512-/37JHuEUAQ5GQ4kLKBmCYvGgf5W1KZWKreKGWFYH8VvT2Hl/o0aJZasu2w0EHEfmE11JCn0X9arVmOTyVCYvww==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.14.2.tgz",
+      "integrity": "sha512-0/E6xXDL+qTpS8XCZBnuwbco9Q87NisQwN0TUEk3rR7g6RxlH+lv9E6pJhcoocFnDFstu24b3U6bIsHbCTd8kA==",
       "requires": {
         "@types/js-yaml": "^3.12.1",
         "@types/node": "^10.12.0",
@@ -1597,6 +1597,7 @@
         "isomorphic-ws": "^4.0.1",
         "js-yaml": "^3.13.1",
         "jsonpath-plus": "^0.19.0",
+        "net-keepalive": "2.0.4",
         "openid-client": "^4.1.1",
         "request": "^2.88.0",
         "rfc4648": "^1.3.0",
@@ -2033,9 +2034,9 @@
       }
     },
     "@types/underscore": {
-      "version": "1.10.24",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.10.24.tgz",
-      "integrity": "sha512-T3NQD8hXNW2sRsSbLNjF/aBo18MyJlbw0lSpQHB/eZZtScPdexN4HSa8cByYwTw9Wy7KuOFr81mlDQcQQaZ79w=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.1.tgz",
+      "integrity": "sha512-mW23Xkp9HYgdMV7gnwuzqnPx6aG0J7xg/b7erQszOcyOizWylwCr9cgYM/BVVJHezUDxwyigG6+wCFQwCvyMBw=="
     },
     "@types/ws": {
       "version": "6.0.4",
@@ -3992,6 +3993,29 @@
         "bser": "2.1.1"
       }
     },
+    "ffi-napi": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
+      "integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
+      "requires": {
+        "debug": "^4.1.1",
+        "get-uv-event-loop-napi-h": "^1.0.5",
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.1",
+        "ref-napi": "^2.0.1 || ^3.0.2",
+        "ref-struct-di": "^1.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -4255,6 +4279,19 @@
         "pump": "^3.0.0"
       }
     },
+    "get-symbol-from-current-process-h": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
+      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
+    },
+    "get-uv-event-loop-napi-h": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
+      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
+      "requires": {
+        "get-symbol-from-current-process-h": "^1.0.1"
+      }
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -4301,9 +4338,9 @@
       }
     },
     "got": {
-      "version": "11.8.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
-      "integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
+      "version": "11.8.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
       "requires": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -7274,6 +7311,15 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
       "dev": true
     },
+    "net-keepalive": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/net-keepalive/-/net-keepalive-2.0.4.tgz",
+      "integrity": "sha512-T85XzamXNCzezArXJfbUk1ScDfhSRZFnKlp+KGiRuS7IPH6ftaUy+WQfW+i0EH3yRc5/kbyXNhSnmmnCQWrxBg==",
+      "requires": {
+        "ffi-napi": "^4.0.1",
+        "ref-napi": "^3.0.0"
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -7326,11 +7372,21 @@
         }
       }
     },
+    "node-addon-api": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
+      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
+    },
     "node-cleanup": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
       "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
       "dev": true
+    },
+    "node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -7584,17 +7640,17 @@
       "dev": true
     },
     "openid-client": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.4.0.tgz",
-      "integrity": "sha512-FZq6rMaItawQc0mMrxlya96fydO7jlkW4I0Hrke3E4ogLAYcFbSefcJlKFLRvr+S5x9N6PMH6OZl9LHgu7JXvw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.6.0.tgz",
+      "integrity": "sha512-MzXjC83Lzh3GuYVHsBaUCcIjZ1bGYHlYSK1rfCLCtBMZn5GBq++b83x4Blcg3kpAI1QveRGNMIRYBq6OP1uiKg==",
       "requires": {
+        "aggregate-error": "^3.1.0",
         "got": "^11.8.0",
         "jose": "^2.0.4",
         "lru-cache": "^6.0.0",
         "make-error": "^1.3.6",
         "object-hash": "^2.0.1",
-        "oidc-token-hash": "^5.0.1",
-        "p-any": "^3.0.0"
+        "oidc-token-hash": "^5.0.1"
       },
       "dependencies": {
         "lru-cache": {
@@ -7648,15 +7704,6 @@
         "own-or": "^1.0.0"
       }
     },
-    "p-any": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-any/-/p-any-3.0.0.tgz",
-      "integrity": "sha512-5rqbqfsRWNb0sukt0awwgJMlaep+8jV45S15SKKB34z4UuzjcofIfnriCBhWjZP2jbVtjt9yRl7buB6RlKsu9w==",
-      "requires": {
-        "p-cancelable": "^2.0.0",
-        "p-some": "^5.0.0"
-      }
-    },
     "p-cancelable": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
@@ -7695,15 +7742,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
-    },
-    "p-some": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-some/-/p-some-5.0.0.tgz",
-      "integrity": "sha512-Js5XZxo6vHjB9NOYAzWDYAIyyiPvva0DWESAIWIK7uhSpGsyg5FwUPxipU/SOQx5x9EqhOh545d1jo6cVkitig==",
-      "requires": {
-        "aggregate-error": "^3.0.0",
-        "p-cancelable": "^2.0.0"
-      }
     },
     "p-try": {
       "version": "2.2.0",
@@ -8107,6 +8145,40 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
         "resolve": "^1.1.6"
+      }
+    },
+    "ref-napi": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.2.tgz",
+      "integrity": "sha512-5YE0XrvWteoTr5DR2sEqxefL06aml7c6qS7hGv3u27do4HlGQphwvB+zD1NYep9utMKScvwOZsSs9EPYdGBVsg==",
+      "requires": {
+        "debug": "^4.1.1",
+        "get-symbol-from-current-process-h": "^1.0.2",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "node-addon-api": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+        }
+      }
+    },
+    "ref-struct-di": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
+      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
+      "requires": {
+        "debug": "^3.1.0"
       }
     },
     "regex-not": {
@@ -10922,9 +10994,9 @@
       "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
     },
     "underscore": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
-      "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ=="
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "unicode-length": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint \"src/**/*.ts\" && (cd test && eslint \"**/*.ts\")"
   },
   "dependencies": {
-    "@kubernetes/client-node": "^0.14.0",
+    "@kubernetes/client-node": "^0.14.2",
     "@snyk/dep-graph": "^1.28.0",
     "async": "^3.2.0",
     "aws-sdk": "^2.867.0",

--- a/test/README.md
+++ b/test/README.md
@@ -49,7 +49,7 @@ All integration tests require the Kubernetes-Monitor to be built into an image o
 The easiest way to achieve it is by running the `scripts/docker/build-image.sh` script.
 Please note that `docker` needs to be installed in order for this script to succeed.
 
-As part of these tests, we attempt pulling and scanning an image hosted on a private GCR registry. For this test case to work, one has to define the following environment variables: `GCR_IO_SERVICE_ACCOUNT`, `GCR_IO_DOCKERCFG`.
+As part of these tests, we attempt pulling and scanning an image hosted on a private GCR registry. For this test case to work, one has to define the following environment variables: `GCR_IO_SERVICE_ACCOUNT`, `GCR_IO_DOCKERCFG`, `DOCKER_HUB_RO_USERNAME`, `DOCKER_HUB_RO_PASSWORD`.
 
 Our integration tests may use different Kubernetes platforms to host the Kubernetes-Monitor. These platforms may use an existing cluster, or create a new one. Both decisions are based on the environment variables:
 * `TEST_PLATFORM` (`kind`, `kindolm`, `eks`)

--- a/test/fixtures/alpine-pod.yaml
+++ b/test/fixtures/alpine-pod.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: alpine
 spec:
+  imagePullSecrets:
+  - name: docker-io
   containers:
   - name: alpine
     image: alpine

--- a/test/fixtures/binaries-deployment.yaml
+++ b/test/fixtures/binaries-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: binaries
     spec:
+      imagePullSecrets:
+      - name: docker-io
       containers:
       - name: node
         image: node@sha256:215a9fbef4df2c1ceb7c79481d3cfd94ad8f1f0105bade39f3be907bf386c5e1

--- a/test/fixtures/centos-deployment.yaml
+++ b/test/fixtures/centos-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app.kubernetes.io/name: centos
     spec:
+      imagePullSecrets:
+      - name: docker-io
       containers:
       - image: centos:7
         imagePullPolicy: Always

--- a/test/fixtures/consul-deployment.yaml
+++ b/test/fixtures/consul-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app.kubernetes.io/name: consul
     spec:
+      imagePullSecrets:
+      - name: docker-io
       containers:
       - image: snyk/runtime-fixtures:consul
         imagePullPolicy: Always

--- a/test/fixtures/insecure-registries/push-dockerhub-image-to-local-registry.yaml
+++ b/test/fixtures/insecure-registries/push-dockerhub-image-to-local-registry.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   template:
     spec:
+      imagePullSecrets:
+        - name: docker-io
       containers:
         - name: my-container
           image: golang:1.13.1-alpine3.10

--- a/test/fixtures/java-deployment.yaml
+++ b/test/fixtures/java-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app.kubernetes.io/name: java
     spec:
+      imagePullSecrets:
+      - name: docker-io
       containers:
       - image: java:latest
         imagePullPolicy: Always

--- a/test/fixtures/nginx-replicationcontroller.yaml
+++ b/test/fixtures/nginx-replicationcontroller.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: nginx
     spec:
+      imagePullSecrets:
+      - name: docker-io
       containers:
       - name: nginx
         image: nginx

--- a/test/fixtures/proxying/tinyproxy-deployment.yaml
+++ b/test/fixtures/proxying/tinyproxy-deployment.yaml
@@ -12,6 +12,8 @@ spec:
       labels:
         app: forwarding-proxy
     spec:
+      imagePullSecrets:
+      - name: docker-io
       containers:
       - name: forwarding-proxy
         image: snyk/runtime-fixtures:tinyproxy

--- a/test/fixtures/redis-deployment.yaml
+++ b/test/fixtures/redis-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app.kubernetes.io/name: redis
     spec:
+      imagePullSecrets:
+      - name: docker-io
       containers:
       - image: redis:latest
         imagePullPolicy: Always

--- a/test/fixtures/scratch-deployment.yaml
+++ b/test/fixtures/scratch-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app.kubernetes.io/name: busybox
     spec:
+      imagePullSecrets:
+      - name: docker-io
       containers:
       - image: busybox:1.31.1
         imagePullPolicy: Always

--- a/test/helpers/kubectl.ts
+++ b/test/helpers/kubectl.ts
@@ -89,7 +89,7 @@ export async function applyK8sYaml(pathToYamlDeployment: string, namespace?: str
 
 export async function createPodFromImage(name: string, image: string, namespace: string) {
   console.log(`Letting Kubernetes decide how to manage image ${image} with name ${name}`);
-  await exec(`./kubectl run ${name} --generator=run-pod/v1 --image=${image} -n ${namespace} -- sleep 999999999`);
+  await exec(`./kubectl run ${name} --image=${image} -n ${namespace} -- sleep 999999999`);
   console.log(`Done Letting Kubernetes decide how to manage image ${image} with name ${name}`);
 }
 

--- a/test/setup/platforms/eks.ts
+++ b/test/setup/platforms/eks.ts
@@ -9,6 +9,8 @@ export async function validateRequiredEnvironment(): Promise<void> {
   throwIfEnvironmentVariableUnset('AWS_ACCESS_KEY_ID');
   throwIfEnvironmentVariableUnset('AWS_SECRET_ACCESS_KEY');
   throwIfEnvironmentVariableUnset('AWS_REGION');
+  throwIfEnvironmentVariableUnset('DOCKER_HUB_RO_USERNAME');
+  throwIfEnvironmentVariableUnset('DOCKER_HUB_RO_PASSWORD');
 }
 
 export async function setupTester(): Promise<void> {

--- a/test/setup/platforms/index.ts
+++ b/test/setup/platforms/index.ts
@@ -28,7 +28,7 @@ const kindSetup: IPlatformSetup = {
   config: kind.exportKubeConfig,
   clean: kind.clean,
   setupTester: kind.setupTester,
-  validateRequiredEnvironment: () => Promise.resolve(),
+  validateRequiredEnvironment: kind.validateRequiredEnvironment,
 };
 
 const kindOlmSetup: IPlatformSetup = {
@@ -38,7 +38,7 @@ const kindOlmSetup: IPlatformSetup = {
   config: kind.exportKubeConfig,
   clean: kind.clean,
   setupTester: kind.setupTester,
-  validateRequiredEnvironment: () => Promise.resolve(),
+  validateRequiredEnvironment: kindOlm.validateRequiredEnvironment,
 };
 
 const eksSetup: IPlatformSetup = {
@@ -59,7 +59,7 @@ const openshift3Setup: IPlatformSetup = {
   config: kind.exportKubeConfig,
   clean: kind.clean,
   setupTester: openshift3.setupTester,
-  validateRequiredEnvironment: () => Promise.resolve(),
+  validateRequiredEnvironment: openshift3.validateRequiredEnvironment,
 };
 
 const openshift4Setup: IPlatformSetup = {

--- a/test/setup/platforms/kind-olm.ts
+++ b/test/setup/platforms/kind-olm.ts
@@ -1,6 +1,7 @@
 import { createCluster as kindCreateCluster } from './kind';
 import * as kubectl from '../../helpers/kubectl';
 import * as sleep from 'sleep-promise';
+import { throwIfEnvironmentVariableUnset } from './helpers';
 
 export async function createCluster(version: string): Promise<void> {
   await kindCreateCluster(version);
@@ -25,3 +26,10 @@ export async function createCluster(version: string): Promise<void> {
   await kubectl.applyK8sYaml('./test/fixtures/operator/marketplace-operator.yaml');
 }
 
+export async function validateRequiredEnvironment(): Promise<void> {
+  console.log(
+    'Checking for the required environment variables: DOCKER_HUB_RO_USERNAME, DOCKER_HUB_RO_PASSWORD',
+  );
+  throwIfEnvironmentVariableUnset('DOCKER_HUB_RO_USERNAME');
+  throwIfEnvironmentVariableUnset('DOCKER_HUB_RO_PASSWORD');
+}

--- a/test/setup/platforms/kind.ts
+++ b/test/setup/platforms/kind.ts
@@ -2,6 +2,7 @@ import { accessSync, chmodSync, constants, writeFileSync } from 'fs';
 import { platform } from 'os';
 import { resolve } from 'path';
 import { execWrapper as exec } from '../../helpers/exec';
+import { throwIfEnvironmentVariableUnset } from './helpers';
 
 const clusterName = 'kind';
 
@@ -67,4 +68,12 @@ export async function download(osDistro: string, kindVersion: string): Promise<v
 
     console.log('KinD downloaded!');
   }
+}
+
+export async function validateRequiredEnvironment(): Promise<void> {
+  console.log(
+    'Checking for the required environment variables: DOCKER_HUB_RO_USERNAME, DOCKER_HUB_RO_PASSWORD',
+  );
+  throwIfEnvironmentVariableUnset('DOCKER_HUB_RO_USERNAME');
+  throwIfEnvironmentVariableUnset('DOCKER_HUB_RO_PASSWORD');
 }

--- a/test/setup/platforms/openshift3.ts
+++ b/test/setup/platforms/openshift3.ts
@@ -1,7 +1,16 @@
 import { platform } from 'os';
-import { download } from '../platforms/kind'; 
+import { download } from '../platforms/kind';
+import { throwIfEnvironmentVariableUnset } from './helpers';
 
 export async function setupTester(): Promise<void> {
   const osDistro = platform();
   await download(osDistro, 'v0.7.0');
+}
+
+export async function validateRequiredEnvironment(): Promise<void> {
+  console.log(
+    'Checking for the required environment variables: DOCKER_HUB_RO_USERNAME, DOCKER_HUB_RO_PASSWORD',
+  );
+  throwIfEnvironmentVariableUnset('DOCKER_HUB_RO_USERNAME');
+  throwIfEnvironmentVariableUnset('DOCKER_HUB_RO_PASSWORD');
 }

--- a/test/setup/platforms/openshift4.ts
+++ b/test/setup/platforms/openshift4.ts
@@ -12,11 +12,13 @@ const OPENSHIFT_CLI_VERSION = '4.7.0';
 
 export async function validateRequiredEnvironment(): Promise<void> {
   console.log(
-    'Checking for the required environment variables: OPENSHIFT4_USER, OPENSHIFT4_PASSWORD, OPENSHIFT4_CLUSTER_URL',
+    'Checking for the required environment variables: OPENSHIFT4_USER, OPENSHIFT4_PASSWORD, OPENSHIFT4_CLUSTER_URL, DOCKER_HUB_RO_USERNAME, DOCKER_HUB_RO_PASSWORD',
   );
   throwIfEnvironmentVariableUnset('OPENSHIFT4_USER');
   throwIfEnvironmentVariableUnset('OPENSHIFT4_PASSWORD');
   throwIfEnvironmentVariableUnset('OPENSHIFT4_CLUSTER_URL');
+  throwIfEnvironmentVariableUnset('DOCKER_HUB_RO_USERNAME');
+  throwIfEnvironmentVariableUnset('DOCKER_HUB_RO_PASSWORD');
 }
 
 export async function setupTester(): Promise<void> {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This has been an outstanding issue for over a month, especially prevalent in AKS. After some inactivity in the cluster, the persistent connection to the K8s API server got interrupted and was never able to recover.

This new fix in the K8s client library puts a 30s keep alive to the Watch connection so that it does not get interrupted.

### More information

- [Jira ticket RUN-1441](https://snyksec.atlassian.net/browse/RUN-1441)
- https://github.com/kubernetes-client/javascript/pull/630
- https://github.com/kubernetes-client/javascript/issues/596
- https://github.com/kubernetes-client/javascript/issues/589
