### PR TITLE
chore: fix operator upgrade test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -473,9 +473,9 @@ jobs:
                     sed -i.bak "s|${OPERATOR_VERSION}|${LATEST_TAG}|g" ./test/fixtures/operator/catalog-source.yaml
                     kubectl apply -f ./test/fixtures/operator/catalog-source.yaml
 
-                    ATTEMPTS=60
+                    ATTEMPTS=120
                     SLEEP_SECONDS_BETWEEN_ATTEMPTS=5
-                    # total = 5 minutes wait time
+                    # total = 10 minutes wait time
 
                     # Periodically poll if the snyk-monitor has upgraded
                     for (( attempt=1; attempt<ATTEMPTS; attempt++))

--- a/.circleci/config/jobs/operator_upgrade_tests.yml
+++ b/.circleci/config/jobs/operator_upgrade_tests.yml
@@ -167,9 +167,9 @@ steps:
         sed -i.bak "s|${OPERATOR_VERSION}|${LATEST_TAG}|g" ./test/fixtures/operator/catalog-source.yaml
         kubectl apply -f ./test/fixtures/operator/catalog-source.yaml
 
-        ATTEMPTS=60
+        ATTEMPTS=120
         SLEEP_SECONDS_BETWEEN_ATTEMPTS=5
-        # total = 5 minutes wait time
+        # total = 10 minutes wait time
 
         # Periodically poll if the snyk-monitor has upgraded
         for (( attempt=1; attempt<ATTEMPTS; attempt++))


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Operator tests seem to fail and it's just a matter of increasing the timeout to give the OpenShift cluster enough time to resolve the changes. When debugging we can see that the new Pod is there but still initialising, so it needs more time to properly start.

```shell
$ kubectl get pod -n snyk-monitor
NAME                             READY   STATUS     RESTARTS   AGE
snyk-monitor-6c978fb849-6vk9j    0/1     Init:0/1   0          4m30s
snyk-monitor-fbb97cd7c-blwrj     1/1     Running    0          7m27s
snyk-operator-7b5459cdcb-l2mkg   1/1     Running    0          4m40s
```

```shell
$ kubectl describe catsrc snyk-operator -n openshift-marketplace
Name:         snyk-operator
Namespace:    openshift-marketplace
...
  Image:         docker.io/snyk/kubernetes-operator-index:1.50.2
...
```