### PR TITLE
chore: trim Operator name in tests so it's within K8s name limits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,8 @@ jobs:
             - run:
                 command: |
                     export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
-                    OPERATOR_TAG="${IMAGE_TAG}-ubi8-${CIRCLE_SHA1}"
-                    MONITOR_TAG="${IMAGE_TAG}-ubi8-${CIRCLE_SHA1}"
+                    OPERATOR_TAG="${IMAGE_TAG}-ubi8-${CIRCLE_SHA1:0:8}"
+                    MONITOR_TAG="${IMAGE_TAG}-ubi8-${CIRCLE_SHA1:0:8}"
                     scripts/operator/create_operator_and_push.py "${OPERATOR_TAG}" "${MONITOR_TAG}" "${DOCKERHUB_USER}" "${DOCKERHUB_PASSWORD}"
                     echo "export OPERATOR_TAG=$OPERATOR_TAG" >> $BASH_ENV
                 name: Create Operator and push Operator image to DockerHub
@@ -86,8 +86,8 @@ jobs:
             - run:
                 command: |
                     export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
-                    export SNYK_MONITOR_IMAGE_TAG="${IMAGE_TAG}-ubi8-${CIRCLE_SHA1}"
-                    export SNYK_OPERATOR_VERSION="0.0.1-ubi8-${CIRCLE_SHA1}"
+                    export SNYK_MONITOR_IMAGE_TAG="${IMAGE_TAG}-ubi8-${CIRCLE_SHA1:0:8}"
+                    export SNYK_OPERATOR_VERSION="0.0.1-ubi8-${CIRCLE_SHA1:0:8}"
                     export SNYK_OPERATOR_IMAGE_TAG="${SNYK_MONITOR_IMAGE_TAG}"
                     OPERATOR_PATH=$(scripts/operator/package_operator_bundle.py "${SNYK_OPERATOR_VERSION}" "${SNYK_OPERATOR_IMAGE_TAG}" "${SNYK_MONITOR_IMAGE_TAG}")
                     echo "export OPERATOR_PATH=$OPERATOR_PATH" >> $BASH_ENV
@@ -95,7 +95,7 @@ jobs:
             - run:
                 command: |
                     export OPERATOR_DIR=$OPERATOR_PATH
-                    export PACKAGE_VERSION="0.0.1-ubi8-${CIRCLE_SHA1}"
+                    export PACKAGE_VERSION="0.0.1-ubi8-${CIRCLE_SHA1:0:8}"
                     scripts/operator/create_operator_bundle_and_index_and_push.py "${OPERATOR_DIR}" "${PACKAGE_VERSION}" "${DOCKERHUB_USER}" "${DOCKERHUB_PASSWORD}"
                 name: Create Operator Bundle and Index and push to Docker Hub
             - run:
@@ -114,7 +114,7 @@ jobs:
                 command: |
                     IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
                     IMAGE_NAME_CANDIDATE=snyk/kubernetes-monitor:${IMAGE_TAG}-${CIRCLE_SHA1}
-                    IMAGE_NAME_CANDIDATE_UBI8=snyk/kubernetes-monitor:${IMAGE_TAG}-ubi8-${CIRCLE_SHA1}
+                    IMAGE_NAME_CANDIDATE_UBI8=snyk/kubernetes-monitor:${IMAGE_TAG}-ubi8-${CIRCLE_SHA1:0:8}
                     echo "export IMAGE_NAME_CANDIDATE=$IMAGE_NAME_CANDIDATE" >> $BASH_ENV
                     echo "export IMAGE_NAME_CANDIDATE_UBI8=$IMAGE_NAME_CANDIDATE_UBI8" >> $BASH_ENV
                 name: Export environment variables
@@ -341,7 +341,7 @@ jobs:
                 name: Create temporary directory for logs
             - run:
                 command: |
-                    export OPERATOR_VERSION="0.0.1-ubi8-${CIRCLE_SHA1}"
+                    export OPERATOR_VERSION="0.0.1-ubi8-${CIRCLE_SHA1:0:8}"
                     export IMAGE_TAG_UBI_SUFFIX="-ubi8"
                     export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
                     .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:kindolm:operator
@@ -433,7 +433,7 @@ jobs:
                 name: create temp dir for logs
             - run:
                 command: |
-                    export OPERATOR_VERSION="0.0.1-ubi8-${CIRCLE_SHA1}"
+                    export OPERATOR_VERSION="0.0.1-ubi8-${CIRCLE_SHA1:0:8}"
                     export IMAGE_TAG_UBI_SUFFIX="-ubi8"
                     export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
                     .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:openshift4:operator

--- a/.circleci/config/jobs/build_and_upload_operator.yml
+++ b/.circleci/config/jobs/build_and_upload_operator.yml
@@ -17,8 +17,8 @@ steps:
       name: Create Operator and push Operator image to DockerHub
       command: |
         export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
-        OPERATOR_TAG="${IMAGE_TAG}-ubi8-${CIRCLE_SHA1}"
-        MONITOR_TAG="${IMAGE_TAG}-ubi8-${CIRCLE_SHA1}"
+        OPERATOR_TAG="${IMAGE_TAG}-ubi8-${CIRCLE_SHA1:0:8}"
+        MONITOR_TAG="${IMAGE_TAG}-ubi8-${CIRCLE_SHA1:0:8}"
         scripts/operator/create_operator_and_push.py "${OPERATOR_TAG}" "${MONITOR_TAG}" "${DOCKERHUB_USER}" "${DOCKERHUB_PASSWORD}"
         echo "export OPERATOR_TAG=$OPERATOR_TAG" >> $BASH_ENV
   - snyk/scan:
