### PR TITLE
fix: upgrade aws-sdk from 2.995.0 to 2.999.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1955,9 +1955,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.995.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.995.0.tgz",
-      "integrity": "sha512-2tZv0GLI7SAhV6hGIhZArCvF2OcQNPrGNmtPtOhBWmovYJ5qIaibtFFtSee3O8jWX87KGDkBA5fgBMXrcG7i/w==",
+      "version": "2.999.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.999.0.tgz",
+      "integrity": "sha512-OcnD7m+HCZv2qDzmS7TgABGf26mVPfIyah0Dgz7hHAxBtx78qFWi/s9U6BDxVBKWLg7OKWVHf0opiMG4ujteqg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@kubernetes/client-node": "^0.15.1",
     "@snyk/dep-graph": "^1.29.0",
     "async": "^3.2.1",
-    "aws-sdk": "^2.995.0",
+    "aws-sdk": "^2.999.0",
     "bunyan": "^1.8.15",
     "child-process-promise": "^2.2.1",
     "fs-extra": "^10.0.0",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Upgrade aws-sdk from 2.995.0 to 2.999.0
