### PR TITLE
Feat/deployment config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,6 @@ RUN chmod 755 /usr/bin/dumb-init
 RUN groupadd -g 10001 snyk
 RUN useradd -g snyk -d /srv/app -u 10001 snyk
 
-# @kubernetes/client-node@0.14.2 started using net-keepalive, which requires the following packages to build modules
-RUN yum --disableplugin=subscription-manager install -y make gcc gcc-c++
-
 WORKDIR /srv/app
 
 COPY --chown=snyk:snyk --from=skopeo-build /usr/bin/skopeo /usr/bin/skopeo
@@ -52,8 +49,6 @@ ADD --chown=snyk:snyk package.json package-lock.json ./
 RUN mkdir -p .config
 
 RUN npm install
-
-RUN yum remove -y make gcc gcc-c++
 
 # add the rest of the app files
 ADD --chown=snyk:snyk . .

--- a/package-lock.json
+++ b/package-lock.json
@@ -1581,9 +1581,9 @@
       }
     },
     "@kubernetes/client-node": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.14.2.tgz",
-      "integrity": "sha512-0/E6xXDL+qTpS8XCZBnuwbco9Q87NisQwN0TUEk3rR7g6RxlH+lv9E6pJhcoocFnDFstu24b3U6bIsHbCTd8kA==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.14.3.tgz",
+      "integrity": "sha512-9hHGDNm2JEFQcRTpDxVoAVr0fowU+JH/l5atCXY9VXwvFM18pW5wr2LzLP+Q2Rh+uQv7Moz4gEjEKSCgVKykEQ==",
       "requires": {
         "@types/js-yaml": "^3.12.1",
         "@types/node": "^10.12.0",
@@ -1597,7 +1597,6 @@
         "isomorphic-ws": "^4.0.1",
         "js-yaml": "^3.13.1",
         "jsonpath-plus": "^0.19.0",
-        "net-keepalive": "2.0.4",
         "openid-client": "^4.1.1",
         "request": "^2.88.0",
         "rfc4648": "^1.3.0",
@@ -3993,29 +3992,6 @@
         "bser": "2.1.1"
       }
     },
-    "ffi-napi": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
-      "integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
-      "requires": {
-        "debug": "^4.1.1",
-        "get-uv-event-loop-napi-h": "^1.0.5",
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1",
-        "ref-napi": "^2.0.1 || ^3.0.2",
-        "ref-struct-di": "^1.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
-      }
-    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -4277,19 +4253,6 @@
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "requires": {
         "pump": "^3.0.0"
-      }
-    },
-    "get-symbol-from-current-process-h": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
-      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
-    },
-    "get-uv-event-loop-napi-h": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
-      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
-      "requires": {
-        "get-symbol-from-current-process-h": "^1.0.1"
       }
     },
     "get-value": {
@@ -6631,9 +6594,9 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "jose": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.4.tgz",
-      "integrity": "sha512-EArN9f6aq1LT/fIGGsfghOnNXn4noD+3dG5lL/ljY3LcRjw1u9w+4ahu/4ahsN6N0kRLyyW6zqdoYk7LNx3+YQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
+      "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
       "requires": {
         "@panva/asn1.js": "^1.0.0"
       }
@@ -7311,15 +7274,6 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
       "dev": true
     },
-    "net-keepalive": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/net-keepalive/-/net-keepalive-2.0.4.tgz",
-      "integrity": "sha512-T85XzamXNCzezArXJfbUk1ScDfhSRZFnKlp+KGiRuS7IPH6ftaUy+WQfW+i0EH3yRc5/kbyXNhSnmmnCQWrxBg==",
-      "requires": {
-        "ffi-napi": "^4.0.1",
-        "ref-napi": "^3.0.0"
-      }
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -7372,21 +7326,11 @@
         }
       }
     },
-    "node-addon-api": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
-      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
-    },
     "node-cleanup": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
       "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
       "dev": true
-    },
-    "node-gyp-build": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -8145,40 +8089,6 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
         "resolve": "^1.1.6"
