### PR TITLE
chore: remove placeholders for internal link from github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,11 +10,6 @@ _Explain why this PR exists_
 
 _Instructions on how to run this locally, background context, what to review, questions…_
 
-### More information
-
-- [Jira ticket SC-0000](https://snyksec.atlassian.net/browse/SC-0000)
-- [Link to documentation](https://github.com/Snyk/registry/wiki/)
-
 ### Screenshots
 
 _Visuals that may help the reviewer_


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Remove placeholders for internal link from github PR template

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_