### PR TITLE
fix: retry on network errors in K8s API informers

### DIFF
--- a/src/supervisor/kuberenetes-api-wrappers.ts
+++ b/src/supervisor/kuberenetes-api-wrappers.ts
@@ -3,17 +3,12 @@ import sleep from 'sleep-promise';
 
 import { logger } from '../common/logger';
 import { IRequestError } from './types';
+import { RETRYABLE_NETWORK_ERRORS } from './watchers/types';
 
 export const ATTEMPTS_MAX = 3;
 export const DEFAULT_SLEEP_SEC = 1;
 export const MAX_SLEEP_SEC = 5;
 type IKubernetesApiFunction<ResponseType> = () => Promise<ResponseType>;
-
-const RETRYABLE_NETWORK_ERRORS: string[] = [
-  'ECONNREFUSED',
-  'ETIMEDOUT',
-  'ECONNRESET',
-];
 
 export async function retryKubernetesApiRequest<ResponseType>(
   func: IKubernetesApiFunction<ResponseType>,

--- a/src/supervisor/watchers/types.ts
+++ b/src/supervisor/watchers/types.ts
@@ -11,4 +11,8 @@ export enum PodPhase {
   Unknown = 'Unknown',
 }
 
-export const ECONNRESET_ERROR_CODE = 'ECONNRESET';
+export const RETRYABLE_NETWORK_ERRORS: readonly string[] = [
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'ECONNRESET',
+];


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add several other errors to the list of retryable errors for when the informer faces a network issue. This should make reconnecting to the K8s API more robust as these network errors are normally only temporary.