-      }
-    },
-    "ref-napi": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.2.tgz",
-      "integrity": "sha512-5YE0XrvWteoTr5DR2sEqxefL06aml7c6qS7hGv3u27do4HlGQphwvB+zD1NYep9utMKScvwOZsSs9EPYdGBVsg==",
-      "requires": {
-        "debug": "^4.1.1",
-        "get-symbol-from-current-process-h": "^1.0.2",
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "node-addon-api": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-        }
-      }
-    },
-    "ref-struct-di": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
-      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
-      "requires": {
-        "debug": "^3.1.0"
       }
     },
     "regex-not": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint \"src/**/*.ts\" && (cd test && eslint \"**/*.ts\")"
   },
   "dependencies": {
-    "@kubernetes/client-node": "^0.14.2",
+    "@kubernetes/client-node": "^0.14.3",
     "@snyk/dep-graph": "^1.28.0",
     "async": "^3.2.0",
     "aws-sdk": "^2.870.0",

--- a/snyk-monitor/templates/clusterrole.yaml
+++ b/snyk-monitor/templates/clusterrole.yaml
@@ -53,6 +53,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
 {{- if .Values.psp.enabled }}
 - apiGroups:
   - policy

--- a/snyk-monitor/templates/role.yaml
+++ b/snyk-monitor/templates/role.yaml
@@ -51,6 +51,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
 {{- if .Values.psp.enabled }}
 - apiGroups:
   - policy

--- a/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
@@ -221,6 +221,12 @@ spec:
                 - "*"
               verbs:
                 - "*"
+            - apiGroups:
+                - apps.openshift.io
+              resources:
+                - deploymentconfigs
+              verbs:
+                - "*"
           serviceAccountName: snyk-operator
       deployments:
         - name: snyk-operator

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,15 +23,15 @@ process.on('uncaughtException', (err) => {
   }
 });
 
