### PR TITLE
AWS ServiceAccountToken not accessible.

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if ne .Values.securityContext.fsGroup "" }}
+      securityContext:
+        fsGroup: 65534
+      {{- end }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -172,6 +176,13 @@ spec:
             name: {{ .Values.defaultWorkloadPoliciesMap }}
             {{- end }}
             optional: true
+        {{- if .Values.volumes.projected.serviceAccountToken }}
+        - name: token-vol
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token  
+        {{- end }}
         - name: registries-conf
           configMap:
             name: {{ .Values.registriesConfConfigMap }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -108,3 +108,18 @@ psp:
 
 # Override the excluded namespaces
 excludedNamespaces:
+
+# Allow specifying a fsGroup in
+# spec:
+#   template:
+#     spec:
+#       securityContext:
+#         fsGroup: 65534 <-- here
+securityContext:
+  fsGroup: ""
+
+# A projected volume maps several existing volume sources into the same directory.
+# https://kubernetes.io/docs/concepts/storage/volumes/#projected
+volumes:
+  projected:
+    serviceAccountToken: false


### PR DESCRIPTION
### What this does

AWS ServiceAccountToken is not readable by the snyk-monitor process.
Using fsGroup and projected volume to solve the issue.

See similar problem: https://github.com/kubernetes-sigs/external-dns/pull/1185
