### PR TITLE
snyk-monitor: Add defaultWorkloadPolicies option

### DIFF
--- a/snyk-monitor/templates/configmap.yaml
+++ b/snyk-monitor/templates/configmap.yaml
@@ -14,11 +14,12 @@ data:
     {{ . }}
     {{- end }}
 {{ end }}
+{{ if not .Values.workloadPoliciesMap }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.workloadPoliciesMap }}
+  name: {{ .Values.defaultWorkloadPoliciesMap }}
   labels:
     app.kubernetes.io/name: {{ include "snyk-monitor.name" . }}
     helm.sh/chart: {{ include "snyk-monitor.chart" . }}
@@ -35,3 +36,4 @@ data:
     workload_events {
       input.kind != "Job"
     }
+{{ end }}

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -166,7 +166,11 @@ spec:
             optional: true
         - name: workload-policies
           configMap:
+            {{- if .Values.workloadPoliciesMap }}
             name: {{ .Values.workloadPoliciesMap }}
+            {{- else }}
+            name: {{ .Values.defaultWorkloadPoliciesMap }}
+            {{- end }}
             optional: true
         - name: registries-conf
           configMap:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -8,10 +8,17 @@ monitorSecrets: snyk-monitor
 certsConfigMap: snyk-monitor-certs
 registriesConfConfigMap: snyk-monitor-registries-conf
 
-# The ConfigMap to use for loading policies into snyk-monitor.
-workloadPoliciesMap: snyk-monitor-workload-policies
+# An external ConfigMap to use for loading policies into snyk-monitor.
+# If not set, defaultWorkloadPoliciesMap will be used.
+workloadPoliciesMap: ""
+
 # A list of Snyk Organization public IDs to let snyk-monitor know in which Organization to auto-import and auto-delete scanned images.
-policyOrgs:
+# This is used to populate the default workload policy file.
+policyOrgs: []
+
+# Default rego workload policies to install.
+# Setting `workloadPoliciesMap` will overwrite this.
+defaultWorkloadPoliciesMap: snyk-monitor-workload-policies
 
 # One of: Cluster, Namespaced
 # Cluster - creates a ClusterRole and ClusterRoleBinding with the ServiceAccount


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

To provide an option to pass an external ConfigMap containing workload policies. Currently it's not possible to provide a custom ConfigMap, as the default one is created and mounted by default. More info in https://github.com/snyk/kubernetes-monitor/issues/809

### Notes for the reviewer

I decided introduce a slight change to the values.yaml interface regarding workload policies, but in terms of default behaviour, those changes don't change anything. The default policy will still be installed by default as it happens in the current version.

`workloadPoliciesMap` changes behaviour to represent an external ConfigMap name instead of the default map name.

I'm of course open for changes on the interface, but in my opinion this is the most flexible setup.

This change might affect documentation on: https://support.snyk.io/hc/en-us/articles/360020835037-Automatic-import-deletion-of-Kubernetes-workloads-projects, although with the current version, the last section of that documentation where an external ConfigMap is created, doesn't really work.