### PR TITLE
fix: check image cache before skipping sending scan results

### DIFF
--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -18,7 +18,10 @@ import {
   Telemetry,
 } from '../transmitter/types';
 import { IPullableImage, IScanImage } from './images/types';
-import { getWorkloadAlreadyScanned } from '../state';
+import {
+  getWorkloadAlreadyScanned,
+  getWorkloadImageAlreadyScanned,
+} from '../state';
 
 export async function processWorkload(
   workloadMetadata: IWorkload[],
@@ -131,8 +134,12 @@ async function scanImagesAndSendResults(
 
   // All workloads are identical, pick the first one
   const workload = workloadMetadata[0];
-  const state = await getWorkloadAlreadyScanned(workload);
-  if (state === undefined) {
+  const workloadState = await getWorkloadAlreadyScanned(workload);
+  const imageState = await getWorkloadImageAlreadyScanned(
+    workload,
+    workload.imageId,
+  );
+  if (workloadState === undefined && imageState === undefined) {
     logger.info(
       { workloadName },
       'the workload has been deleted while scanning was in progress, skipping sending scan results',

--- a/src/state.ts
+++ b/src/state.ts
@@ -3,7 +3,7 @@ import * as LruCache from 'lru-cache';
 
 import { config } from './common/config';
 
-const imagesLruCacheOptions = {
+const imagesLruCacheOptions: LruCache.Options<string, string> = {
   // limit cache size so we don't exceed memory limit
   max: config.IMAGES_SCANNED_CACHE.MAX_SIZE,
   // limit cache life so if our backend loses track of an image's data,
@@ -12,7 +12,7 @@ const imagesLruCacheOptions = {
   updateAgeOnGet: false,
 };
 
-const workloadsLruCacheOptions = {
+const workloadsLruCacheOptions: LruCache.Options<string, string> = {
   // limit cache size so we don't exceed memory limit
   max: config.WORKLOADS_SCANNED_CACHE.MAX_SIZE,
   // limit cache life so if our backend loses track of an image's data,


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The workload cache expires in one minute, which means that images that weren't scanned quickly enough were accidentally not transmitted to Snyk.
The check now ensures that it skips sending data only if both the workload and the image are missing.
