### PR TITLE
fix: track image state to avoid sending data for deleted workloads

### DIFF
--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -136,9 +136,9 @@ async function scanImagesAndSendResults(
   const workloadState = await getWorkloadAlreadyScanned(workload);
   const imageState = await getWorkloadImageAlreadyScanned(
     workload,
-    workload.imageId,
+    workload.imageName,
   );
-  if (workloadState === undefined && imageState === undefined) {
+  if (workloadState === undefined || imageState === undefined) {
     logger.info(
       { workloadName },
       'the workload has been deleted while scanning was in progress, skipping sending scan results',

--- a/src/supervisor/watchers/handlers/pod.ts
+++ b/src/supervisor/watchers/handlers/pod.ts
@@ -95,12 +95,19 @@ async function handleReadyPod(workloadMetadata: IWorkload[]): Promise<void> {
   for (const workload of workloadMetadata) {
     const scanned = await getWorkloadImageAlreadyScanned(
       workload,
-      workload.imageId,
+      workload.imageName,
     );
-    if (scanned !== undefined) {
+    // ImageID contains the resolved image digest.
+    // ImageName may contain a tag. The image behind this tag can be mutated and can change over time.
+    // We need to compare on ImageID which will reliably tell us if the image has changed.
+    if (scanned === workload.imageId) {
       continue;
     }
-    await setWorkloadImageAlreadyScanned(workload, workload.imageId, ''); // empty string takes zero bytes and is !== undefined
+    await setWorkloadImageAlreadyScanned(
+      workload,
+      workload.imageName,
+      workload.imageId,
+    );
     workloadToScan.push(workload);
   }
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Small bugfix to how we track state. Previously we were not actually deleting keys from the cache at all. This could result in a race condition where we would still send scan results to the upstream even though the workload was already deleted.

We used to set the key in the cache by "image id" but try to delete by "image name"
