### PR TITLE
fix: exclude gradle/cache path when extracting jars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1722,9 +1722,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.50",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.50.tgz",
-          "integrity": "sha512-y7kkh+hX/0jZNxMyBR/6asG0QMSaPSzgeVK63dhWHl4QAXCQB8lExXmzLL6SzmOgKHydtawpMnNhlDbv7DXPEA=="
+          "version": "13.13.51",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.51.tgz",
+          "integrity": "sha512-66/xg5I5Te4oGi5Jws11PtNmKkZbOPZWyBZZ/l5AOrWj1Dyw+6Ge/JhYTq/2/Yvdqyhrue8RL+DGI298OJ0xcg=="
         }
       }
     },
@@ -8785,9 +8785,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.20.1",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.20.1.tgz",
-      "integrity": "sha512-qFExaxdu9bNgvkv5TCE/AOyCCOWjjFRuX3Dhf0TWbpj+TtzgpZj2nmi4AG3XiOBn1cQUZ7pCSHoy7bNJeyUBww==",
+      "version": "4.20.2",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.20.2.tgz",
+      "integrity": "sha512-cxRU6lNybAJgOs1RPDTk3fJh7rS0BkXSAw/8/GFGTeJlQ+dNhEnCWni7PKmaZT9phFNOqLQcDd8+oOZZB5UQnw==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "needle": "^2.6.0",
     "sleep-promise": "^8.0.1",
     "snyk-config": "4.0.0",
-    "snyk-docker-plugin": "^4.20.1",
+    "snyk-docker-plugin": "^4.20.2",
     "source-map-support": "^0.5.16",
     "tunnel": "0.0.6",
     "typescript": "^3.9.9",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Excluding `gradle/cache` paths when extracting `jar`s from images.

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_
