### PR TITLE
fix: ensure Helm releases have unique names for the resources

### DIFF
--- a/snyk-monitor/templates/_helpers.tpl
+++ b/snyk-monitor/templates/_helpers.tpl
@@ -3,25 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "snyk-monitor.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "snyk-monitor.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+{{- default .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/snyk-operator-certified/helm-charts/snyk-monitor/templates/_helpers.tpl
+++ b/snyk-operator-certified/helm-charts/snyk-monitor/templates/_helpers.tpl
@@ -3,25 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "snyk-monitor.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "snyk-monitor.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+{{- default .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This ensures that customers can install multiple copies of snyk-monitor in their cluster.
We now ensure that all of the Helm resources have a name matching the Helm release name, which will be unique.

This allows global resources such as ClusterRoles to be unique.

### Notes for the reviewer

https://snyk.zendesk.com/agent/tickets/12631