### PR TITLE
fix: upgrade Helm Operator base image to resolve 3 high severity vulns

### DIFF
--- a/snyk-operator/build/Dockerfile
+++ b/snyk-operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/helm-operator:v1.5.0
+FROM quay.io/operator-framework/helm-operator:v1.7.2
 
 LABEL name="Snyk Operator" \
       maintainer="support@snyk.io" \


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

**Before:**
```shell
✗ High severity vulnerability found in openssl-libs
  Description: RHSA-2021:1024
  Info: https://snyk.io/vuln/SNYK-RHEL8-OPENSSLLIBS-1089748
  Introduced through: openssl-libs@1:1.1.1g-12.el8_3
  From: openssl-libs@1:1.1.1g-12.el8_3
  Fixed in: 1:1.1.1g-15.el8_3

✗ High severity vulnerability found in nettle
  Description: RHSA-2021:1206
  Info: https://snyk.io/vuln/SNYK-RHEL8-NETTLE-1287634
  Introduced through: nettle@3.4.1-2.el8
  From: nettle@3.4.1-2.el8
  Fixed in: 0:3.4.1-4.el8_3

✗ High severity vulnerability found in gnutls
  Description: RHSA-2021:1206
  Info: https://snyk.io/vuln/SNYK-RHEL8-GNUTLS-1287630
  Introduced through: gnutls@3.6.14-7.el8_3
  From: gnutls@3.6.14-7.el8_3
  Fixed in: 0:3.6.14-8.el8_3

Tested 104 dependencies for known issues, found 3 issues.
```

**After:**
```shell
✓ Tested 104 dependencies for known issues, no vulnerable paths found.
```