### PR TITLE
fix: stabilise the monitor agent id

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -15,5 +15,6 @@
   "REQUEST_QUEUE_LENGTH": 2,
   "QUEUE_LENGTH_LOG_FREQUENCY_MINUTES": 15,
   "INTEGRATION_ID": "",
-  "DEFAULT_KUBERNETES_UPSTREAM_URL": "https://kubernetes-upstream.snyk.io"
+  "DEFAULT_KUBERNETES_UPSTREAM_URL": "https://kubernetes-upstream.snyk.io",
+  "MAX_RETRY_BACKOFF_DURATION_SECONDS": 300
 }

--- a/src/supervisor/agent.ts
+++ b/src/supervisor/agent.ts
@@ -1,7 +1,7 @@
 import { config } from '../common/config';
 import { logger } from '../common/logger';
 import { k8sApi } from './cluster';
-import { retryKubernetesApiRequest } from './kuberenetes-api-wrappers';
+import { retryKubernetesApiRequestIndefinitely } from './kuberenetes-api-wrappers';
 
 export async function setSnykMonitorAgentId(): Promise<void> {
   const name = config.DEPLOYMENT_NAME;
@@ -20,8 +20,9 @@ async function getSnykMonitorDeploymentUid(
   namespace: string,
 ): Promise<string | undefined> {
   try {
-    const attemptedApiCall = await retryKubernetesApiRequest(() =>
-      k8sApi.appsClient.readNamespacedDeployment(name, namespace),
+    const attemptedApiCall = await retryKubernetesApiRequestIndefinitely(
+      () => k8sApi.appsClient.readNamespacedDeployment(name, namespace),
+      config.MAX_RETRY_BACKOFF_DURATION_SECONDS,
     );
     return attemptedApiCall.body.metadata?.uid;
   } catch (error) {

--- a/test/system/kind.spec.ts
+++ b/test/system/kind.spec.ts
@@ -58,7 +58,7 @@ test('Kubernetes-Monitor with KinD', async (jestDoneCallback) => {
 
   const agentId = randomUUID();
   const retryKubernetesApiRequestMock = jest
-    .spyOn(kubernetesApiWrappers, 'retryKubernetesApiRequest')
+    .spyOn(kubernetesApiWrappers, 'retryKubernetesApiRequestIndefinitely')
     .mockResolvedValueOnce({
       body: {
         metadata: {


### PR DESCRIPTION
Rather than retrying the request at most 3 times, and then simply setting the agentId to an automatically generated UUID, we instead keep retrying the request indefinitely until we're able to retrieve the Kubernetes Deployment ID.

The retry logic will backoff exponentially up to a maximum configured value in seconds.
