### PR TITLE
feat: add metadata annotations for deployment

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
         app.kubernetes.io/name: {{ include "snyk-monitor.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
+      {{- with .Values.metadata.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       affinity:
         nodeAffinity:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -91,6 +91,10 @@ log_level:
 
 nodeSelector: {}
 
+# Additional annotations for the snyk-monitor Deployment's Pod
+metadata:
+  annotations: {}
+
 psp:
   enabled: false
   name: ""


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Allow setting annotations on the PodSpec of the snyk-monitor Deployment, which is useful for annotating it with AWS-specific data.

### Notes for the reviewer

Cherry-picked from https://github.com/snyk/kubernetes-monitor/pull/793
Closes https://github.com/snyk/kubernetes-monitor/issues/765
