### PR TITLE
Add init delay to liveness and readiness probes

### DIFF
--- a/snyk-monitor/Chart.yaml
+++ b/snyk-monitor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for the Snyk Monitor
 name: snyk-monitor
-version: 0.1.0
+version: 0.1.1
 icon: https://res.cloudinary.com/snyk/image/upload/v1533761770/logo-1_wtob68.svg

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -141,10 +141,12 @@ spec:
               {{- toYaml . | nindent 14 }}
             {{- end }}
           livenessProbe:
+            initialDelaySeconds: 60
             exec:
               command:
               - "true"
           readinessProbe:
+            initialDelaySeconds: 60
             exec:
               command:
               - "true"


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

We are attempting to use the monitor and in our environment are experiencing probes failing on startup. From our investigation we see the monitor pinning the CPU on startup which is causing the probes to fail and in turn the container to be killed before it starts up.

I was able to get things to startup sometimes by giving the container more CPU cores but even this was not reliable. Adding an init delay should hopefully resolve this and allow the container to start before it is nuked due to failing probes.

As the probes are not overly useful here I just went with a long init delay.
