### PR TITLE
Flag to disable NetworkPolicy

### DIFF
--- a/snyk-monitor/templates/networkpolicy.yaml
+++ b/snyk-monitor/templates/networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -19,4 +20,7 @@ spec:
   # Ingress is denied hence there is no "ingress" block.
   # Egress is allowed for any traffic.
   egress:
-  - {}
+  {{- with .Values.networkPolicy.egress }}
+  {{- toYaml . | trim | nindent 2 -}}
+  {{- end }}
+{{- end }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -106,6 +106,12 @@ metadata:
   labels: {}
   annotations: {}
 
+# Override the NetworkPolicy
+networkPolicy:
+  enabled: true
+  egress:
+  - {}
+
 psp:
   enabled: false
   name: ""


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds a flag to disable the default `NetworkPolicy`. Ref - https://github.com/snyk/kubernetes-monitor/issues/984

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### Screenshots

_Visuals that may help the reviewer_
