### PR TITLE
Feat/stable agent

### DIFF
--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -49,6 +49,12 @@ spec:
                 name: snyk-monitor
                 key: namespace
                 optional: true
+          - name: SNYK_DEPLOYMENT_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SNYK_DEPLOYMENT_NAME
+            value: snyk-monitor
           - name: SNYK_INTEGRATION_API
             valueFrom:
               configMapKeyRef:

--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -43,7 +43,7 @@ spec:
               secretKeyRef:
                 name: snyk-monitor
                 key: integrationId
-          - name: SNYK_NAMESPACE
+          - name: SNYK_WATCH_NAMESPACE
             valueFrom:
               configMapKeyRef:
                 name: snyk-monitor

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
               secretKeyRef:
                 name: {{ .Values.monitorSecrets }}
                 key: integrationId
-          - name: SNYK_NAMESPACE
+          - name: SNYK_WATCH_NAMESPACE
             value: {{ include "snyk-monitor.scope" . }}
           - name: SNYK_INTEGRATION_API
             value: {{ .Values.integrationApi }}

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -72,6 +72,12 @@ spec:
                 key: integrationId
           - name: SNYK_WATCH_NAMESPACE
             value: {{ include "snyk-monitor.scope" . }}
+          - name: SNYK_DEPLOYMENT_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SNYK_DEPLOYMENT_NAME
+            value: {{ include "snyk-monitor.name" . }}
           - name: SNYK_INTEGRATION_API
             value: {{ .Values.integrationApi }}
           - name: SNYK_CLUSTER_NAME

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -18,7 +18,9 @@ function loadExcludedNamespaces(): string[] | null {
   }
 }
 
+// NOTE: The agent identifier is replaced with a stable identifier once snyk-monitor starts up
 config.AGENT_ID = uuidv4();
+
 config.INTEGRATION_ID = config.INTEGRATION_ID.trim();
 config.CLUSTER_NAME = config.CLUSTER_NAME || 'Default cluster';
 config.IMAGE_STORAGE_ROOT = '/var/tmp';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { currentClusterName } from './supervisor/cluster';
 import { beginWatchingWorkloads } from './supervisor/watchers';
 import { loadAndSendWorkloadEventsPolicy } from './common/policy';
 import { sendClusterMetadata } from './transmitter';
