### PR TITLE
chore: remove initContainer leftover data

### DIFF
--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -23,11 +23,6 @@ image:
   tag: IMAGE_TAG_OVERRIDE_WHEN_PUBLISHING
   pullPolicy: Always
 
-# If deploying in an air-gapped environment that can't pull from DockerHub, override the initContainer's image here for one that is accessible to your environment.
-initContainerImage:
-  repository: busybox
-  tag: latest
-
 # The snyk-monitor requires knowing the cluster name so that it can organise
 # scanned workloads. The Kubernetes API does not provide an API to query this.
 # Set the name of the cluster, otherwise the snyk-monitor will set this to a default value.

--- a/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
@@ -26,10 +26,6 @@ metadata:
               "create": false,
               "name": "snyk-monitor-pvc",
               "storageClassName": null
-            },
-            "initContainerImage": {
-              "repository": "busybox",
-              "tag": "latest"
             }
           }
         }
@@ -138,18 +134,6 @@ spec:
               The name of the StorageClass to use for the PVC, when enabled.
             displayName: PVC StorageClass name
             path: pvc.storageClassName
-            x-descriptors:
-              - "urn:alm:descriptor:text"
-          - description: >-
-              The repo to use for initContainer, if overriding.
-            displayName: InitContainer image repo
-            path: initContainerImage.repository
-            x-descriptors:
-              - "urn:alm:descriptor:text"
-          - description: >-
-              The tag for the initContainer's image.
-            displayName: InitContainer image tag
-            path: initContainerImage.tag
             x-descriptors:
               - "urn:alm:descriptor:text"
   description: |-

--- a/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snykmonitors.charts.helm.k8s.io.crd.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snykmonitors.charts.helm.k8s.io.crd.yaml
@@ -57,13 +57,6 @@ spec:
                 storageClassName:
                   type: string
               type: object
-            initContainerImage:
-              properties:
-                repository:
-                  type: string
-                tag:
-                  type: string
-              type: object
   # "version" will be deprecated in apiextensions.k8s.io/v1
   version: v1alpha1
   versions:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Remove `initContainer` leftover data after we removed usage of `initContainer` in #742 
