### PR TITLE
fix: retry listing workloads when receiving ECONNRESET

### DIFF
--- a/src/supervisor/kuberenetes-api-wrappers.ts
+++ b/src/supervisor/kuberenetes-api-wrappers.ts
@@ -8,6 +8,12 @@ export const DEFAULT_SLEEP_SEC = 1;
 export const MAX_SLEEP_SEC = 5;
 type IKubernetesApiFunction<ResponseType> = () => Promise<ResponseType>;
 
+const RETRYABLE_NETWORK_ERRORS: string[] = [
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'ECONNRESET',
+];
+
 export async function retryKubernetesApiRequest<ResponseType>(
   func: IKubernetesApiFunction<ResponseType>,
 ): Promise<ResponseType> {
@@ -89,11 +95,7 @@ function shouldRetryRequest(err: IRequestError, attempt: number): boolean {
     return false;
   }
 
-  if (err.code === 'ECONNREFUSED') {
-    return true;
-  }
-
-  if (err.code === 'ETIMEDOUT') {
+  if (err.code && RETRYABLE_NETWORK_ERRORS.includes(err.code)) {
     return true;
   }
 

--- a/test/system/kind.spec.ts
+++ b/test/system/kind.spec.ts
@@ -176,7 +176,7 @@ test('Kubernetes-Monitor with KinD', async (jestDoneCallback) => {
     .get('/apis/apps/v1/namespaces/snyk-monitor/deployments')
     .times(1)
     .replyWithError({
-      code: 'ETIMEDOUT',
+      code: 'ECONNRESET',
     });
 
   nock('https://kubernetes-upstream.snyk.io')


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Currently this crashes the application when the API server interrupts the connection while listing namespaces.
Retrying now gives us the opportunity to recover. Since we retry only a few times, we could still eventually crash the app again. But now the app  is protected from temporary API server flakes.

### Notes for the reviewer

https://snyk.slack.com/archives/CFSQFR0TH/p1629158892003300

