### PR TITLE
feat: Allow passing arbitrary annotations to ServiceAccount with Helm

### DIFF
--- a/snyk-monitor/templates/serviceaccount.yaml
+++ b/snyk-monitor/templates/serviceaccount.yaml
@@ -7,3 +7,7 @@ metadata:
     helm.sh/chart: {{ include "snyk-monitor.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.rbac.serviceAccount.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+{{- end }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -52,6 +52,11 @@ pvc:
   ##
   # storageClassName: "-"
 
+# Additional annotations for the Kubernetes ServiceAccount
+rbac:
+  serviceAccount:
+    annotations: {}
+
 # Node.js in-container process memory enhancements
 envs:
   - name: V8_MAX_OLD_SPACE_SIZE

--- a/test/helpers/kubectl.ts
+++ b/test/helpers/kubectl.ts
@@ -1,9 +1,11 @@
-import { execWrapper as exec } from './exec';
 import { chmodSync, writeFileSync, existsSync, unlinkSync } from 'fs';
 import { platform } from 'os';
 import { resolve } from 'path';
 import * as needle from 'needle';
 import * as sleep from 'sleep-promise';
+import type { V1ServiceAccount } from '@kubernetes/client-node';
+
+import { execWrapper as exec } from './exec';
 
 /**
  * @param version For example: "v1.18.0"
@@ -187,6 +189,16 @@ export async function getDeploymentJson(
 ): Promise<any> {
   const getDeploymentResult = await exec(
     `./kubectl get deployment ${deploymentName} -n ${namespace} -o json`,
+  );
+  return JSON.parse(getDeploymentResult.stdout);
+}
+
+export async function getServiceAccountJson(
+  name: string,
+  namespace: string,
+): Promise<V1ServiceAccount> {
+  const getDeploymentResult = await exec(
+    `./kubectl get serviceaccount ${name} -n ${namespace} -o json`,
   );
   return JSON.parse(getDeploymentResult.stdout);
 }

--- a/test/integration/kubernetes.spec.ts
+++ b/test/integration/kubernetes.spec.ts
@@ -576,6 +576,25 @@ test('snyk-monitor has log level', async () => {
   expect(logLevel.value).toBeTruthy();
 });
 
+test('service account has annotations that were set on deployment', async () => {
+  if (process.env.DEPLOYMENT_TYPE !== 'Helm') {
+    console.log(
+      "Not testing annotations existence because we're not installing with Helm",
+    );
+    return;
+  }
+
+  const snykMonitorServiceAccount = await kubectl.getServiceAccountJson(
+    'snyk-monitor',
+    namespace,
+  );
+  expect(snykMonitorServiceAccount.metadata?.annotations).toEqual(
+    expect.objectContaining({
+      foo: 'bar',
+    }),
+  );
+});
+
 test('snyk-monitor has nodeSelector', async () => {
   if (process.env['DEPLOYMENT_TYPE'] !== 'Helm') {
     console.log(

--- a/test/setup/deployers/helm.ts
+++ b/test/setup/deployers/helm.ts
@@ -34,7 +34,8 @@ async function deployKubernetesMonitor(
       '--set psp.enabled=true ' +
       '--set pvc.enabled=true ' +
       '--set pvc.create=true ' +
-      '--set log_level="INFO"',
+      '--set log_level="INFO" ' +
+      '--set rbac.serviceAccount.annotations."foo"="bar"',
   );
   console.log(
     `Deployed ${imageOptions.nameAndTag} with pull policy ${imageOptions.pullPolicy}`,


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Allow passing arbitrary annotations to ServiceAccount with Helm.

### Notes for the reviewer

Cherry-picked from https://github.com/snyk/kubernetes-monitor/pull/719, please see the original submission for the details!

### More information

- https://github.com/snyk/kubernetes-monitor/pull/719
