### PR TITLE
fix: internally track/cache watched namespaces

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -1,3 +1,4 @@
+import { V1Namespace } from '@kubernetes/client-node';
 import * as LruCache from 'lru-cache';
 
 import { config } from './common/config';
@@ -26,6 +27,7 @@ const state = {
   workloadsAlreadyScanned: new LruCache<string, string>(
     workloadsLruCacheOptions,
   ),
+  watchedNamespaces: {} as Record<string, V1Namespace>,
 };
 
 export { state };

--- a/src/transmitter/payload.ts
+++ b/src/transmitter/payload.ts
@@ -13,6 +13,7 @@ import {
   IDependencyGraphPayload,
   IWorkloadEventsPolicyPayload,
 } from './types';
+import { state } from '../state';
 
 export function constructDepGraph(
   scannedImages: IScanResult[],
@@ -99,6 +100,8 @@ export function constructWorkloadMetadata(
     specLabels: workload.specLabels,
     annotations: workload.annotations,
     specAnnotations: workload.specAnnotations,
+    namespaceAnnotations:
+      state.watchedNamespaces[workload.namespace]?.metadata?.annotations,
     revision: workload.revision,
     podSpec: workload.podSpec,
   };

--- a/src/transmitter/types.ts
+++ b/src/transmitter/types.ts
@@ -22,6 +22,7 @@ export interface IWorkloadMetadata {
   specLabels: StringMap | undefined;
   annotations: StringMap | undefined;
   specAnnotations: StringMap | undefined;
+  namespaceAnnotations: StringMap | undefined;
   revision: number | undefined;
   podSpec: V1PodSpec;
 }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Collecting the namespace metadata so that later we can use it for easy querying. Will be useful for the namespaced annotated import.

