### PR TITLE
fix: adjust yaml indetation for helm deployment

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
             readOnly: true
           - name: registries-conf
             mountPath: "/srv/app/.config/containers"
-           {{- if .Values.excludedNamespaces }}
+          {{- if .Values.excludedNamespaces }}
           - name: excluded-namespaces
             mountPath: "/etc/config"
           {{- end }}
@@ -121,7 +121,7 @@ spec:
             value: {{ quote .Values.skip_k8s_jobs }}
           {{- with .Values.envs }}
           {{- toYaml . | trim | nindent 10 -}}
-          {{ end }}
+          {{- end }}
           resources:
             requests:
               cpu: {{ .Values.requests.cpu }}


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Fix indentation for helm deployment.