### PR TITLE
chore: fix Operator tests with OLM on vanilla Kubernetes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,9 +236,10 @@ jobs:
                 name: Create temporary directory for logs
             - run:
                 command: |
+                    export OPERATOR_VERSION="0.0.1-${CIRCLE_SHA1}"
                     export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
                     .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:kindolm:operator
-                name: Operator integration tests on plain k8s
+                name: Operator integration tests on vanilla Kubernetes
             - run:
                 command: |
                     ./scripts/slack/notify_failure_on_branch.py "${CIRCLE_BRANCH}" "${CIRCLE_JOB}" "${CIRCLE_BUILD_URL}" "${CIRCLE_PULL_REQUEST}" "${SLACK_WEBHOOK}"

--- a/.circleci/config/jobs/integration_tests_operator_on_k8s.yml
+++ b/.circleci/config/jobs/integration_tests_operator_on_k8s.yml
@@ -11,9 +11,10 @@ steps:
     name: Create temporary directory for logs
 - run:
     command: |
+      export OPERATOR_VERSION="0.0.1-${CIRCLE_SHA1}"
       export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
       .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:kindolm:operator
-    name: Operator integration tests on plain k8s
+    name: Operator integration tests on vanilla Kubernetes
 - run:
     command: |
       ./scripts/slack/notify_failure_on_branch.py "${CIRCLE_BRANCH}" "${CIRCLE_JOB}" "${CIRCLE_BUILD_URL}" "${CIRCLE_PULL_REQUEST}" "${SLACK_WEBHOOK}"

--- a/test/fixtures/operator/catalog-source-k8s.yaml
+++ b/test/fixtures/operator/catalog-source-k8s.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: snyk-operator
+  namespace: marketplace
+spec:
+  sourceType: grpc
+  image: docker.io/snyk/kubernetes-operator-index:TAG_OVERRIDE
+  displayName: Snyk Operator Bundle
+  publisher: Snyk Ltd.
+  updateStrategy:
+    registryPoll:
+      interval: 1m

--- a/test/setup/deployers/operator-olm.ts
+++ b/test/setup/deployers/operator-olm.ts
@@ -1,5 +1,7 @@
-
 import * as sleep from 'sleep-promise';
+import { parse, stringify } from 'yaml';
+import { readFileSync, writeFileSync } from 'fs';
+
 import { IDeployer, IImageOptions } from './types';
 import * as kubectl from '../../helpers/kubectl';
 
@@ -33,14 +35,37 @@ async function waitToDeployKubernetesOperator(namespace: string): Promise<void> 
 async function deployKubernetesMonitor(
   _imageOptions: IImageOptions,
 ): Promise<void> {
-    await kubectl.applyK8sYaml('./test/fixtures/operator/operator-source-k8s.yaml');
-    await kubectl.applyK8sYaml('./test/fixtures/operator/installation-k8s.yaml');
+  const overriddenOperatorSource = 'snyk-monitor-catalog-source.yaml';
+  createTestOperatorSource(overriddenOperatorSource);
+  await kubectl.applyK8sYaml(overriddenOperatorSource);
+  await kubectl.applyK8sYaml('./test/fixtures/operator/installation-k8s.yaml');
 
-    // Await for the Operator to become available, only then
-    // the Operator can start processing the custom resource.
-    await kubectl.waitForDeployment('snyk-operator', 'marketplace');
-    await kubectl.waitForCRD('snykmonitors.charts.helm.k8s.io');
-    await kubectl.applyK8sYaml('./test/fixtures/operator/custom-resource-k8s.yaml');
-    await waitToDeployKubernetesOperator('marketplace');
-    await kubectl.waitForDeployment('snyk-operator', 'marketplace');
+  // Await for the Operator to become available, only then
+  // the Operator can start processing the custom resource.
+  await kubectl.waitForDeployment('snyk-operator', 'marketplace');
+  await kubectl.waitForCRD('snykmonitors.charts.helm.k8s.io');
+  await kubectl.applyK8sYaml('./test/fixtures/operator/custom-resource-k8s.yaml');
+  await waitToDeployKubernetesOperator('marketplace');
+  await kubectl.waitForDeployment('snyk-operator', 'marketplace');
+}
+
+function createTestOperatorSource(newYamlPath: string): void {
+  console.log('Creating YAML CatalogSource...');
+  const operatorVersion =
+    process.env.OPERATOR_VERSION ?? readFileSync('./.operator_version', 'utf8');
+  const originalCatalogSourceYaml = readFileSync(
+    './test/fixtures/operator/catalog-source-k8s.yaml',
+    'utf8',
+  );
+  const catalogSource: { spec: { image: string } } = parse(
+    originalCatalogSourceYaml,
+  );
+
+  catalogSource.spec.image = catalogSource.spec.image.replace(
+    'TAG_OVERRIDE',
+    operatorVersion,
+  );
+
+  writeFileSync(newYamlPath, stringify(catalogSource));
+  console.log('Created YAML CatalogSource');
 }

