### PR TITLE
chore: fix OpenShift 3 tests by using previously removed Pod generator

### DIFF
--- a/test/helpers/kubectl.ts
+++ b/test/helpers/kubectl.ts
@@ -89,7 +89,17 @@ export async function applyK8sYaml(pathToYamlDeployment: string, namespace?: str
 
 export async function createPodFromImage(name: string, image: string, namespace: string) {
   console.log(`Letting Kubernetes decide how to manage image ${image} with name ${name}`);
-  await exec(`./kubectl run ${name} --image=${image} -n ${namespace} -- sleep 999999999`);
+  /**
+   * HACK! The newest version of kubectl does not support generators. However, "OpenShift 3" tests run on K8s 1.11 which supports generators.
+   * The default behaviour there is to create a Deployment, whereas new versions of kubectl create Pods.
+   * We can't use the default behaviour for both OpenShift 3 and other tests, because we would get different results.
+   * Hence we need to specifically select the Pod generator on OS3 but it would default to Pod on anything else.
+   */
+  const generator =
+    process.env['TEST_PLATFORM'] === 'openshift3'
+      ? '--generator=run-pod/v1'
+      : '';
+  await exec(`./kubectl run ${name} ${generator} --image=${image} -n ${namespace} -- sleep 999999999`);
   console.log(`Done Letting Kubernetes decide how to manage image ${image} with name ${name}`);
 }
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Previous change f6cd5964b94ed021c6887518ddd6a6e9b325cf03 removed the Pod generator from tests. However, generators in kubectl 1.11 (the OpenShift version) default to applying Deployments instead of Pods.

Restore the Pod generator only for OpenShift 3 tests.
