### PR TITLE
[RUN-1518] Add support for CronJobs in batch/v1 API

### DIFF
--- a/src/supervisor/types.ts
+++ b/src/supervisor/types.ts
@@ -2,7 +2,6 @@ import { IncomingMessage } from 'http';
 import {
   AppsV1Api,
   BatchV1Api,
-  BatchV1beta1Api,
   CoreV1Api,
   CustomObjectsApi,
   KubeConfig,
@@ -41,7 +40,6 @@ export interface IK8sClients {
   readonly appsClient: AppsV1Api;
   readonly coreClient: CoreV1Api;
   readonly batchClient: BatchV1Api;
-  readonly batchUnstableClient: BatchV1beta1Api;
   readonly customObjectsClient: CustomObjectsApi;
 }
 
@@ -49,12 +47,6 @@ export class K8sClients implements IK8sClients {
   public readonly appsClient: AppsV1Api;
   public readonly coreClient: CoreV1Api;
   public readonly batchClient: BatchV1Api;
-  // TODO: Keep an eye on this! We need v1beta1 API for CronJobs.
-  // https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning
-  // CronJobs will appear in v2 API, but for now there' only v2alpha1, so it's a bad idea to use it.
-  // TODO: https://kubernetes.io/blog/2021/04/09/kubernetes-release-1.21-cronjob-ga/
-  // CronJobs are now GA in Kubernetes 1.21 in the batch/v1 API, we should add support for it!
-  public readonly batchUnstableClient: BatchV1beta1Api;
   /** This client is used to access Custom Resources in the cluster, e.g. DeploymentConfig on OpenShift. */
   public readonly customObjectsClient: CustomObjectsApi;
 
@@ -62,7 +54,6 @@ export class K8sClients implements IK8sClients {
     this.appsClient = config.makeApiClient(AppsV1Api);
     this.coreClient = config.makeApiClient(CoreV1Api);
     this.batchClient = config.makeApiClient(BatchV1Api);
-    this.batchUnstableClient = config.makeApiClient(BatchV1beta1Api);
     this.customObjectsClient = config.makeApiClient(CustomObjectsApi);
   }
 }

--- a/src/supervisor/watchers/handlers/cron-job.ts
+++ b/src/supervisor/watchers/handlers/cron-job.ts
@@ -1,4 +1,4 @@
-import { V1beta1CronJob, V1beta1CronJobList } from '@kubernetes/client-node';
+import { V1CronJob, V1CronJobList } from '@kubernetes/client-node';
 import { deleteWorkload, trimWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
@@ -13,25 +13,21 @@ import {
 
 export async function paginatedCronJobList(namespace: string): Promise<{
   response: IncomingMessage;
-  body: V1beta1CronJobList;
+  body: V1CronJobList;
 }> {
-  const v1CronJobList = new V1beta1CronJobList();
-  v1CronJobList.apiVersion = 'batch/v1beta1';
+  const v1CronJobList = new V1CronJobList();
+  v1CronJobList.apiVersion = 'batch/v1';
   v1CronJobList.kind = 'CronJobList';
-  v1CronJobList.items = new Array<V1beta1CronJob>();
+  v1CronJobList.items = new Array<V1CronJob>();
 
   return await paginatedList(
     namespace,
     v1CronJobList,
-    k8sApi.batchUnstableClient.listNamespacedCronJob.bind(
-      k8sApi.batchUnstableClient,
-    ),
+    k8sApi.batchClient.listNamespacedCronJob.bind(k8sApi.batchClient),
   );
 }
 
-export async function cronJobWatchHandler(
-  cronJob: V1beta1CronJob,
-): Promise<void> {
+export async function cronJobWatchHandler(cronJob: V1CronJob): Promise<void> {
   cronJob = trimWorkload(cronJob);
 
   if (

--- a/src/supervisor/watchers/handlers/index.ts
+++ b/src/supervisor/watchers/handlers/index.ts
@@ -69,7 +69,7 @@ const workloadWatchMetadata: Readonly<IWorkloadWatchMetadata> = {
       paginatedReplicationControllerList(namespace),
   },
   [WorkloadKind.CronJob]: {
-    endpoint: '/apis/batch/v1beta1/watch/namespaces/{namespace}/cronjobs',
+    endpoint: '/apis/batch/v1/watch/namespaces/{namespace}/cronjobs',
     handlers: {
       [DELETE]: cronJobWatchHandler,
     },

--- a/src/supervisor/workload-reader.ts
+++ b/src/supervisor/workload-reader.ts
@@ -206,13 +206,10 @@ const jobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
   return metadata;
 };
 
-// Keep an eye on this! We need v1beta1 API for CronJobs.
-// https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning
-// CronJobs will appear in v2 API, but for now there' only v2alpha1, so it's a bad idea to use it.
+// cronJobReader can read v1 and v1beta1 CronJobs
 const cronJobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
   const cronJobResult = await kubernetesApiWrappers.retryKubernetesApiRequest(
-    () =>
-      k8sApi.batchUnstableClient.readNamespacedCronJob(workloadName, namespace),
+    () => k8sApi.batchClient.readNamespacedCronJob(workloadName, namespace),
   );
   const cronJob = trimWorkload(cronJobResult.body);
 

--- a/test/fixtures/cronjob-v1beta1.yaml
+++ b/test/fixtures/cronjob-v1beta1.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cron-job-v1beta1
+  namespace: services
+  labels:
+    app.kubernetes.io/name: cron-job-v1beta1
+spec:
+  schedule: '* * * * *'
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: cron-job-v1beta1
+        spec:
+          containers:
+            - name: cron-job-v1beta1
+              image: busybox
+              imagePullPolicy: IfNotPresent
+              command: ['/bin/sleep']
+              args: ['180']
+          restartPolicy: OnFailure

--- a/test/fixtures/cronjob.yaml
+++ b/test/fixtures/cronjob.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cron-job
+  namespace: services
+  labels:
+    app.kubernetes.io/name: cron-job
+spec:
+  schedule: '* * * * *'
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: cron-job
+        spec:
+          containers:
+            - name: cron-job
+              image: busybox
+              imagePullPolicy: IfNotPresent
+              command: ['/bin/sleep']
+              args: ['180']
+          restartPolicy: OnFailure

--- a/test/helpers/kubectl.ts
+++ b/test/helpers/kubectl.ts
@@ -231,7 +231,7 @@ export async function waitForDeployment(
   namespace: string,
 ): Promise<void> {
   console.log(`Trying to find deployment ${name} in namespace ${namespace}`);
-  for (let attempt = 0; attempt < 120; attempt++) {
+  for (let attempt = 0; attempt < 180; attempt++) {
     try {
       await exec(`./kubectl get deployment.apps/${name} -n ${namespace}`);
     } catch (error) {

--- a/test/setup/platforms/kind.ts
+++ b/test/setup/platforms/kind.ts
@@ -8,7 +8,7 @@ const clusterName = 'kind';
 
 export async function setupTester(): Promise<void> {
   const osDistro = platform();
-  await download(osDistro, 'v0.8.1');
+  await download(osDistro, 'v0.11.1');
 }
 
 export async function createCluster(version: string): Promise<void> {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The CronJob workload that snyk-monitor supports is the batch/v1beta1 API which has been around for a long time. Starting version 1.21 of Kubernetes this API has graduated and is now GA under batch/v1. This PR updates the monitor to use that version.
