### PR TITLE
chore: install Helm from script instead of 3rd party repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,12 @@
 commands:
     install_helm:
-        description: Install requests library
+        description: Install Helm
         steps:
             - run:
                 command: |
-                    export DEBIAN_FRONTEND=noninteractive
-                    curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
-                    sudo apt-get install -y apt-transport-https
-                    echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-                    sudo apt-get update -qq
-                    sudo apt-get install -y helm
+                    curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+                    chmod 700 get_helm.sh
+                    ./get_helm.sh
                 name: Install Helm
     install_python_requests:
         description: Install requests library

--- a/.circleci/config/commands/install_helm.yml
+++ b/.circleci/config/commands/install_helm.yml
@@ -1,11 +1,8 @@
-description: Install requests library
+description: Install Helm
 steps:
   - run:
       name: Install Helm
       command: |
-        export DEBIAN_FRONTEND=noninteractive
-        curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
-        sudo apt-get install -y apt-transport-https
-        echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-        sudo apt-get update -qq
-        sudo apt-get install -y helm
+        curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+        chmod 700 get_helm.sh
+        ./get_helm.sh


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Install via script (https://helm.sh/docs/intro/install/#from-script) instead of from 3rd party repo. This way we can ensure that the latest release is always picked and there are no issues with downloading it.
