### PR TITLE
fix: the snyk-operator does not use OCP 4.9 due to deprecated APIs

### DIFF
--- a/snyk-operator-certified/Dockerfile
+++ b/snyk-operator-certified/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/operator-framework/helm-operator:v1.8.0
+FROM quay.io/operator-framework/helm-operator:v1.12
 
 LABEL name="Snyk Operator" \
       maintainer="support@snyk.io" \

--- a/snyk-operator-certified/bundle.Dockerfile
+++ b/snyk-operator-certified/bundle.Dockerfile
@@ -14,7 +14,7 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 
 # Labels added in accord with the documentation
 # https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions
-LABEL com.redhat.openshift.versions="v4.5-v4.7"
+LABEL com.redhat.openshift.versions="v4.5-v4.8"
 LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.delivery.backport=true
 

--- a/snyk-operator-certified/bundle/manifests/snyk-monitor.clusterserviceversion.yaml
+++ b/snyk-operator-certified/bundle/manifests/snyk-monitor.clusterserviceversion.yaml
@@ -39,6 +39,7 @@ metadata:
           }
         }
       ]
+    "olm.properties": '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
     capabilities: Basic Install
     categories: Developer Tools
     certified: "true"

--- a/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
@@ -34,6 +34,7 @@ metadata:
           }
         }
       ]
+    "olm.properties": '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
     capabilities: Basic Install
     categories: Developer Tools, Security
     containerImage: docker.io/snyk/kubernetes-operator:SNYK_OPERATOR_IMAGE_TAG_OVERRIDE
@@ -272,11 +273,11 @@ spec:
                     livenessProbe:
                       exec:
                         command:
-                        - "true"
+                          - "true"
                     readinessProbe:
                       exec:
                         command:
-                        - "true"
+                          - "true"
                     securityContext:
                       privileged: false
                       runAsNonRoot: true


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Kubernetes has been deprecating API(s) which will be removed and no longer available in 1.22 and in the Openshift version 4.9.

For now we disable upgrades until we resolve the deprecated APIs and upgrade them to supported versions. Without this change the current version of the Operator does not get approved to the Community Operators repo.

### Notes for the reviewer

https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/208#issuecomment-915354409
