### PR TITLE
chore: pin Operator Lifecycle Manager to version 0.17.0

### DIFF
--- a/test/setup/platforms/kind-olm.ts
+++ b/test/setup/platforms/kind-olm.ts
@@ -9,11 +9,11 @@ export async function createCluster(version: string): Promise<void> {
 
   // OLM installation: https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md#installing-olm
   await kubectl.applyK8sYaml(
-    'https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/crds.yaml',
+    'https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/v0.17.0/deploy/upstream/quickstart/crds.yaml',
   );
   await sleep(5000); // give enough time to k8s to apply the previous yaml
   await kubectl.applyK8sYaml(
-    'https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml',
+    'https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/v0.17.0/deploy/upstream/quickstart/olm.yaml',
   );
   await kubectl.waitForDeployment('catalog-operator', 'olm');
   await kubectl.waitForDeployment('olm-operator', 'olm');


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The recent release of version 0.18.0 releases a breaking change and causes the setup of our OLM tests to fail.
For now instead of using the main branch, we pin to the non-breaking change release until we understand what we need to change in our test setup to accommodate the new version.
