### PR TITLE
fix: add permissions to the Operator to apply NetworkPolicies

### DIFF
--- a/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
@@ -227,6 +227,12 @@ spec:
                 - deploymentconfigs
               verbs:
                 - "*"
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - "*"
           serviceAccountName: snyk-operator
       deployments:
         - name: snyk-operator


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Missed in the previous change. This allows the Operator to apply our Helm chart, which now contains a default NetworkPolicy.