@@ -30,8 +30,8 @@ steps:
       name: Package Operator Bundle
       command: |
         export IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
-        export SNYK_MONITOR_IMAGE_TAG="${IMAGE_TAG}-ubi8-${CIRCLE_SHA1}"
-        export SNYK_OPERATOR_VERSION="0.0.1-ubi8-${CIRCLE_SHA1}"
+        export SNYK_MONITOR_IMAGE_TAG="${IMAGE_TAG}-ubi8-${CIRCLE_SHA1:0:8}"
+        export SNYK_OPERATOR_VERSION="0.0.1-ubi8-${CIRCLE_SHA1:0:8}"
         export SNYK_OPERATOR_IMAGE_TAG="${SNYK_MONITOR_IMAGE_TAG}"
         OPERATOR_PATH=$(scripts/operator/package_operator_bundle.py "${SNYK_OPERATOR_VERSION}" "${SNYK_OPERATOR_IMAGE_TAG}" "${SNYK_MONITOR_IMAGE_TAG}")
         echo "export OPERATOR_PATH=$OPERATOR_PATH" >> $BASH_ENV
@@ -39,7 +39,7 @@ steps:
       name: Create Operator Bundle and Index and push to Docker Hub
       command: |
         export OPERATOR_DIR=$OPERATOR_PATH
-        export PACKAGE_VERSION="0.0.1-ubi8-${CIRCLE_SHA1}"
+        export PACKAGE_VERSION="0.0.1-ubi8-${CIRCLE_SHA1:0:8}"
         scripts/operator/create_operator_bundle_and_index_and_push.py "${OPERATOR_DIR}" "${PACKAGE_VERSION}" "${DOCKERHUB_USER}" "${DOCKERHUB_PASSWORD}"
   - run:
       name: Notify Slack on failure

--- a/.circleci/config/jobs/build_image.yml
+++ b/.circleci/config/jobs/build_image.yml
@@ -9,7 +9,7 @@ steps:
       command: |
         IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
         IMAGE_NAME_CANDIDATE=snyk/kubernetes-monitor:${IMAGE_TAG}-${CIRCLE_SHA1}
-        IMAGE_NAME_CANDIDATE_UBI8=snyk/kubernetes-monitor:${IMAGE_TAG}-ubi8-${CIRCLE_SHA1}
+        IMAGE_NAME_CANDIDATE_UBI8=snyk/kubernetes-monitor:${IMAGE_TAG}-ubi8-${CIRCLE_SHA1:0:8}
         echo "export IMAGE_NAME_CANDIDATE=$IMAGE_NAME_CANDIDATE" >> $BASH_ENV
         echo "export IMAGE_NAME_CANDIDATE_UBI8=$IMAGE_NAME_CANDIDATE_UBI8" >> $BASH_ENV
   - run:

--- a/.circleci/config/jobs/integration_tests_operator_on_k8s.yml
+++ b/.circleci/config/jobs/integration_tests_operator_on_k8s.yml
@@ -11,7 +11,7 @@ steps:
 - run:
     name: Operator integration tests on vanilla Kubernetes
     command: |
-      export OPERATOR_VERSION="0.0.1-ubi8-${CIRCLE_SHA1}"
+      export OPERATOR_VERSION="0.0.1-ubi8-${CIRCLE_SHA1:0:8}"
       export IMAGE_TAG_UBI_SUFFIX="-ubi8"
       export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
       .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:kindolm:operator

--- a/.circleci/config/jobs/openshift4_integration_tests.yml
+++ b/.circleci/config/jobs/openshift4_integration_tests.yml
@@ -12,7 +12,7 @@ steps:
   - run:
       name: Integration tests OpenShift 4
       command: |
-        export OPERATOR_VERSION="0.0.1-ubi8-${CIRCLE_SHA1}"
+        export OPERATOR_VERSION="0.0.1-ubi8-${CIRCLE_SHA1:0:8}"
         export IMAGE_TAG_UBI_SUFFIX="-ubi8"
         export KUBERNETES_MONITOR_IMAGE_NAME_AND_TAG=$(./scripts/circleci-jobs/setup-integration-tests.py)
         .circleci/do-exclusively --branch staging --job ${CIRCLE_JOB} npm run test:integration:openshift4:operator

--- a/scripts/docker/approve-image.sh
+++ b/scripts/docker/approve-image.sh
@@ -16,7 +16,7 @@ else
   docker push ${IMAGE_NAME_APPROVED}
   ./scripts/slack/notify_push.py ${IMAGE_NAME_APPROVED}
 
-  IMAGE_NAME_CANDIDATE_UBI8=snyk/kubernetes-monitor:staging-candidate-ubi8-${CIRCLE_SHA1}
+  IMAGE_NAME_CANDIDATE_UBI8=snyk/kubernetes-monitor:staging-candidate-ubi8-${CIRCLE_SHA1:0:8}
   IMAGE_NAME_APPROVED_UBI8=snyk/kubernetes-monitor:${1}-ubi8-approved
 
   docker pull ${IMAGE_NAME_CANDIDATE_UBI8}

--- a/scripts/operator/main.py
+++ b/scripts/operator/main.py
@@ -26,7 +26,7 @@ from create_operator_bundle_and_index_and_push import createOperatorBundleAndInd
 
 if __name__ == '__main__':
     random_digest = sha1(str(datetime.now()).encode("utf-8")).hexdigest()
-    operator_version = "0.0.1-" + random_digest
+    operator_version = "0.0.1-ubi8-" + random_digest[0:8]
 
     with open(getcwd() + "/" + ".operator_version", "w") as f:
         f.write(operator_version)


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Trim Operator name in tests so it's within K8s name limits.
The limit is 63 characters and because we generate a SHA for the name, it exceeds the limit.
