### PR TITLE
fix: allow overriding queue size with environment variable

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -42,6 +42,8 @@ config.CLUSTER_NAME = getClusterName();
 config.IMAGE_STORAGE_ROOT = '/var/tmp';
 config.POLICIES_STORAGE_ROOT = '/tmp/policies';
 config.EXCLUDED_NAMESPACES = loadExcludedNamespaces();
+config.WORKLOADS_TO_SCAN_QUEUE_WORKER_COUNT =
+  Number(config.WORKLOADS_TO_SCAN_QUEUE_WORKER_COUNT) || 10;
 
 /**
  * Important: we delete the following env vars because we don't want to proxy requests to the Kubernetes API server.

--- a/test/common/config.spec.ts
+++ b/test/common/config.spec.ts
@@ -59,4 +59,18 @@ describe('extractNamespaceName()', () => {
       delete process.env.SNYK_CLUSTER_NAME;
     },
   );
+
+  it('loads the expected configuration values', () => {
+    const { config } = require('../../src/common/config');
+    expect(config.AGENT_ID).toEqual(expect.any(String));
+    expect(config.INTEGRATION_ID).toEqual(expect.any(String));
+    expect(config.CLUSTER_NAME).toEqual('Default cluster');
+    expect(config.IMAGE_STORAGE_ROOT).toEqual('/var/tmp');
+    expect(config.EXCLUDED_NAMESPACES).toBeNull();
+    expect(config.HTTPS_PROXY).toBeUndefined();
+    expect(config.HTTP_PROXY).toBeUndefined();
+    expect(config.NO_PROXY).toBeUndefined();
+    expect(config.SKIP_K8S_JOBS).toEqual(false);
+    expect(config.WORKLOADS_TO_SCAN_QUEUE_WORKER_COUNT).toEqual(10);
+  });
 });


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

You can now set the environment variable SNYK_WORKLOADS_TO_SCAN_QUEUE_WORKER_COUNT to override the queue size.

