### PR TITLE
feat: allow setting and using NODE_EXTRA_CA_CERTS

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -59,6 +59,8 @@ spec:
           - name: registries-conf
             mountPath: "/srv/app/.config/containers"
           env:
+          - name: NODE_EXTRA_CA_CERTS
+            value: {{ .Values.extraCaCerts }}
           - name: SNYK_INTEGRATION_ID
             valueFrom:
               secretKeyRef:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -66,6 +66,8 @@ envs:
   - name: NODE_OPTIONS
     value: --max_old_space_size=2048
 
+extraCaCerts: /srv/app/certs/ca.pem
+
 # CPU/Mem requests and limits for snyk-monitor
 requests:
   cpu: '250m'


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Currently users can provide certificate files to be used to validate the TLS connection when pulling images from private container registries. However, these certificates are not used when doing HTTP requests to Kubernetes Upstream - the certs are used only for contacting the container registries.

If users provide a CA certificate under a configurable path (by default `/srv/app/certs/ca.pem`) then we can now use this cert to validate the chain of certs in the TLS connection to Kubernetes Upstream.

This is useful for on-prem customers that run their own copy of the Snyk infrastructure and provision their own certificates for TLS.

### Notes for the reviewer

Manually tested 🙏 

I also considered automatically loading certificates from the `/srv/app/certs` directory, decoding the PEM to BER, and then using https://www.npmjs.com/package/pkijs to filter out only the Root CA certificates. Then we can load these certs in `needle`'s `options` parameter. However, it seems like significantly more work and has a lot more failure modes to deal with so I opted for the easy path now. We can definitely consider doing this auto-provisioning method at a later point!
