### PR TITLE
feat(snyk-monitor): add ability to configure additionnal labels

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         app.kubernetes.io/name: {{ include "snyk-monitor.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
+        {{- with .Values.metadata.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.metadata.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -101,8 +101,9 @@ nodeSelector: {}
 nodeAffinity:
   disableBetaArchNodeSelector: false
 
-# Additional annotations for the snyk-monitor Deployment's Pod
+# Additional labels and annotations for the snyk-monitor Deployment's Pod
 metadata:
+  labels: {}
   annotations: {}
 
 psp:


### PR DESCRIPTION
Signed-off-by: Valentin Maillot <valentin.maillot@adfinis.com>

### What this does

This PR is adding the ability to add additionnal labels for the snyk-monitor pod deployment.

### Notes for the reviewer

Just add some labels et try to render the chart with `helm template .`.

### Screenshots

_Visuals that may help the reviewer_
