### PR TITLE
[RUN-1516] Add gcloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,12 @@ RUN chmod 755 /usr/bin/dumb-init
 RUN groupadd -g 10001 snyk
 RUN useradd -g snyk -d /srv/app -u 10001 snyk
 
+# Install gcloud 
+RUN curl -sL https://sdk.cloud.google.com > /install.sh
+RUN bash /install.sh --disable-prompts --install-dir=/
+ENV PATH=/google-cloud-sdk/bin:$PATH
+RUN rm /install.sh
+
 WORKDIR /srv/app
 
 COPY --chown=snyk:snyk --from=skopeo-build /usr/bin/skopeo /usr/bin/skopeo

--- a/README.md
+++ b/README.md
@@ -43,13 +43,24 @@ The Snyk Integration ID is used in the `--from-literal=integrationId=` parameter
 
 Create a file named `dockercfg.json`. Store your `dockercfg` in there; it should look like this:
 
-```json
+```hjson
 {
+  // If your cluster does not run on GKE or it runs on GKE and pulls images from other private registries, add the following:
   "auths": {
     "gcr.io": {
       "auth": "BASE64-ENCODED-AUTH-DETAILS"
     }
     // Add other registries as necessary
+  },
+  
+  // If your cluster runs on GKE and you are using GCR, add the following:
+  "credHelpers": {
+    "us.gcr.io": "gcloud",
+    "asia.gcr.io": "gcloud",
+    "marketplace.gcr.io": "gcloud",
+    "gcr.io": "gcloud",
+    "eu.gcr.io": "gcloud",
+    "staging-k8s.gcr.io": "gcloud"
   }
 }
 ```


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds gcloud to the image. This to allow users to automatically access GCR images when their whole cluster runs on GKE. 