### PR TITLE
fix: trim workload metadata everywhere we read workloads

### DIFF
--- a/src/supervisor/watchers/handlers/cron-job.ts
+++ b/src/supervisor/watchers/handlers/cron-job.ts
@@ -1,5 +1,5 @@
 import { V1beta1CronJob, V1beta1CronJobList } from '@kubernetes/client-node';
-import { deleteWorkload } from './workload';
+import { deleteWorkload, trimWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 import { IncomingMessage } from 'http';
@@ -32,6 +32,8 @@ export async function paginatedCronJobList(namespace: string): Promise<{
 export async function cronJobWatchHandler(
   cronJob: V1beta1CronJob,
 ): Promise<void> {
+  cronJob = trimWorkload(cronJob);
+
   if (
     !cronJob.metadata ||
     !cronJob.spec ||

--- a/src/supervisor/watchers/handlers/daemon-set.ts
+++ b/src/supervisor/watchers/handlers/daemon-set.ts
@@ -1,5 +1,5 @@
 import { V1DaemonSet, V1DaemonSetList } from '@kubernetes/client-node';
-import { deleteWorkload } from './workload';
+import { deleteWorkload, trimWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 import { IncomingMessage } from 'http';
@@ -30,6 +30,8 @@ export async function paginatedDaemonSetList(namespace: string): Promise<{
 export async function daemonSetWatchHandler(
   daemonSet: V1DaemonSet,
 ): Promise<void> {
+  daemonSet = trimWorkload(daemonSet);
+
   if (
     !daemonSet.metadata ||
     !daemonSet.spec ||

--- a/src/supervisor/watchers/handlers/deployment-config.ts
+++ b/src/supervisor/watchers/handlers/deployment-config.ts
@@ -1,5 +1,5 @@
 import { IncomingMessage } from 'http';
-import { deleteWorkload } from './workload';
+import { deleteWorkload, trimWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import {
   FALSY_WORKLOAD_NAME_MARKER,
@@ -54,6 +54,8 @@ export async function paginatedDeploymentConfigList(
 export async function deploymentConfigWatchHandler(
   deploymentConfig: V1DeploymentConfig,
 ): Promise<void> {
+  deploymentConfig = trimWorkload(deploymentConfig);
+
   if (
     !deploymentConfig.metadata ||
     !deploymentConfig.spec ||

--- a/src/supervisor/watchers/handlers/deployment.ts
+++ b/src/supervisor/watchers/handlers/deployment.ts
@@ -1,5 +1,5 @@
 import { V1Deployment, V1DeploymentList } from '@kubernetes/client-node';
-import { deleteWorkload } from './workload';
+import { deleteWorkload, trimWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 import { IncomingMessage } from 'http';
@@ -30,6 +30,8 @@ export async function paginatedDeploymentList(namespace: string): Promise<{
 export async function deploymentWatchHandler(
   deployment: V1Deployment,
 ): Promise<void> {
+  deployment = trimWorkload(deployment);
+
   if (
     !deployment.metadata ||
     !deployment.spec ||

--- a/src/supervisor/watchers/handlers/job.ts
+++ b/src/supervisor/watchers/handlers/job.ts
@@ -1,5 +1,5 @@
 import { V1Job, V1JobList } from '@kubernetes/client-node';
-import { deleteWorkload } from './workload';
+import { deleteWorkload, trimWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 import { IncomingMessage } from 'http';
@@ -28,6 +28,8 @@ export async function paginatedJobList(namespace: string): Promise<{
 }
 
 export async function jobWatchHandler(job: V1Job): Promise<void> {
+  job = trimWorkload(job);
+
   if (
     !job.metadata ||
     !job.spec ||

--- a/src/supervisor/watchers/handlers/pod.ts
+++ b/src/supervisor/watchers/handlers/pod.ts
@@ -21,7 +21,7 @@ import {
 } from '../../../state';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 import { WorkloadKind } from '../../types';
-import { deleteWorkload } from './workload';
+import { deleteWorkload, trimWorkload } from './workload';
 import { k8sApi } from '../../cluster';
 import { paginatedList } from './pagination';
 
@@ -146,6 +146,8 @@ export async function podWatchHandler(pod: V1Pod): Promise<void> {
   if (!isPodReady(pod)) {
     return;
   }
+
+  pod = trimWorkload(pod);
 
   const podName =
     pod.metadata && pod.metadata.name

--- a/src/supervisor/watchers/handlers/replica-set.ts
+++ b/src/supervisor/watchers/handlers/replica-set.ts
@@ -1,5 +1,5 @@
 import { V1ReplicaSet, V1ReplicaSetList } from '@kubernetes/client-node';
-import { deleteWorkload } from './workload';
+import { deleteWorkload, trimWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 import { IncomingMessage } from 'http';
@@ -30,6 +30,8 @@ export async function paginatedReplicaSetList(namespace: string): Promise<{
 export async function replicaSetWatchHandler(
   replicaSet: V1ReplicaSet,
 ): Promise<void> {
+  replicaSet = trimWorkload(replicaSet);
+
   if (
     !replicaSet.metadata ||
     !replicaSet.spec ||

--- a/src/supervisor/watchers/handlers/replication-controller.ts
+++ b/src/supervisor/watchers/handlers/replication-controller.ts
@@ -2,7 +2,7 @@ import {
   V1ReplicationController,
   V1ReplicationControllerList,
 } from '@kubernetes/client-node';
-import { deleteWorkload } from './workload';
+import { deleteWorkload, trimWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 import { IncomingMessage } from 'http';
@@ -37,6 +37,8 @@ export async function paginatedReplicationControllerList(
 export async function replicationControllerWatchHandler(
   replicationController: V1ReplicationController,
 ): Promise<void> {
+  replicationController = trimWorkload(replicationController);
+
   if (
     !replicationController.metadata ||
     !replicationController.spec ||

--- a/src/supervisor/watchers/handlers/stateful-set.ts
+++ b/src/supervisor/watchers/handlers/stateful-set.ts
@@ -1,5 +1,5 @@
 import { V1StatefulSet, V1StatefulSetList } from '@kubernetes/client-node';
-import { deleteWorkload } from './workload';
+import { deleteWorkload, trimWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
 import { IncomingMessage } from 'http';
@@ -30,6 +30,8 @@ export async function paginatedStatefulSetList(namespace: string): Promise<{
 export async function statefulSetWatchHandler(
   statefulSet: V1StatefulSet,
 ): Promise<void> {
+  statefulSet = trimWorkload(statefulSet);
+
   if (
     !statefulSet.metadata ||
     !statefulSet.spec ||

--- a/src/supervisor/watchers/handlers/workload.ts
+++ b/src/supervisor/watchers/handlers/workload.ts
@@ -1,3 +1,6 @@
+import { V1ObjectMeta } from '@kubernetes/client-node';
+import type { KubernetesObject } from '@kubernetes/client-node';
+
 import { logger } from '../../../common/logger';
 import { IKubeObjectMetadata } from '../../types';
 import { buildWorkloadMetadata } from '../../metadata-extractor';
@@ -27,4 +30,40 @@ export async function deleteWorkload(
       'could not delete workload',
     );
   }
+}
+
+export function trimWorkloads<
+  T extends KubernetesObject & Partial<{ status: unknown; spec: unknown }>,
+>(items: T[]): KubernetesObject[] {
+  return items.map(trimWorkload);
+}
+
+/**
+ * Pick only the minimum relevant data from the workload. Sometimes the workload
+ * spec may be bloated with server-side information that is not necessary for vulnerability analysis.
+ * This ensures that any data we hold in memory is minimal, which in turn allows us to hold more workloads to scan.
+ */
+export function trimWorkload<
+  T extends KubernetesObject & Partial<{ status: unknown; spec: unknown }>,
+>(workload: T): T & { metadata: V1ObjectMeta } {
+  return {
+    apiVersion: workload.apiVersion,
+    kind: workload.kind,
+    metadata: trimMetadata(workload.metadata),
+    spec: workload.spec,
+    status: workload.status,
+  } as T & { metadata: V1ObjectMeta };
+}
+
+export function trimMetadata(metadata?: V1ObjectMeta): V1ObjectMeta {
+  return {
+    name: metadata?.name,
+    namespace: metadata?.namespace,
+    annotations: metadata?.annotations,
+    labels: metadata?.labels,
+    ownerReferences: metadata?.ownerReferences,
+    uid: metadata?.uid,
+    resourceVersion: metadata?.resourceVersion,
+    generation: metadata?.generation,
+  };
 }

--- a/src/supervisor/workload-reader.ts
+++ b/src/supervisor/workload-reader.ts
@@ -5,6 +5,7 @@ import { k8sApi } from './cluster';
 import { IKubeObjectMetadata, WorkloadKind } from './types';
 import { logger } from '../common/logger';
 import { V1DeploymentConfig } from './watchers/handlers/types';
+import { trimWorkload } from './watchers/handlers/workload';
 
 type IKubeObjectMetadataWithoutPodSpec = Omit<IKubeObjectMetadata, 'podSpec'>;
 type IWorkloadReaderFunc = (
@@ -20,7 +21,7 @@ const deploymentReader: IWorkloadReaderFunc = async (
     await kubernetesApiWrappers.retryKubernetesApiRequest(() =>
       k8sApi.appsClient.readNamespacedDeployment(workloadName, namespace),
     );
-  const deployment = deploymentResult.body;
+  const deployment = trimWorkload(deploymentResult.body);
 
   if (
     !deployment.metadata ||
@@ -59,7 +60,7 @@ const deploymentConfigReader: IWorkloadReaderFunc = async (
         workloadName,
       ),
     );
-  const deployment: V1DeploymentConfig = deploymentResult.body;
+  const deployment: V1DeploymentConfig = trimWorkload(deploymentResult.body);
 
   if (
     !deployment.metadata ||
@@ -91,7 +92,7 @@ const replicaSetReader: IWorkloadReaderFunc = async (
     await kubernetesApiWrappers.retryKubernetesApiRequest(() =>
       k8sApi.appsClient.readNamespacedReplicaSet(workloadName, namespace),
     );
-  const replicaSet = replicaSetResult.body;
+  const replicaSet = trimWorkload(replicaSetResult.body);
 
   if (
     !replicaSet.metadata ||
@@ -124,7 +125,7 @@ const statefulSetReader: IWorkloadReaderFunc = async (
     await kubernetesApiWrappers.retryKubernetesApiRequest(() =>
       k8sApi.appsClient.readNamespacedStatefulSet(workloadName, namespace),
     );
-  const statefulSet = statefulSetResult.body;
+  const statefulSet = trimWorkload(statefulSetResult.body);
 
   if (
     !statefulSet.metadata ||
@@ -155,7 +156,7 @@ const daemonSetReader: IWorkloadReaderFunc = async (
   const daemonSetResult = await kubernetesApiWrappers.retryKubernetesApiRequest(
     () => k8sApi.appsClient.readNamespacedDaemonSet(workloadName, namespace),
   );
-  const daemonSet = daemonSetResult.body;
+  const daemonSet = trimWorkload(daemonSetResult.body);
 
   if (
     !daemonSet.metadata ||
@@ -183,7 +184,7 @@ const jobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
   const jobResult = await kubernetesApiWrappers.retryKubernetesApiRequest(() =>
     k8sApi.batchClient.readNamespacedJob(workloadName, namespace),
   );
-  const job = jobResult.body;
+  const job = trimWorkload(jobResult.body);
 
   if (
     !job.metadata ||
@@ -213,7 +214,7 @@ const cronJobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
     () =>
       k8sApi.batchUnstableClient.readNamespacedCronJob(workloadName, namespace),
   );
-  const cronJob = cronJobResult.body;
+  const cronJob = trimWorkload(cronJobResult.body);
 
   if (
     !cronJob.metadata ||
@@ -247,7 +248,7 @@ const replicationControllerReader: IWorkloadReaderFunc = async (
         namespace,
       ),
     );
-  const replicationController = replicationControllerResult.body;
+  const replicationController = trimWorkload(replicationControllerResult.body);
 
   if (
     !replicationController.metadata ||


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

I noticed a few other places where the workload metadata is not trimmed.
In the logs you could still see "managedFields" appearing, which is a pretty large object in some cases.
This change now ensures that we trim the metadata everywhere we receive a workload.
