### PR TITLE
fix: pull OCI archives instead of Docker archives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "needle": "^3.0.0",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.0.0",
-        "snyk-docker-plugin": "^4.33.2",
+        "snyk-docker-plugin": "^4.34.2",
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "^4.5.2",
@@ -9583,9 +9583,9 @@
       }
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "4.33.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.33.2.tgz",
-      "integrity": "sha512-TWxw3/x125FVypQxRNu2TExaKcjJoJLz54yY81HxK49IytkEHNEcLidMuVXENTEZfMEFpcOd9Hez9xSHq4V8vg==",
+      "version": "4.34.2",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.34.2.tgz",
+      "integrity": "sha512-PyLnzCaL6YhiIMRKamQpi7LACUJP/3APvZqaV1NoM7I1jrT4Kkwp/ZiU0VlN0NjHg1uO6PDna3d2tk8cpG7HLQ==",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",
@@ -18660,9 +18660,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.33.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.33.2.tgz",
-      "integrity": "sha512-TWxw3/x125FVypQxRNu2TExaKcjJoJLz54yY81HxK49IytkEHNEcLidMuVXENTEZfMEFpcOd9Hez9xSHq4V8vg==",
+      "version": "4.34.2",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.34.2.tgz",
+      "integrity": "sha512-PyLnzCaL6YhiIMRKamQpi7LACUJP/3APvZqaV1NoM7I1jrT4Kkwp/ZiU0VlN0NjHg1uO6PDna3d2tk8cpG7HLQ==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "needle": "^3.0.0",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.0.0",
-    "snyk-docker-plugin": "^4.33.2",
+    "snyk-docker-plugin": "^4.34.2",
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "^4.5.2",

--- a/src/scanner/images/skopeo.ts
+++ b/src/scanner/images/skopeo.ts
@@ -26,7 +26,6 @@ function prefixRespository(target: string, type: SkopeoRepositoryType): string {
     case SkopeoRepositoryType.ImageRegistry:
       return `${type}://${target}`;
     case SkopeoRepositoryType.DockerArchive:
-    case SkopeoRepositoryType.OciArchive:
       return `${type}:${target}`;
     default:
       throw new Error(`Unhandled Skopeo repository type ${type}`);

--- a/src/scanner/images/types.ts
+++ b/src/scanner/images/types.ts
@@ -16,7 +16,5 @@ export interface IPullableImage {
  */
 export enum SkopeoRepositoryType {
   DockerArchive = 'docker-archive',
-  OciArchive = 'oci',
   ImageRegistry = 'docker',
-  Directory = 'dir', // Note, skopeo marks this as a non-standard format
 }

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -120,7 +120,7 @@ async function scanImagesAndSendResults(
   telemetry: Partial<Telemetry>,
 ): Promise<void> {
   const imageScanStartTimestampMs = Date.now();
-  const scannedImages = await scanImages(pulledImages);
+  const scannedImages = await scanImages(pulledImages, telemetry);
   const imageScanDurationMs = Date.now() - imageScanStartTimestampMs;
 
   if (scannedImages.length === 0) {

--- a/src/supervisor/watchers/handlers/index.ts
+++ b/src/supervisor/watchers/handlers/index.ts
@@ -161,7 +161,7 @@ async function isSupportedWorkload(
       attemptedApiCall.response.statusCode < 300
     );
   } catch (error) {
-    logger.info(
+    logger.debug(
       { error, workloadKind },
       'Failed on Kubernetes API call to list DeploymentConfig',
     );
@@ -176,7 +176,7 @@ export async function setupInformer(
   const logContext: Record<string, unknown> = { namespace, workloadKind };
   const isSupported = await isSupportedWorkload(namespace, workloadKind);
   if (!isSupported) {
-    logger.info(
+    logger.debug(
       logContext,
       'The Kubernetes cluster does not support this workload',
     );

--- a/src/transmitter/types.ts
+++ b/src/transmitter/types.ts
@@ -101,6 +101,10 @@ export interface IRequestError {
 export interface Telemetry {
   enqueueDurationMs: number;
   queueSize: number;
+  /** This metric captures the total duration to pull all images of a workload. */
   imagePullDurationMs: number;
+  /** This metric captures the total duration to scan all images of a workload. */
   imageScanDurationMs: number;
+  /** This metric captures the combined size of all images of a workload. */
+  imageSizeBytes: number;
 }

--- a/test/system/kind.spec.ts
+++ b/test/system/kind.spec.ts
@@ -254,6 +254,7 @@ test('Kubernetes-Monitor with KinD', async (jestDoneCallback) => {
             enqueueDurationMs: expect.any(Number),
             imagePullDurationMs: expect.any(Number),
             imageScanDurationMs: expect.any(Number),
+            imageSizeBytes: expect.any(Number),
             queueSize: expect.any(Number),
           },
           imageLocator: expect.objectContaining({
@@ -270,10 +271,7 @@ test('Kubernetes-Monitor with KinD', async (jestDoneCallback) => {
                 { type: 'imageOsReleasePrettyName', data: expect.any(String) },
               ]),
               target: { image: 'docker-image|docker.io/library/java' },
-              identity: {
-                type: 'deb',
-                args: { platform: 'linux/amd64' },
-              },
+              identity: { type: 'deb', args: { platform: 'linux/amd64' } },
             },
             {
               facts: [

--- a/test/system/kind.spec.ts
+++ b/test/system/kind.spec.ts
@@ -270,7 +270,10 @@ test('Kubernetes-Monitor with KinD', async (jestDoneCallback) => {
                 { type: 'imageOsReleasePrettyName', data: expect.any(String) },
               ]),
               target: { image: 'docker-image|docker.io/library/java' },
-              identity: { type: 'deb', args: { platform: 'linux/amd64' } },
+              identity: {
+                type: 'deb',
+                args: { platform: 'linux/amd64' },
+              },
             },
             {
               facts: [


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

For some image archives this results in much smaller pulled images as it allows to directly download compressed layers.
Also, it reduces the need to convert between different formats on the fly, which skopeo had to do for us.

