### PR TITLE
fix: allow configuring fsGroup and projected volumes for AWS EKS

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.securityContext.fsGroup }}
+      securityContext:
+        fsGroup: {{ int . }}
+      {{- end }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -172,6 +176,13 @@ spec:
             name: {{ .Values.defaultWorkloadPoliciesMap }}
             {{- end }}
             optional: true
+        {{- if .Values.volumes.projected.serviceAccountToken }}
+        - name: token-vol
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token  
+        {{- end }}
         - name: registries-conf
           configMap:
             name: {{ .Values.registriesConfConfigMap }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -108,3 +108,18 @@ psp:
 
 # Override the excluded namespaces
 excludedNamespaces:
+
+# Allow specifying a fsGroup in the PodSpec securityContext:
+# spec:
+#   template:
+#     spec:
+#       securityContext:
+#         fsGroup: <-- here
+securityContext:
+  fsGroup:
+
+# A projected volume maps several existing volume sources into the same directory.
+# https://kubernetes.io/docs/concepts/storage/volumes/#projected
+volumes:
+  projected:
+    serviceAccountToken: false

--- a/test/setup/deployers/helm.ts
+++ b/test/setup/deployers/helm.ts
@@ -35,7 +35,9 @@ async function deployKubernetesMonitor(
       '--set pvc.enabled=true ' +
       '--set pvc.create=true ' +
       '--set log_level="INFO" ' +
-      '--set rbac.serviceAccount.annotations."foo"="bar"',
+      '--set rbac.serviceAccount.annotations."foo"="bar" ' +
+      '--set volumes.projected.serviceAccountToken=true ' +
+      '--set securityContext.fsGroup=65534 ',
   );
   console.log(
     `Deployed ${imageOptions.nameAndTag} with pull policy ${imageOptions.pullPolicy}`,


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### Notes for the reviewer

Resolves https://github.com/snyk/kubernetes-monitor/pull/871.
Added tests with Helm.

