### PR TITLE
fix: allow requests and limits to be configurable

### DIFF
--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -237,6 +237,16 @@ helm upgrade --install snyk-monitor snyk-charts/snyk-monitor \
   --set volumes.projected.serviceAccountToken=true
 ```
 
+## Configuring resources
+
+If more resources is required in order to deploy snyk-monitor, you can configure the helm charts default value for requests and limits with the `--set` flag.
+```shell
+helm upgrade --install snyk-monitor snyk-charts/snyk-monitor \
+  --namespace snyk-monitor \
+  --set requests."ephemeral-storage"="50Gi"
+  --set limits."ephemeral-storage"="50Gi"
+```
+
 ## Using custom CA certificate
 You can provide custom CA certificates to use for validating TLS connections by adding them to a ConfigMap named snyk-monitor-certs. These additional certificates are used when pulling images from container registries.
 

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -127,12 +127,14 @@ spec:
           {{- toYaml . | trim | nindent 10 -}}
           {{- end }}
           resources:
+            {{- with .Values.requests }}
             requests:
-              cpu: {{ .Values.requests.cpu }}
-              memory: {{ .Values.requests.memory }}
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.limits }}
             limits:
-              cpu: {{ .Values.limits.cpu }}
-              memory: {{ .Values.limits.memory }}
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

It comes as a feature request from a customer experiencing problem of deploying snyk-monitor due to not having enough ephemeral-storage in the pod resources. We want to make requests and limits configurable, so user can adjust the value as needed.

### Notes for the reviewer

[Github Issue](https://github.com/snyk/kubernetes-monitor/issues/870)
