### PR TITLE
chore: Add clusterName advice to README

### DIFF
--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -98,6 +98,8 @@ helm upgrade --install snyk-monitor snyk-charts/snyk-monitor --namespace snyk-mo
 To better organise the data scanned inside your cluster, the monitor requires a cluster name to be set.
 Replace the value of `clusterName` with the name of your cluster.
 
+**Please note that we cannot process cluster names that include `/`. The workloads will not be imported.**
+
 ## Upgrades ##
 
 You can apply the latest version of the YAML installation files to upgrade.


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Having / in cluster name shows the cluster as empty in Snyk UI. Added note to README to advice users of this.
