### PR TITLE
Fix/invalid dep graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "needle": "^3.0.0",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.0.0",
-        "snyk-docker-plugin": "^4.34.2",
+        "snyk-docker-plugin": "^4.34.5",
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "^4.5.2",
@@ -9600,9 +9600,9 @@
       }
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "4.34.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.34.2.tgz",
-      "integrity": "sha512-PyLnzCaL6YhiIMRKamQpi7LACUJP/3APvZqaV1NoM7I1jrT4Kkwp/ZiU0VlN0NjHg1uO6PDna3d2tk8cpG7HLQ==",
+      "version": "4.34.5",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.34.5.tgz",
+      "integrity": "sha512-s8NVOFigLbhRfMEWZNtOQAV4HUmpZ5cCEPybsL/f7fKmw3HFSYNsH0YQtESBx77fAUAN2gK/8wF/7y6C/Dgnig==",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",
@@ -18690,9 +18690,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.34.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.34.2.tgz",
-      "integrity": "sha512-PyLnzCaL6YhiIMRKamQpi7LACUJP/3APvZqaV1NoM7I1jrT4Kkwp/ZiU0VlN0NjHg1uO6PDna3d2tk8cpG7HLQ==",
+      "version": "4.34.5",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.34.5.tgz",
+      "integrity": "sha512-s8NVOFigLbhRfMEWZNtOQAV4HUmpZ5cCEPybsL/f7fKmw3HFSYNsH0YQtESBx77fAUAN2gK/8wF/7y6C/Dgnig==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "needle": "^3.0.0",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.0.0",
-    "snyk-docker-plugin": "^4.34.2",
+    "snyk-docker-plugin": "^4.34.5",
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "^4.5.2",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This PR bumps `snyk-docker-plugin` to v4.34.5 which fixes invalid `dep-graph` in Maven
projects causing issues with calculating a package's vulnerable paths.

- https://snyk.zendesk.com/agent/tickets/17457
- https://snyksec.atlassian.net/browse/CAP-684
