### PR TITLE
fix: revert mount permissions and init container

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -18,10 +18,23 @@ spec:
         app.kubernetes.io/name: {{ include "snyk-monitor.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      securityContext:
-        fsGroup: 2000
       serviceAccountName: {{ include "snyk-monitor.name" . }}
       restartPolicy: Always
+      initContainers:
+        - name: volume-permissions
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          command : ['sh', '-c', 'chmod -R go+rwX /var/tmp || true']
+          volumeMounts:
+            - name: temporary-storage
+              mountPath: "/var/tmp"
+          securityContext:
+            privileged: false
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
       containers:
         - name: {{ include "snyk-monitor.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
### What this does

This reverts commit be7c3e343da2b8e417e7eeabd44466787d5fc686, reversing
changes made to 24f49225aa72e60b48ef5bea6138cbe703517e4c.

OpenShift is unhappy about this change!