### PR TITLE
feat: Helm flag to set the Orgs to use for workload auto import/delete

### DIFF
--- a/snyk-monitor/templates/configmap.yaml
+++ b/snyk-monitor/templates/configmap.yaml
@@ -3,9 +3,35 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-excluded-namespaces
+  labels:
+    app.kubernetes.io/name: {{ include "snyk-monitor.name" . }}
+    helm.sh/chart: {{ include "snyk-monitor.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   excludedNamespaces: |-
     {{- range .Values.excludedNamespaces }}
     {{ . }}
     {{- end }}
 {{ end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.workloadPoliciesMap }}
+  labels:
+    app.kubernetes.io/name: {{ include "snyk-monitor.name" . }}
+    helm.sh/chart: {{ include "snyk-monitor.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  workload-events.rego: |-
+    package snyk
+
+    orgs := {{ .Values.policyOrgs | toJson }}
+
+    default workload_events = false
+
+    workload_events {
+      input.kind != "Job"
+    }

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -7,7 +7,11 @@
 monitorSecrets: snyk-monitor
 certsConfigMap: snyk-monitor-certs
 registriesConfConfigMap: snyk-monitor-registries-conf
+
+# The ConfigMap to use for loading policies into snyk-monitor.
 workloadPoliciesMap: snyk-monitor-workload-policies
+# A list of Snyk Organization public IDs to let snyk-monitor know in which Organization to auto-import and auto-delete scanned images.
+policyOrgs:
 
 # One of: Cluster, Namespaced
 # Cluster - creates a ClusterRole and ClusterRoleBinding with the ServiceAccount
@@ -60,9 +64,9 @@ rbac:
 # Node.js in-container process memory enhancements
 envs:
   - name: V8_MAX_OLD_SPACE_SIZE
-    value: '2048'
+    value: "2048"
   - name: UV_THREADPOOL_SIZE
-    value: '24'
+    value: "24"
   - name: NODE_OPTIONS
     value: --max_old_space_size=2048
 
@@ -70,12 +74,12 @@ extraCaCerts: /srv/app/certs/ca.pem
 
 # CPU/Mem requests and limits for snyk-monitor
 requests:
-  cpu: '250m'
-  memory: '400Mi'
+  cpu: "250m"
+  memory: "400Mi"
 
 limits:
-  cpu: '1'
-  memory: '2Gi'
+  cpu: "1"
+  memory: "2Gi"
 
 http_proxy:
 https_proxy:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The workload auto-import and auto-delete policy now comes as a preset. In order to use it, users should provide a list of Snyk Organization public IDs so that snyk-monitor knows which Orgs to use for importing or deleting scanned images.
