### PR TITLE
[WIP] chore: sign container images when pushing with cosign

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,19 @@ jobs:
                 name: Build image
             - run:
                 command: |
+                    docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} &&
+                    export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable") &&
+                    IMAGE_NAME_CANDIDATE=snyk/kubernetes-monitor:${IMAGE_TAG}-${CIRCLE_SHA1} &&
+                    sudo apt update &&
+                    sudo apt install -y wget &&
+                    wget https://github.com/sigstore/cosign/releases/download/v1.3.1/cosign-linux-amd64 &&
+                    sudo apt remove wget &&
+                    chmod +x ./cosign-linux-amd64 &&
+                    printf $COSIGN_PRIVATE_KEY_B64 | base64 -d > pri.key &&
+                    ./cosign-linux-amd64 sign --key ./pri.key $IMAGE_NAME_CANDIDATE
+                name: Sign image
+            - run:
+                command: |
                     ./scripts/slack/notify_failure_on_branch.py "${CIRCLE_BRANCH}" "${CIRCLE_JOB}" "${CIRCLE_BUILD_URL}" "${CIRCLE_PULL_REQUEST}" "${SLACK_WEBHOOK}"
                 name: Notify Slack on failure
                 when: on_fail

--- a/.circleci/config/jobs/@jobs.yml
+++ b/.circleci/config/jobs/@jobs.yml
@@ -14,6 +14,20 @@ build_image:
           ./scripts/docker/build-image.sh ${IMAGE_NAME_CANDIDATE} &&
           docker push ${IMAGE_NAME_CANDIDATE}
     - run:
+        name: Sign image
+        command: |
+          docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASSWORD} &&
+          export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable") &&
+          IMAGE_NAME_CANDIDATE=snyk/kubernetes-monitor:${IMAGE_TAG}-${CIRCLE_SHA1} &&
+          sudo apt update &&
+          sudo apt install -y wget &&
+          wget https://github.com/sigstore/cosign/releases/download/v1.3.1/cosign-linux-amd64 &&
+          sudo apt remove wget &&
+          chmod +x ./cosign-linux-amd64 &&
+          printf $COSIGN_PRIVATE_KEY_B64 | base64 -d > pri.key &&
+          ./cosign-linux-amd64 sign --key ./pri.key $IMAGE_NAME_CANDIDATE
+
+    - run:
         name: Notify Slack on failure
         command: |
           ./scripts/slack/notify_failure_on_branch.py "${CIRCLE_BRANCH}" "${CIRCLE_JOB}" "${CIRCLE_BUILD_URL}" "${CIRCLE_PULL_REQUEST}" "${SLACK_WEBHOOK}"


### PR DESCRIPTION
first attempt at signing our public images when pushing to the container registry

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds image signing phase

### Screenshots

![image](https://user-images.githubusercontent.com/40919381/143439831-91e66e3d-02ed-4930-adf1-e42a3dfbea07.png)
