### PR TITLE
Allow passing arbitrary annotations to ServiceAccount

### DIFF
--- a/snyk-monitor/Chart.yaml
+++ b/snyk-monitor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for the Snyk Monitor
 name: snyk-monitor
-version: 0.1.0
+version: 0.2.0
 icon: https://res.cloudinary.com/snyk/image/upload/v1533761770/logo-1_wtob68.svg

--- a/snyk-monitor/templates/serviceaccount.yaml
+++ b/snyk-monitor/templates/serviceaccount.yaml
@@ -7,3 +7,6 @@ metadata:
     helm.sh/chart: {{ include "snyk-monitor.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.rbac.serviceAccount.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+{{- end }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -52,6 +52,11 @@ pvc:
   ##
   # storageClassName: "-"
 
+# Additional annotations for the Kubernetes ServiceAccount
+rbac:
+  serviceAccount:
+    annotations: {}
+
 # Node.js in-container process memory enhancements
 envs:
   - name: V8_MAX_OLD_SPACE_SIZE


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Expose ServiceAccount annotations as a template value.

### Notes for the reviewer

We would like to use Snyk Monitor on our EKS cluster but all of our images are hosted in private ECR repositories. With the [IAM Role for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) feature from AWS the aws-sdk can assume temporary IAM credentials by completing an oauth flow using the k8s service account token.

By itself this does not give Snyk everything it needs to pull from ECR repositories, but we can use the existing Helm values to provide our own extended build of the snyk-monitor container with the additional binaries required.

I tested this with Helm template and it generated the expected configuration:
```
❯ helm template snyk-monitor ./snyk-monitor                      
---
# Source: snyk-monitor/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: snyk-monitor
  labels:
    app.kubernetes.io/name: snyk-monitor
    helm.sh/chart: snyk-monitor-0.2.0
    app.kubernetes.io/instance: snyk-monitor
    app.kubernetes.io/managed-by: Helm
  annotations: 
    eks.amazonaws.com/role-arn: arn:aws:iam::12345678999:role/snyk-monitor
---
```

### More information

- [Jira ticket SC-0000](https://snyksec.atlassian.net/browse/SC-0000)
- [Link to documentation](https://github.com/Snyk/registry/wiki/)

### Screenshots

_Visuals that may help the reviewer_
