### PR TITLE
[RUN-1850] feat: collect telemetry to understand time spent scanning images

### DIFF
--- a/src/transmitter/payload.ts
+++ b/src/transmitter/payload.ts
@@ -12,6 +12,7 @@ import {
   ScanResultsPayload,
   IDependencyGraphPayload,
   IWorkloadEventsPolicyPayload,
+  Telemetry,
 } from './types';
 import { state } from '../state';
 
@@ -51,6 +52,7 @@ export function constructDepGraph(
 export function constructScanResults(
   scannedImages: IScanResult[],
   workloadMetadata: IWorkload[],
+  telemetry: Partial<Telemetry>,
 ): ScanResultsPayload[] {
   return scannedImages.map<ScanResultsPayload>((scannedImage) => {
     // We know that .find() won't return undefined
@@ -72,6 +74,7 @@ export function constructScanResults(
     };
 
     return {
+      telemetry,
       imageLocator,
       agentId: config.AGENT_ID,
       scanResults: scannedImage.scanResults,

--- a/src/transmitter/types.ts
+++ b/src/transmitter/types.ts
@@ -42,6 +42,7 @@ export interface ScanResultsPayload {
   imageLocator: IImageLocator;
   agentId: string;
   scanResults: ScanResult[];
+  telemetry: Partial<Telemetry>;
 }
 
 export interface IWorkloadMetadataPayload {
@@ -95,4 +96,11 @@ export interface IResponseWithAttempts {
 export interface IRequestError {
   code: string;
   message: string;
+}
+
+export interface Telemetry {
+  enqueueDurationMs: number;
+  queueSize: number;
+  imagePullDurationMs: number;
+  imageScanDurationMs: number;
 }

--- a/test/system/kind.spec.ts
+++ b/test/system/kind.spec.ts
@@ -250,6 +250,12 @@ test('Kubernetes-Monitor with KinD', async (jestDoneCallback) => {
       try {
         expect(requestBody).toEqual<transmitterTypes.ScanResultsPayload>({
           agentId,
+          telemetry: {
+            enqueueDurationMs: expect.any(Number),
+            imagePullDurationMs: expect.any(Number),
+            imageScanDurationMs: expect.any(Number),
+            queueSize: expect.any(Number),
+          },
           imageLocator: expect.objectContaining({
             imageId: expect.any(String),
           }),

--- a/test/unit/transmitter-payload.spec.ts
+++ b/test/unit/transmitter-payload.spec.ts
@@ -60,8 +60,14 @@ describe('transmitter payload tests', () => {
         },
       ];
 
+      const telemetry: Record<string, number> = {};
+
       expect(() =>
-        payload.constructScanResults(scannedImages, workloadMetadata),
+        payload.constructScanResults(
+          scannedImages,
+          workloadMetadata,
+          telemetry,
+        ),
       ).toThrow();
     },
   );
@@ -97,6 +103,7 @@ describe('transmitter payload tests', () => {
         podSpec: podSpecFixture,
       },
     ];
+    const telemetry: Record<string, number> = {};
 
     // These values are populated at runtime (injected by the deployment) so we have to mock them
     // to make sure the function uses them to construct the payload (otherwise they are undefined).
@@ -110,6 +117,7 @@ describe('transmitter payload tests', () => {
     const payloads = payload.constructScanResults(
       scannedImages,
       workloadMetadata,
+      telemetry,
     );
     expect(payloads).toHaveLength(1);
 


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

We are looking to improve our process of scanning images. Right now we have no visibility into how long an average image scan takes. For this reason we collect the following timings: time spent in queue, time spent pulling images, time spent scanning images. Additionally, collect the current queue size at the start of the image scan.
