### PR TITLE
fix: add pvc to allowed volumes in psp

### DIFF
--- a/snyk-monitor/templates/psp.yaml
+++ b/snyk-monitor/templates/psp.yaml
@@ -33,5 +33,9 @@ spec:
   volumes:
     - secret
     - configMap
+    {{- if .Values.pvc.enabled }}
+    - persistentVolumeClaim
+    {{- else }}
     - emptyDir
+    {{- end }}
 {{- end }}{{- end }}


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Allow `persistentVolumeClaim` in PodSecurityPolicy if PersistentVolumeClaim was selected to be used in `kubernetes-monitor`

Related to #739