### PR TITLE
fix: don't attempt to log an entire pod object

### DIFF
--- a/src/supervisor/metadata-extractor.ts
+++ b/src/supervisor/metadata-extractor.ts
@@ -177,7 +177,7 @@ export async function buildMetadataForWorkload(
 
   if (podOwner === undefined) {
     logger.info(
-      { pod },
+      { podMetadata: pod.metadata },
       'pod associated with owner, but owner not found. not building metadata.',
     );
     return undefined;


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

When encountering a pod associated with an owner, but not finding its owner, it should suffice to log the pod's metadata so we know the name and ownerReference.
Logging the entire pod object could result in either accidentally leaking sensitive data, or just logging an unbounded huge object and break log parsing.

https://snyk.slack.com/archives/CGSNWAE76/p1629843908057000