### PR TITLE
fix: correctly track workload and image state

### DIFF
--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -138,7 +138,7 @@ async function scanImagesAndSendResults(
     workload,
     workload.imageName,
   );
-  if (workloadState === undefined || imageState === undefined) {
+  if (workloadState === undefined && imageState === undefined) {
     logger.info(
       { workloadName },
       'the workload has been deleted while scanning was in progress, skipping sending scan results',


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The previous change introduced a regression - workload scan results are now rarely sent upstream.
