### PR TITLE
fix: remove docker layer caching in build step to bring new node versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,6 @@ jobs:
         working_directory: ~/kubernetes-monitor
     build_image:
         machine:
-            docker_layer_caching: true
             image: ubuntu-2004:202010-01
         steps:
             - checkout

--- a/.circleci/config/jobs/@jobs.yml
+++ b/.circleci/config/jobs/@jobs.yml
@@ -1,7 +1,6 @@
 build_image:
   machine:
     image: ubuntu-2004:202010-01
-    docker_layer_caching: true
   working_directory: ~/kubernetes-monitor
   steps:
     - checkout


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Remove docker layer caching in the build step to bring new node versions

Docker layer prevent to execute installation of new node version, hence older versions are brought to release 
