### PR TITLE
fix: remove Buffer constructor use for security reasons

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
     "@typescript-eslint/await-thenable": "error",
     "@typescript-eslint/ban-ts-comment": "error",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
-    "@typescript-eslint/unbound-method": "error"
+    "@typescript-eslint/unbound-method": "error",
+    "node/prefer-global/buffer": "off"
   }
 }

--- a/src/scanner/images/credentials.ts
+++ b/src/scanner/images/credentials.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import * as aws from 'aws-sdk';
 
 import { logger } from '../../common/logger';
@@ -47,7 +48,7 @@ function getEcrCredentials(region: string): Promise<string> {
         );
       }
 
-      const buff = new Buffer(authorizationTokenBase64, 'base64');
+      const buff = Buffer.from(authorizationTokenBase64, 'base64');
       const userColonPassword = buff.toString('utf-8');
       return resolve(userColonPassword);
     });


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [X] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Remove `new Buffer` usage, cos of security concerns
