### PR TITLE
fix: revert aws-sdk to v2.1067.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@kubernetes/client-node": "^0.15.1",
         "@snyk/dep-graph": "^1.30.0",
         "async": "^3.2.3",
-        "aws-sdk": "^2.1069.0",
+        "aws-sdk": "^2.1067.0",
         "bunyan": "^1.8.15",
         "child-process-promise": "^2.2.1",
         "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@kubernetes/client-node": "^0.15.1",
     "@snyk/dep-graph": "^1.30.0",
     "async": "^3.2.3",
-    "aws-sdk": "^2.1069.0",
+    "aws-sdk": "^2.1067.0",
     "bunyan": "^1.8.15",
     "child-process-promise": "^2.2.1",
     "fs-extra": "^10.0.0",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The new aws-sdk version is failing the eks-integration test. Revert back to the latest working version.
 
### Notes for the reviewer

[Success EKS integration test](https://app.circleci.com/pipelines/github/snyk/kubernetes-monitor/4315/workflows/bc33dc8c-1394-418b-bc34-166c90856aa1)