--- a/test/setup/platforms/kind-olm.ts
+++ b/test/setup/platforms/kind-olm.ts
@@ -1,29 +1,19 @@
+import * as sleep from 'sleep-promise';
+
 import { createCluster as kindCreateCluster } from './kind';
 import * as kubectl from '../../helpers/kubectl';
-import * as sleep from 'sleep-promise';
 import { throwIfEnvironmentVariableUnset } from './helpers';
 
 export async function createCluster(version: string): Promise<void> {
   await kindCreateCluster(version);
 
-  // OLM installation: https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md#2-install-olm
-
-  const operatorLifecycleManagerVersion = '0.15.1'; // https://github.com/operator-framework/operator-lifecycle-manager/releases/tag/0.15.1
-  await kubectl.applyK8sYaml(`https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${operatorLifecycleManagerVersion}/crds.yaml`);
+  // OLM installation: https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md#installing-olm
+  await kubectl.applyK8sYaml('https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/crds.yaml');
   await sleep(5000); // give enough time to k8s to apply the previous yaml
-  await kubectl.applyK8sYaml(`https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${operatorLifecycleManagerVersion}/olm.yaml`);
+  await kubectl.applyK8sYaml('https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml');
   await kubectl.waitForDeployment('catalog-operator', 'olm');
   await kubectl.waitForDeployment('olm-operator', 'olm');
   await kubectl.waitForDeployment('packageserver', 'olm');
-
-  await kubectl.applyK8sYaml('https://raw.githubusercontent.com/operator-framework/operator-marketplace/0c2dfdec91f3518370b9af6a50a88dd5eb16a91e/deploy/upstream/01_namespace.yaml');
-  await kubectl.applyK8sYaml('https://raw.githubusercontent.com/operator-framework/operator-marketplace/0c2dfdec91f3518370b9af6a50a88dd5eb16a91e/deploy/upstream/03_operatorsource.crd.yaml');
-  await kubectl.applyK8sYaml('https://raw.githubusercontent.com/operator-framework/operator-marketplace/0c2dfdec91f3518370b9af6a50a88dd5eb16a91e/deploy/upstream/04_service_account.yaml');
-  await kubectl.applyK8sYaml('https://raw.githubusercontent.com/operator-framework/operator-marketplace/0c2dfdec91f3518370b9af6a50a88dd5eb16a91e/deploy/upstream/05_role.yaml');
-  await kubectl.applyK8sYaml('https://raw.githubusercontent.com/operator-framework/operator-marketplace/0c2dfdec91f3518370b9af6a50a88dd5eb16a91e/deploy/upstream/06_role_binding.yaml');
-  await kubectl.applyK8sYaml('https://raw.githubusercontent.com/operator-framework/operator-marketplace/0c2dfdec91f3518370b9af6a50a88dd5eb16a91e/deploy/upstream/07_upstream_operatorsource.cr.yaml');
-  // Fixing the marketplace-operator image version to 4.5.0
-  await kubectl.applyK8sYaml('./test/fixtures/operator/marketplace-operator.yaml');
 }
 
 export async function validateRequiredEnvironment(): Promise<void> {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Update OLM to the latest version, which matches the one on OpenShift. This means the existing OperatorSource resource is deprecated, so we can now use CatalogSource instead, similarly to OpenShift.

Also align the CI/CD pipeline to the recent changes in OpenShift tests.

### More information

- [Jira ticket RUN-1490](https://snyksec.atlassian.net/browse/RUN-1490)