+import { setSnykMonitorAgentId } from './supervisor/agent';
 
 process.on('uncaughtException', (err) => {
   if (state.shutdownInProgress) {
@@ -63,6 +64,7 @@ cleanUpTempStorage();
 
 // Allow running in an async context
 setImmediate(async function setUpAndMonitor(): Promise<void> {
+  await setSnykMonitorAgentId();
   await sendClusterMetadata();
   await loadAndSendWorkloadEventsPolicy();
   await monitor();

--- a/src/supervisor/agent.ts
+++ b/src/supervisor/agent.ts
@@ -1,0 +1,34 @@
+import { config } from '../common/config';
+import { logger } from '../common/logger';
+import { k8sApi } from './cluster';
+import { retryKubernetesApiRequest } from './kuberenetes-api-wrappers';
+
+export async function setSnykMonitorAgentId(): Promise<void> {
+  const name = config.DEPLOYMENT_NAME;
+  const namespace = config.DEPLOYMENT_NAMESPACE;
+
+  const agentId = await getSnykMonitorDeploymentUid(name, namespace);
+  if (agentId === undefined) {
+    return;
+  }
+
+  config.AGENT_ID = agentId;
+}
+
+async function getSnykMonitorDeploymentUid(
+  name: string,
+  namespace: string,
+): Promise<string | undefined> {
+  try {
+    const attemptedApiCall = await retryKubernetesApiRequest(() =>
+      k8sApi.appsClient.readNamespacedDeployment(name, namespace),
+    );
+    return attemptedApiCall.body.metadata?.uid;
+  } catch (error) {
+    logger.error(
+      { error, namespace, name },
+      'could not read the snyk-monitor deployment unique id',
+    );
+    return undefined;
+  }
+}

--- a/src/supervisor/watchers/index.ts
+++ b/src/supervisor/watchers/index.ts
@@ -116,12 +116,12 @@ async function setupWatchesForCluster(): Promise<void> {
 }
 
 export async function beginWatchingWorkloads(): Promise<void> {
-  if (config.NAMESPACE) {
+  if (config.WATCH_NAMESPACE) {
     logger.info(
-      { namespace: config.NAMESPACE },
+      { namespace: config.WATCH_NAMESPACE },
       'kubernetes-monitor restricted to specific namespace',
     );
-    await setupWatchesForNamespace(config.NAMESPACE);
+    await setupWatchesForNamespace(config.WATCH_NAMESPACE);
     return;
   }
 

--- a/src/transmitter/payload.ts
+++ b/src/transmitter/payload.ts
@@ -9,7 +9,6 @@ import {
   IWorkloadMetadataPayload,
   IWorkloadMetadata,
   IWorkloadLocator,
-  IKubernetesMonitorMetadata,
   ScanResultsPayload,
   IDependencyGraphPayload,
   IWorkloadEventsPolicyPayload,
@@ -38,17 +37,10 @@ export function constructDepGraph(
       name,
     };
 
-    const monitorMetadata: IKubernetesMonitorMetadata = {
-      agentId: config.AGENT_ID,
-      namespace: config.WATCH_NAMESPACE,
-      version: config.MONITOR_VERSION,
-    };
-
     return {
       imageLocator,
       agentId: config.AGENT_ID,
       dependencyGraph: JSON.stringify(scannedImage.pluginResult),
-      metadata: monitorMetadata,
     };
   });
 
@@ -78,17 +70,10 @@ export function constructScanResults(
       name,
     };
 
-    const monitorMetadata: IKubernetesMonitorMetadata = {
-      agentId: config.AGENT_ID,
-      namespace: config.WATCH_NAMESPACE,
-      version: config.MONITOR_VERSION,
-    };
-
     return {
       imageLocator,
       agentId: config.AGENT_ID,
       scanResults: scannedImage.scanResults,
-      metadata: monitorMetadata,
     };
   });
 }

--- a/src/transmitter/payload.ts
+++ b/src/transmitter/payload.ts
@@ -40,7 +40,7 @@ export function constructDepGraph(
 
     const monitorMetadata: IKubernetesMonitorMetadata = {
       agentId: config.AGENT_ID,
-      namespace: config.NAMESPACE,
+      namespace: config.WATCH_NAMESPACE,
       version: config.MONITOR_VERSION,
     };
 
@@ -80,7 +80,7 @@ export function constructScanResults(
 
     const monitorMetadata: IKubernetesMonitorMetadata = {
       agentId: config.AGENT_ID,
-      namespace: config.NAMESPACE,
+      namespace: config.WATCH_NAMESPACE,
       version: config.MONITOR_VERSION,
     };
 

--- a/src/transmitter/types.ts
+++ b/src/transmitter/types.ts
@@ -31,25 +31,16 @@ export interface IImageLocator extends IWorkloadLocator {
   imageWithDigest?: string;
 }
 
-export interface IKubernetesMonitorMetadata {
-  agentId: string;
-  version: string;
-  namespace?: string;
-}
-
 export interface IDependencyGraphPayload {
   imageLocator: IImageLocator;
   agentId: string;
   dependencyGraph?: string;
-  metadata: IKubernetesMonitorMetadata;
 }
 
 export interface ScanResultsPayload {
   imageLocator: IImageLocator;
   agentId: string;
   scanResults: ScanResult[];
-  /** @deprecated TODO: This should be sent in a separate API. */
-  metadata: IKubernetesMonitorMetadata;
 }
 
 export interface IWorkloadMetadataPayload {

--- a/test/fixtures/pod-spec.json
+++ b/test/fixtures/pod-spec.json
@@ -12,7 +12,7 @@
           }
         },
         {
-          "name": "SNYK_NAMESPACE"
+          "name": "SNYK_WATCH_NAMESPACE"
         },
         {
           "name": "SNYK_INTEGRATION_API"

--- a/test/setup/deployers/yaml.ts
+++ b/test/setup/deployers/yaml.ts
@@ -34,14 +34,18 @@ function createTestYamlDeployment(
   );
   const deployment = parse(originalDeploymentYaml);
 
-  deployment.spec.template.spec.containers[0].image = imageNameAndTag;
-  deployment.spec.template.spec.containers[0].imagePullPolicy = imagePullPolicy;
+  const container = deployment.spec.template.spec.containers.find(
+    (container) => container.name === 'snyk-monitor',
+  );
+  container.image = imageNameAndTag;
+  container.imagePullPolicy = imagePullPolicy;
 
   // Inject the baseUrl of kubernetes-upstream that snyk-monitor container use to send metadata
-  deployment.spec.template.spec.containers[0].env[2] = {
-    name: 'SNYK_INTEGRATION_API',
-    value: 'https://kubernetes-upstream.dev.snyk.io',
-  };
+  const envVar = container.env.find(
+    (env) => env.name === 'SNYK_INTEGRATION_API',
+  );
+  envVar.value = 'https://kubernetes-upstream.dev.snyk.io';
+  delete envVar.valueFrom;
 
   writeFileSync(newYamlPath, stringify(deployment));
   console.log('Created YAML snyk-monitor deployment');

--- a/test/unit/transmitter-payload.spec.ts
+++ b/test/unit/transmitter-payload.spec.ts
@@ -125,11 +125,6 @@ describe('transmitter payload tests', () => {
         type: 'type',
       }),
     );
-    expect(firstPayload.metadata).toEqual({
-      agentId: config.AGENT_ID,
-      namespace: 'b7',
-      version: '1.2.3',
-    });
 
     config.WATCH_NAMESPACE = backups.namespace;
     config.MONITOR_VERSION = backups.version;

--- a/test/unit/transmitter-payload.spec.ts
+++ b/test/unit/transmitter-payload.spec.ts
@@ -101,10 +101,10 @@ describe('transmitter payload tests', () => {
     // These values are populated at runtime (injected by the deployment) so we have to mock them
     // to make sure the function uses them to construct the payload (otherwise they are undefined).
     const backups = {
-      namespace: config.NAMESPACE,
+      namespace: config.WATCH_NAMESPACE,
       version: config.MONITOR_VERSION,
     };
-    config.NAMESPACE = 'b7';
+    config.WATCH_NAMESPACE = 'b7';
     config.MONITOR_VERSION = '1.2.3';
 
     const payloads = payload.constructScanResults(
@@ -131,7 +131,7 @@ describe('transmitter payload tests', () => {
       version: '1.2.3',
     });
 
-    config.NAMESPACE = backups.namespace;
+    config.WATCH_NAMESPACE = backups.namespace;
     config.MONITOR_VERSION = backups.version;
   });
 


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Agent ID is now a stable identifier instead of getting randomly generated every time the application starts, this ensures we are tracking the same deployment of the snyk-monitor throughout application upgrades.