### PR TITLE
chore: revert @kubernetes/client-node to v0.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@snyk/kubernetes-monitor",
       "license": "private",
       "dependencies": {
-        "@kubernetes/client-node": "^0.16.1",
+        "@kubernetes/client-node": "^0.15.1",
         "@snyk/dep-graph": "^1.29.0",
         "async": "^3.2.2",
         "aws-sdk": "^2.1035.0",
@@ -1314,9 +1314,9 @@
       }
     },
     "node_modules/@kubernetes/client-node": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.16.1.tgz",
-      "integrity": "sha512-/Ah+3gFSjXFeqDMGGTyYBKug44Eu2D2qowKLdiZqxCkHdSNgy+CNk6FU1Vy80WrTvGkF/CZr4az6O5AopAiJEw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.15.1.tgz",
+      "integrity": "sha512-j3o5K4TWkdrX2yDndbEZcDxhgea6O2JKnesWoYCJ64WtMn2GbQXGBOnkn2i0WT2MugGbLR+qCm8Y3oHWBApaTA==",
       "dependencies": {
         "@types/js-yaml": "^4.0.1",
         "@types/node": "^10.12.0",
@@ -12200,9 +12200,9 @@
       }
     },
     "@kubernetes/client-node": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.16.1.tgz",
-      "integrity": "sha512-/Ah+3gFSjXFeqDMGGTyYBKug44Eu2D2qowKLdiZqxCkHdSNgy+CNk6FU1Vy80WrTvGkF/CZr4az6O5AopAiJEw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.15.1.tgz",
+      "integrity": "sha512-j3o5K4TWkdrX2yDndbEZcDxhgea6O2JKnesWoYCJ64WtMn2GbQXGBOnkn2i0WT2MugGbLR+qCm8Y3oHWBApaTA==",
       "requires": {
         "@types/js-yaml": "^4.0.1",
         "@types/node": "^10.12.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format:check": "prettier --check '{src,test}/**/*.{js,ts,json,yml}'"
   },
   "dependencies": {
-    "@kubernetes/client-node": "^0.16.1",
+    "@kubernetes/client-node": "^0.15.1",
     "@snyk/dep-graph": "^1.29.0",
     "async": "^3.2.2",
     "aws-sdk": "^2.1035.0",

--- a/src/supervisor/watchers/handlers/deployment-config.ts
+++ b/src/supervisor/watchers/handlers/deployment-config.ts
@@ -43,7 +43,6 @@ export async function paginatedDeploymentConfigList(
         namespace,
         'deploymentconfigs',
         pretty,
-        _allowWatchBookmarks,
         _continue,
         fieldSelector,
         labelSelector,

--- a/src/supervisor/watchers/handlers/index.ts
+++ b/src/supervisor/watchers/handlers/index.ts
@@ -134,10 +134,8 @@ async function isSupportedWorkload(
     const continueToken = undefined;
     const fieldSelector = undefined;
     const labelSelector = undefined;
-    const allowWatchBookmarks = undefined;
     const limit = 1; // Try to grab only a single object
     const resourceVersion = undefined; // List anything in the cluster
-    const resourceVersionMatch = undefined;
     const timeoutSeconds = 10; // Don't block the snyk-monitor indefinitely
     const attemptedApiCall =
       await kubernetesApiWrappers.retryKubernetesApiRequest(() =>
@@ -147,13 +145,11 @@ async function isSupportedWorkload(
           namespace,
           'deploymentconfigs',
           pretty,
-          allowWatchBookmarks,
           continueToken,
           fieldSelector,
           labelSelector,
           limit,
           resourceVersion,
-          resourceVersionMatch,
           timeoutSeconds,
         ),
       );


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Upgrading  @kubernetes/client-node-version to v0.16.1 seemed to stop Kubernetes Monitor from scanning. We are hoping reverting to v0.15.1 would fix the issue.

### Notes for the reviewer

[slack thread](https://snyk.slack.com/archives/C01KWP7CKQC/p1640013904002500)

