### PR TITLE
fix: add world read/write permissions to temp volume

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       initContainers:
         - name: volume-permissions
           image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
-          command : ['sh', '-c', 'chmod -R g+rwX /var/tmp || true']
+          command : ['sh', '-c', 'chmod -R go+rwX /var/tmp || true']
           volumeMounts:
             - name: temporary-storage
               mountPath: "/var/tmp"


### PR DESCRIPTION
Change the `initContainer` command to add "world" read/write permissions.