### PR TITLE
fix: provide possibility for user to configure requests and limits value for resources in Helm Chart

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -128,11 +128,14 @@ spec:
           {{- end }}
           resources:
             requests:
-              cpu: {{ .Values.requests.cpu }}
-              memory: {{ .Values.requests.memory }}
+            {{- range $key, $val := .Values.requests }}
+              {{ $key }}: {{ $val | quote }}
+            {{- end }}
+
             limits:
-              cpu: {{ .Values.limits.cpu }}
-              memory: {{ .Values.limits.memory }}
+            {{- range $key, $val := .Values.limits }}
+              {{ $key }}: {{ $val | quote }}
+            {{- end }}
           livenessProbe:
             exec:
               command:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -81,10 +81,12 @@ extraCaCerts: /srv/app/certs/ca.pem
 
 # CPU/Mem requests and limits for snyk-monitor
 requests:
-  cpu: "250m"
-  memory: "400Mi"
+  ephemeral-storage: "50Gi"
+  cpu: "1"
+  memory: "2Gi"
 
 limits:
+  ephemeral-storage: "50Gi"
   cpu: "1"
   memory: "2Gi"
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

It comes as a`feature request` from a customer experiencing problem of deploying snyk-monitor due to not having enough `ephemeral-storage` in the pod resources. 
We also updated the `resources.requests` to match `resources.limits` for the container, so the pod won't experience over provisioning.

### Notes for the reviewer

[Github Issue](https://github.com/snyk/kubernetes-monitor/issues/870)

