### PR TITLE
fix: exclude Pod kind from auto events

### DIFF
--- a/snyk-monitor/templates/configmap.yaml
+++ b/snyk-monitor/templates/configmap.yaml
@@ -35,5 +35,6 @@ data:
 
     workload_events {
       input.kind != "Job"
+      input.kind != "Pod"
     }
 {{ end }}


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Exclude Pod kind from auto events

This happens if Pods are running as a self-sufficient object.