### PR TITLE
Fix/allow disabling beta node affinity

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -39,9 +39,11 @@ spec:
                 - key: "kubernetes.io/arch"
                   operator: In
                   values: ["amd64"]
+                {{- if not .Values.nodeAffinity.disableBetaArchNodeSelector }}
                 - key: "beta.kubernetes.io/arch"
                   operator: In
                   values: ["amd64"]
+                {{- end }}
       serviceAccountName: {{ include "snyk-monitor.name" . }}
       restartPolicy: Always
       initContainers:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -98,6 +98,9 @@ log_level:
 
 nodeSelector: {}
 
+nodeAffinity:
+  disableBetaArchNodeSelector: false
+
 # Additional annotations for the snyk-monitor Deployment's Pod
 metadata:
   annotations: {}

--- a/snyk-operator-certified/bundle/manifests/charts.snyk.io_snykmonitors.yaml
+++ b/snyk-operator-certified/bundle/manifests/charts.snyk.io_snykmonitors.yaml
@@ -70,6 +70,11 @@ spec:
                     pullPolicy:
                       type: string
                   type: object
+                nodeAffinity:
+                  properties:
+                    disableBetaArchNodeSelector:
+                      type: boolean
+                  type: object
             status:
               description: Status defines the observed state of SnykMonitor
               type: object

--- a/snyk-operator-certified/bundle/manifests/snyk-monitor.clusterserviceversion.yaml
+++ b/snyk-operator-certified/bundle/manifests/snyk-monitor.clusterserviceversion.yaml
@@ -41,6 +41,9 @@ metadata:
             },
             "limits": {
               "memory": "2Gi"
+            },
+            "nodeAffinity": {
+              "disableBetaArchNodeSelector": false
             }
           }
         }

--- a/snyk-operator-certified/config/manifests/bases/snyk-monitor.clusterserviceversion.yaml
+++ b/snyk-operator-certified/config/manifests/bases/snyk-monitor.clusterserviceversion.yaml
@@ -34,6 +34,9 @@ metadata:
             },
             "limits": {
               "memory": "2Gi"
+            },
+            "nodeAffinity": {
+              "disableBetaArchNodeSelector": false
             }
           }
         }

--- a/snyk-operator/build/Dockerfile
+++ b/snyk-operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/helm-operator:v1.13
+FROM quay.io/operator-framework/helm-operator:v1.14
 
 LABEL name="Snyk Operator" \
       maintainer="support@snyk.io" \

--- a/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snyk-operator.v0.0.0.clusterserviceversion.yaml
@@ -36,6 +36,9 @@ metadata:
             },
             "limits": {
               "memory": "2Gi"
+            },
+            "nodeAffinity": {
+              "disableBetaArchNodeSelector": false
             }
           }
         }
@@ -171,6 +174,12 @@ spec:
             path: limits.memory
             x-descriptors:
               - "urn:alm:descriptor:text"
+          - description: >-
+              True to disable the beta.kubernetes.io/arch node affinity term.
+            displayName: Disable beta.kubernetes.io/arch node affinity
+            path: nodeAffinity.disableBetaArchNodeSelector
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
   description: |-
     A Kubernetes Operator for creating and managing Snyk Kubernetes controller instances.
 

--- a/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snykmonitors.charts.helm.k8s.io.crd.yaml
+++ b/snyk-operator/deploy/olm-catalog/snyk-operator/0.0.0/snykmonitors.charts.helm.k8s.io.crd.yaml
@@ -81,3 +81,8 @@ spec:
                     memory:
                       type: string
                   type: object
+                nodeAffinity:
+                  properties:
+                    disableBetaArchNodeSelector:
+                      type: boolean
+                  type: object


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Allow disabling the `beta.kubernetes.io/arch` node affinity term via Helm flag for GKE AP.
