### PR TITLE
fix: remove anthoscli from google cloud SDK reducing image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN useradd -g snyk -d /srv/app -u 10001 snyk
 
 # Install gcloud 
 RUN curl -sL https://sdk.cloud.google.com > /install.sh
-RUN bash /install.sh --disable-prompts --install-dir=/
+RUN bash /install.sh --disable-prompts --install-dir=/ && rm /google-cloud-sdk/bin/anthoscli
 ENV PATH=/google-cloud-sdk/bin:$PATH
 RUN rm /install.sh
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The Anthos CLI is not used by snyk-monitor so it can be safely removed.

### Notes for the reviewer

Reduces the image size by ~120 MB
