### PR TITLE
fix: fixes #739 set securityContext.fsGroup at pod level

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -18,23 +18,10 @@ spec:
         app.kubernetes.io/name: {{ include "snyk-monitor.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      securityContext:
+        fsGroup: 2000
       serviceAccountName: {{ include "snyk-monitor.name" . }}
       restartPolicy: Always
-      initContainers:
-        - name: volume-permissions
-          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
-          command : ['sh', '-c', 'chmod -R go+rwX /var/tmp || true']
-          volumeMounts:
-            - name: temporary-storage
-              mountPath: "/var/tmp"
-          securityContext:
-            privileged: false
-            runAsNonRoot: false
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
       containers:
         - name: {{ include "snyk-monitor.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Instead of using an `initContainer` we instad set the `fsGroup` within the pod `securityContext`. Kubernetes will **create** this supplimentary group and assign it to all processes running within the pod.

Fixes #739 