### PR TITLE
Feat/cache control

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -4,7 +4,7 @@
     "level": "info"
   },
   "IMAGES_SCANNED_CACHE": {
-    "MAX_SIZE": 10000,
+    "MAX_SIZE": 20000,
     "MAX_AGE_MS": 86400000
   },
   "WORKLOADS_SCANNED_CACHE": {

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -18,6 +18,7 @@ import {
   Telemetry,
 } from '../transmitter/types';
 import { IPullableImage, IScanImage } from './images/types';
+import { getWorkloadAlreadyScanned } from '../state';
 
 export async function processWorkload(
   workloadMetadata: IWorkload[],
@@ -124,6 +125,17 @@ async function scanImagesAndSendResults(
     logger.info(
       { workloadName },
       'no images were scanned, halting scanner process.',
+    );
+    return;
+  }
+
+  // All workloads are identical, pick the first one
+  const workload = workloadMetadata[0];
+  const state = await getWorkloadAlreadyScanned(workload);
+  if (state === undefined) {
+    logger.info(
+      { workloadName },
+      'the workload has been deleted while scanning was in progress, skipping sending scan results',
     );
     return;
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,4 +1,4 @@
-import { V1Namespace } from '@kubernetes/client-node';
+import { KubernetesObject, V1Namespace } from '@kubernetes/client-node';
 import * as LruCache from 'lru-cache';
 
 import { config } from './common/config';
@@ -21,7 +21,99 @@ const workloadsLruCacheOptions = {
   updateAgeOnGet: false,
 };
 
-const state = {
+interface WorkloadAlreadyScanned {
+  namespace: string;
+  type: string;
+  uid: string;
+}
+
+interface WorkloadImagesAlreadyScanned {
+  namespace: string;
+  type: string;
+  uid: string;
+  imageIds: string[];
+}
+
+function getWorkloadAlreadyScannedKey(
+  workload: WorkloadAlreadyScanned,
+): string {
+  return `${workload.namespace}/${workload.type}/${workload.uid}`;
+}
+
+function getWorkloadImageAlreadyScannedKey(
+  workload: WorkloadAlreadyScanned,
+  imageId: string,
+): string {
+  return `${workload.namespace}/${workload.type}/${workload.uid}/${imageId}`;
+}
+
+export async function getWorkloadAlreadyScanned(
+  workload: WorkloadAlreadyScanned,
+): Promise<string | undefined> {
+  const key = getWorkloadAlreadyScannedKey(workload);
+  return state.workloadsAlreadyScanned.get(key);
+}
+
+export async function setWorkloadAlreadyScanned(
+  workload: WorkloadAlreadyScanned,
+  value: string,
+): Promise<boolean> {
+  const key = getWorkloadAlreadyScannedKey(workload);
+  return state.workloadsAlreadyScanned.set(key, value);
+}
+
+export async function deleteWorkloadAlreadyScanned(
+  workload: WorkloadAlreadyScanned,
+): Promise<void> {
+  const key = getWorkloadAlreadyScannedKey(workload);
+  state.workloadsAlreadyScanned.del(key);
+}
+
+export async function getWorkloadImageAlreadyScanned(
+  workload: WorkloadAlreadyScanned,
+  imageId: string,
+): Promise<string | undefined> {
+  const key = getWorkloadImageAlreadyScannedKey(workload, imageId);
+  return state.imagesAlreadyScanned.get(key);
+}
+
+export async function setWorkloadImageAlreadyScanned(
+  workload: WorkloadAlreadyScanned,
+  imageId: string,
+  value: string,
+): Promise<boolean> {
+  const key = getWorkloadImageAlreadyScannedKey(workload, imageId);
+  return state.imagesAlreadyScanned.set(key, value);
+}
+
+export async function deleteWorkloadImagesAlreadyScanned(
+  workload: WorkloadImagesAlreadyScanned,
+): Promise<void> {
+  for (const imageId of workload.imageIds) {
+    const key = getWorkloadImageAlreadyScannedKey(workload, imageId);
+    state.imagesAlreadyScanned.del(key);
+  }
+}
+
+export function kubernetesObjectToWorkloadAlreadyScanned(
+  workload: KubernetesObject,
+): WorkloadAlreadyScanned | undefined {
+  if (
+    workload.metadata &&
+    workload.metadata.namespace &&
+    workload.metadata.uid &&
+    workload.kind
+  ) {
+    return {
+      namespace: workload.metadata.namespace,
+      type: workload.kind,
+      uid: workload.metadata.uid,
+    };
+  }
+  return undefined;
+}
+
+export const state = {
   shutdownInProgress: false,
   imagesAlreadyScanned: new LruCache<string, string>(imagesLruCacheOptions),
   workloadsAlreadyScanned: new LruCache<string, string>(
@@ -29,5 +121,3 @@ const state = {
   ),
   watchedNamespaces: {} as Record<string, V1Namespace>,
 };
-
-export { state };

--- a/src/supervisor/watchers/handlers/deployment.ts
+++ b/src/supervisor/watchers/handlers/deployment.ts
@@ -5,6 +5,11 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 import { IncomingMessage } from 'http';
 import { k8sApi } from '../../cluster';
 import { paginatedList } from './pagination';
+import {
+  deleteWorkloadAlreadyScanned,
+  deleteWorkloadImagesAlreadyScanned,
+  kubernetesObjectToWorkloadAlreadyScanned,
+} from '../../../state';
 
 export async function paginatedDeploymentList(namespace: string): Promise<{
   response: IncomingMessage;
@@ -33,6 +38,20 @@ export async function deploymentWatchHandler(
     !deployment.status
   ) {
     return;
+  }
+
+  const workloadAlreadyScanned =
+    kubernetesObjectToWorkloadAlreadyScanned(deployment);
+  if (workloadAlreadyScanned !== undefined) {
+    await Promise.all([
+      deleteWorkloadAlreadyScanned(workloadAlreadyScanned),
+      deleteWorkloadImagesAlreadyScanned({
+        ...workloadAlreadyScanned,
+        imageIds: deployment.spec.template.spec.containers
+          .filter((container) => container.image !== undefined)
+          .map((container) => container.image!),
+      }),
+    ]);
   }
 
   const workloadName = deployment.metadata.name || FALSY_WORKLOAD_NAME_MARKER;

--- a/src/supervisor/watchers/handlers/replica-set.ts
+++ b/src/supervisor/watchers/handlers/replica-set.ts
@@ -5,6 +5,11 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 import { IncomingMessage } from 'http';
 import { k8sApi } from '../../cluster';
 import { paginatedList } from './pagination';
+import {
+  deleteWorkloadAlreadyScanned,
+  deleteWorkloadImagesAlreadyScanned,
+  kubernetesObjectToWorkloadAlreadyScanned,
+} from '../../../state';
 
 export async function paginatedReplicaSetList(namespace: string): Promise<{
   response: IncomingMessage;
@@ -34,6 +39,20 @@ export async function replicaSetWatchHandler(
     !replicaSet.status
   ) {
     return;
+  }
+
+  const workloadAlreadyScanned =
+    kubernetesObjectToWorkloadAlreadyScanned(replicaSet);
+  if (workloadAlreadyScanned !== undefined) {
+    await Promise.all([
+      deleteWorkloadAlreadyScanned(workloadAlreadyScanned),
+      deleteWorkloadImagesAlreadyScanned({
+        ...workloadAlreadyScanned,
+        imageIds: replicaSet.spec.template.spec.containers
+          .filter((container) => container.image !== undefined)
+          .map((container) => container.image!),
+      }),
+    ]);
   }
 
   const workloadName = replicaSet.metadata.name || FALSY_WORKLOAD_NAME_MARKER;

--- a/src/supervisor/watchers/handlers/stateful-set.ts
+++ b/src/supervisor/watchers/handlers/stateful-set.ts
@@ -5,6 +5,11 @@ import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 import { IncomingMessage } from 'http';
 import { k8sApi } from '../../cluster';
 import { paginatedList } from './pagination';
+import {
+  deleteWorkloadAlreadyScanned,
+  deleteWorkloadImagesAlreadyScanned,
+  kubernetesObjectToWorkloadAlreadyScanned,
+} from '../../../state';
 
 export async function paginatedStatefulSetList(namespace: string): Promise<{
   response: IncomingMessage;
@@ -33,6 +38,20 @@ export async function statefulSetWatchHandler(
     !statefulSet.status
   ) {
     return;
+  }
+
+  const workloadAlreadyScanned =
+    kubernetesObjectToWorkloadAlreadyScanned(statefulSet);
+  if (workloadAlreadyScanned !== undefined) {
+    await Promise.all([
+      deleteWorkloadAlreadyScanned(workloadAlreadyScanned),
+      deleteWorkloadImagesAlreadyScanned({
+        ...workloadAlreadyScanned,
+        imageIds: statefulSet.spec.template.spec.containers
+          .filter((container) => container.image !== undefined)
+          .map((container) => container.image!),
+      }),
+    ]);
   }
 
   const workloadName = statefulSet.metadata.name || FALSY_WORKLOAD_NAME_MARKER;


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This change has several goals:
- remove cached keys of scanned workloads and images as soon as we receive an event about a workload being deleted
- skip sending workload scan results if the workload was deleted while image scanning was in progress

This change tries to prevent a series of race conditions and to hopefully improve memory management in the Snyk Monitor.

Additional small fixes:
- double the image cache size to allow more images to be tracked
- log queue size 1 minute after snyk monitor starts (in addition to the existing periodic 15 minutes logging)
