### PR TITLE
[RUN-1602] Remove slashes from cluster names

### DIFF
--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -98,7 +98,7 @@ helm upgrade --install snyk-monitor snyk-charts/snyk-monitor --namespace snyk-mo
 To better organise the data scanned inside your cluster, the monitor requires a cluster name to be set.
 Replace the value of `clusterName` with the name of your cluster.
 
-**Please note that we cannot process cluster names that include `/`. The workloads will not be imported.**
+**Please note that `/` in cluster name is disallowed. Any `/` in cluster names will be removed.**
 
 ## Upgrades ##
 

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -18,11 +18,27 @@ function loadExcludedNamespaces(): string[] | null {
   }
 }
 
+function getClusterName(): string {
+  if (!config.CLUSTER_NAME) {
+    return 'Default cluster';
+  }
+
+  if (config.CLUSTER_NAME.includes('/')) {
+    // logger is not yet created so defaulting to console.log
+    console.log(
+      `removing disallowed character "/" from clusterName (${config.CLUSTER_NAME})`,
+    );
+    return config.CLUSTER_NAME.replace(/\//g, '');
+  }
+
+  return config.CLUSTER_NAME;
+}
+
 // NOTE: The agent identifier is replaced with a stable identifier once snyk-monitor starts up
 config.AGENT_ID = uuidv4();
 
 config.INTEGRATION_ID = config.INTEGRATION_ID.trim();
-config.CLUSTER_NAME = config.CLUSTER_NAME || 'Default cluster';
+config.CLUSTER_NAME = getClusterName();
 config.IMAGE_STORAGE_ROOT = '/var/tmp';
 config.POLICIES_STORAGE_ROOT = '/tmp/policies';
 config.EXCLUDED_NAMESPACES = loadExcludedNamespaces();

--- a/test/common/config.spec.ts
+++ b/test/common/config.spec.ts
@@ -1,0 +1,62 @@
+describe('extractNamespaceName()', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test.each([
+    [
+      'cluster name with /',
+      {
+        clusterNameEnvVar: 'cluster/name',
+        wantClusterName: 'clustername',
+        consoleLogCalledTimes: 1,
+      },
+    ],
+    [
+      'cluster name with  more than one /',
+      {
+        clusterNameEnvVar: 'cluster/name/slash',
+        wantClusterName: 'clusternameslash',
+        consoleLogCalledTimes: 1,
+      },
+    ],
+    [
+      'cluster name without /',
+      {
+        clusterNameEnvVar: 'normal cluster name',
+        wantClusterName: 'normal cluster name',
+        consoleLogCalledTimes: 0,
+      },
+    ],
+    [
+      'no cluster name set',
+      {
+        clusterNameEnvVar: '',
+        wantClusterName: 'Default cluster',
+        consoleLogCalledTimes: 0,
+      },
+    ],
+  ])(
+    '%s',
+    (
+      _testCaseName,
+      { clusterNameEnvVar, wantClusterName, consoleLogCalledTimes },
+    ) => {
+      if (clusterNameEnvVar) {
+        process.env.SNYK_CLUSTER_NAME = clusterNameEnvVar;
+      }
+
+      const consoleSpy = jest.spyOn(console, 'log').mockReturnValue();
+
+      const { config } = require('../../src/common/config');
+      expect(config.CLUSTER_NAME).toBe(wantClusterName);
+      expect(consoleSpy).toHaveBeenCalledTimes(consoleLogCalledTimes);
+
+      delete process.env.SNYK_CLUSTER_NAME;
+    },
+  );
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Having `/ `in cluster name shows the cluster as empty in Snyk UI as the workloads fail to import. Any `/` in cluster names are now removed. The advice in the readme has been updated accordingly.