-process.on('unhandledRejection', (reason) => {
+process.on('unhandledRejection', (reason, promise) => {
   if (state.shutdownInProgress) {
     return;
   }
 
   try {
-    logger.error({reason}, 'UNHANDLED REJECTION!');
+    logger.error({ reason, promise }, 'UNHANDLED REJECTION!');
   } catch (ignore) {
-    console.log('UNHANDLED REJECTION!', reason);
+    console.log('UNHANDLED REJECTION!', reason, promise);
   } finally {
     process.exit(1);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,10 +47,10 @@ function cleanUpTempStorage() {
   }
 };
 
-function monitor(): void {
+async function monitor(): Promise<void> {
   try {
     logger.info({cluster: currentClusterName}, 'starting to monitor');
-    beginWatchingWorkloads();
+    await beginWatchingWorkloads();
   } catch (error) {
     logger.error({error}, 'an error occurred while monitoring the cluster');
     process.exit(1);
@@ -63,5 +63,5 @@ cleanUpTempStorage();
 // Allow running in an async context
 setImmediate(async function setUpAndMonitor(): Promise<void> {
   await loadAndSendWorkloadAutoImportPolicy();
-  monitor();
+  await monitor();
 });

--- a/src/supervisor/types.ts
+++ b/src/supervisor/types.ts
@@ -1,6 +1,15 @@
-import { IncomingMessage }  from 'http';
-import { AppsV1Api, BatchV1Api, BatchV1beta1Api, CoreV1Api, KubeConfig,
-  V1ObjectMeta, V1OwnerReference, V1PodSpec } from '@kubernetes/client-node';
+import { IncomingMessage } from 'http';
+import {
+  AppsV1Api,
+  BatchV1Api,
+  BatchV1beta1Api,
+  CoreV1Api,
+  CustomObjectsApi,
+  KubeConfig,
+  V1ObjectMeta,
+  V1OwnerReference,
+  V1PodSpec,
+} from '@kubernetes/client-node';
 
 export enum WorkloadKind {
   Deployment = 'Deployment',
@@ -11,6 +20,7 @@ export enum WorkloadKind {
   CronJob = 'CronJob',
   ReplicationController = 'ReplicationController',
   Pod = 'Pod',
+  DeploymentConfig = 'DeploymentConfig',
 }
 
 export interface IRequestError {
@@ -32,6 +42,7 @@ export interface IK8sClients {
   readonly coreClient: CoreV1Api;
   readonly batchClient: BatchV1Api;
   readonly batchUnstableClient: BatchV1beta1Api;
+  readonly customObjectsClient: CustomObjectsApi;
 }
 
 export class K8sClients implements IK8sClients {
@@ -41,12 +52,17 @@ export class K8sClients implements IK8sClients {
   // TODO: Keep an eye on this! We need v1beta1 API for CronJobs.
   // https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning
   // CronJobs will appear in v2 API, but for now there' only v2alpha1, so it's a bad idea to use it.
+  // TODO: https://kubernetes.io/blog/2021/04/09/kubernetes-release-1.21-cronjob-ga/
+  // CronJobs are now GA in Kubernetes 1.21 in the batch/v1 API, we should add support for it!
   public readonly batchUnstableClient: BatchV1beta1Api;
+  /** This client is used to access Custom Resources in the cluster, e.g. DeploymentConfig on OpenShift. */
+  public readonly customObjectsClient: CustomObjectsApi;
 
   constructor(config: KubeConfig) {
     this.appsClient = config.makeApiClient(AppsV1Api);
     this.coreClient = config.makeApiClient(CoreV1Api);
     this.batchClient = config.makeApiClient(BatchV1Api);
     this.batchUnstableClient = config.makeApiClient(BatchV1beta1Api);
+    this.customObjectsClient = config.makeApiClient(CustomObjectsApi);
   }
 }

--- a/src/supervisor/watchers/handlers/deployment-config.ts
+++ b/src/supervisor/watchers/handlers/deployment-config.ts
@@ -1,0 +1,32 @@
+import { deleteWorkload } from './workload';
+import { WorkloadKind } from '../../types';
+import { FALSY_WORKLOAD_NAME_MARKER, V1DeploymentConfig } from './types';
+
+export async function deploymentConfigWatchHandler(
+  deploymentConfig: V1DeploymentConfig,
+): Promise<void> {
+  if (
+    !deploymentConfig.metadata ||
+    !deploymentConfig.spec ||
+    !deploymentConfig.spec.template.metadata ||
+    !deploymentConfig.spec.template.spec ||
+    !deploymentConfig.status
+  ) {
+    return;
+  }
+
+  const workloadName =
+    deploymentConfig.metadata.name || FALSY_WORKLOAD_NAME_MARKER;
+
+  await deleteWorkload(
+    {
+      kind: WorkloadKind.DeploymentConfig,
+      objectMeta: deploymentConfig.metadata,
+      specMeta: deploymentConfig.spec.template.metadata,
+      ownerRefs: deploymentConfig.metadata.ownerReferences,
+      revision: deploymentConfig.status.observedGeneration,
+      podSpec: deploymentConfig.spec.template.spec,
+    },
+    workloadName,
+  );
+}

--- a/src/supervisor/watchers/handlers/types.ts
+++ b/src/supervisor/watchers/handlers/types.ts
@@ -1,3 +1,5 @@
+import { V1ObjectMeta, V1PodTemplateSpec } from "@kubernetes/client-node";
+
 export const FALSY_WORKLOAD_NAME_MARKER = 'falsy workload name';
 
 type WorkloadHandlerFunc = (workload: any) => Promise<void>;
@@ -15,4 +17,20 @@ export interface IWorkloadWatchMetadata {
     },
     listFactory: ListWorkloadFunctionFactory;
   };
+}
+
+export interface V1DeploymentConfig {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: V1ObjectMeta;
+  spec?: V1DeploymentConfigSpec;
+  status?: V1DeploymentConfigStatus;
+}
+
+export interface V1DeploymentConfigSpec {
+  template: V1PodTemplateSpec;
+}
+
+export interface V1DeploymentConfigStatus {
+  observedGeneration?: number;
 }

--- a/src/supervisor/workload-reader.ts
+++ b/src/supervisor/workload-reader.ts
@@ -224,10 +224,6 @@ export function getWorkloadReader(workloadType: string): IWorkloadReaderFunc {
 
 export function getSupportedWorkload(ownerRefs: V1OwnerReference[] | undefined): V1OwnerReference | undefined {
   return ownerRefs !== undefined
-    ? ownerRefs.find(
-        (owner) =>
-          SupportedWorkloadTypes.includes(owner.kind) &&
-          owner.controller === true,
-      )
+    ? ownerRefs.find((owner) => SupportedWorkloadTypes.includes(owner.kind))
     : undefined;
 }

--- a/src/supervisor/workload-reader.ts
+++ b/src/supervisor/workload-reader.ts
@@ -4,6 +4,7 @@ import * as kubernetesApiWrappers from './kuberenetes-api-wrappers';
 import { k8sApi } from './cluster';
 import { IKubeObjectMetadata, WorkloadKind } from './types';
 import { logger } from '../common/logger';
+import { V1DeploymentConfig } from './watchers/handlers/types';
 
 type IKubeObjectMetadataWithoutPodSpec = Omit<IKubeObjectMetadata, 'podSpec'>;
 type IWorkloadReaderFunc = (
@@ -25,6 +26,37 @@ const deploymentReader: IWorkloadReaderFunc = async (workloadName, namespace) =>
 
   const metadata: IKubeObjectMetadataWithoutPodSpec = {
     kind: WorkloadKind.Deployment,
+    objectMeta: deployment.metadata,
+    specMeta: deployment.spec.template.metadata,
+    ownerRefs: deployment.metadata.ownerReferences,
+    revision: deployment.status.observedGeneration,
+  };
+  return metadata;
+};
+
+/** https://docs.openshift.com/container-platform/4.7/rest_api/workloads_apis/deploymentconfig-apps-openshift-io-v1.html */
+const deploymentConfigReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
+  const deploymentResult = await kubernetesApiWrappers.retryKubernetesApiRequest(
+    () =>
+      k8sApi.customObjectsClient.getNamespacedCustomObject(
+        'apps.openshift.io',
+        'v1',
+        namespace,
+        'deploymentconfigs',
+        workloadName,
+      ),
+  );
+  const deployment: V1DeploymentConfig = deploymentResult.body;
+
+  if (!deployment.metadata || !deployment.spec || !deployment.spec.template.metadata ||
+      !deployment.spec.template.spec || !deployment.status) {
+    logIncompleteWorkload(workloadName, namespace);
+
+    return undefined;
+  }
+
+  const metadata: IKubeObjectMetadataWithoutPodSpec = {
+    kind: WorkloadKind.DeploymentConfig,
     objectMeta: deployment.metadata,
     specMeta: deployment.spec.template.metadata,
     ownerRefs: deployment.metadata.ownerReferences,
@@ -181,6 +213,7 @@ const workloadReader = {
   [WorkloadKind.Job]: jobReader,
   [WorkloadKind.CronJob]: cronJobReader,
   [WorkloadKind.ReplicationController]: replicationControllerReader,
+  [WorkloadKind.DeploymentConfig]: deploymentConfigReader,
 };
 
 export const SupportedWorkloadTypes = Object.keys(workloadReader);

--- a/test/fixtures/hello-world-deploymentconfig.yaml
+++ b/test/fixtures/hello-world-deploymentconfig.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  namespace: services
+  name: deployment-config
+spec:
+  replicas: 1
+  selector:
+    name: deployment-config
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: deployment-config
+      name: deployment-config
+    spec:
+      containers:
+      - command:
+        - /hello
+        image: hello-world:latest
+        imagePullPolicy: IfNotPresent
+        name: main
+      securityContext:
+        runAsNonRoot: true
+  test: false
+  triggers:
+  - type: ConfigChange

--- a/test/unit/supervisor/workload-reader.spec.ts
+++ b/test/unit/supervisor/workload-reader.spec.ts
@@ -29,18 +29,19 @@ describe('workload reader tests', () => {
       getSupportedWorkload(unsupportedOwnerRefs as V1OwnerReference[]),
     ).toBeUndefined();
 
+    // Selects the first one that matches a supported workload
     const noController = [{ kind: 'ReplicaSet' }, { kind: 'Deployment' }];
-    expect(
-      getSupportedWorkload(noController as V1OwnerReference[]),
-    ).toBeUndefined();
+    expect(getSupportedWorkload(noController as V1OwnerReference[])).toEqual({
+      kind: 'ReplicaSet',
+    });
 
+    // Selects the first one that matches a supported workload, regardless of controllers
     const oneController = [
       { kind: 'ReplicaSet' },
       { kind: 'Deployment', controller: true },
     ];
     expect(getSupportedWorkload(oneController as V1OwnerReference[])).toEqual({
-      kind: 'Deployment',
-      controller: true,
+      kind: 'ReplicaSet',
     });
 
     const twoControllers = [


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add support for [DeploymentConfig](https://docs.openshift.com/container-platform/4.7/applications/deployments/what-deployments-are.html) on OpenShift.

Before we set up Informers in the cluster for all the different workloads (e.g. Deployment, ReplicaSet), specifically for DeploymentConfig we now do a small query to the API server to understand if it's supported. If the API request returns successfully (non-404 code) then DeploymentConfig is supported and we set up a Watch following the routes in the [API reference](https://docs.openshift.com/container-platform/4.7/rest_api/workloads_apis/deploymentconfig-apps-openshift-io-v1.html). If the K8s API returns 404 (meaning the resource is unknown) then we skip creating a DeploymentConfig Informer.

What was added:
- an integration test for OpenShift 4 that applies a DeploymentConfig and checks that the workload was scanned
- TypeScript types for `DeploymentConfigV1` based on the [API reference](https://docs.openshift.com/container-platform/4.7/rest_api/workloads_apis/deploymentconfig-apps-openshift-io-v1.html)
- some functions are now `async` to allow querying the API server for supported workloads before deciding whether to set an Informer; we also await `informer.start()` calls since it returns a Promise

### More information

Commit by commit 🙏 

- [Jira ticket RUN-1505](https://snyksec.atlassian.net/browse/RUN-1505)

