### PR TITLE
fix: operator upgrade tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -600,21 +600,18 @@ jobs:
                     SLEEP_SECONDS_BETWEEN_ATTEMPTS=5
                     # total = 10 minutes wait time
 
-                    EXPECTED_TAG="${LATEST_TAG}-ubi8"
                     # Periodically poll if the snyk-monitor has upgraded
                     for (( attempt=1; attempt<ATTEMPTS; attempt++))
                     do
-                      # Grab the tag of the snyk-monitor container image.
-                      SNYK_MONITOR_POD=$(kubectl get pods -n snyk-monitor --no-headers | grep "snyk-monitor")
-                      if [[ ! -z "${SNYK_MONITOR_POD}" ]]; then
-                        VERSION=$(echo "${SNYK_MONITOR_POD}" | \
-                        awk 'END { print $1 }' | \
+                      # Grab the tag of the snyk-monitor container image. If snyk-monitor is not deployed for some reason, we exit immediately.
+                      VERSION=$(kubectl get pods -n snyk-monitor --no-headers | \
+                        grep "snyk-monitor" | \
+                        awk 'END { if (NR==0) exit 1; else print $1 }' | \
                         xargs '-I{}' kubectl get pod '{}' -n snyk-monitor -o 'jsonpath={..containers[*].image}' | \
-                        grep -oE "[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,3}$")
-                      fi
+                        awk '{print $1}' | grep -oE "[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,3}$")
 
                       # Break out of the polling if the tag matches the one we want to upgrade to.
-                      if [[ "${VERSION}" == "${EXPECTED_TAG}" ]]; then
+                      if [[ "${VERSION}" == "${LATEST_TAG}" ]]; then
                         break
                       fi
 
@@ -627,8 +624,8 @@ jobs:
                       awk 'END { if (NR==0) exit 101; else print $1 }')
 
                     # If we polled for 5 minutes and the snyk-monitor still hasn't upgraded, fail the current job.
-                    if [[ "${VERSION}" != "${EXPECTED_TAG}" ]]; then
-                      &>2 echo "versions (${VERSION}) does not match expected (${EXPECTED_TAG})!"
+                    if [[ "${VERSION}" != "${LATEST_TAG}" ]]; then
+                      &>2 echo "versions (${VERSION}) does not match expected (${LATEST_TAG})!"
 
                       kubectl describe pod ${SNYK_MONITOR_POD} -n snyk-monitor
                       kubectl describe catalogsource snyk-operator -n openshift-marketplace

--- a/.circleci/config/jobs/operator_upgrade_tests.yml
+++ b/.circleci/config/jobs/operator_upgrade_tests.yml
@@ -175,21 +175,18 @@ steps:
         SLEEP_SECONDS_BETWEEN_ATTEMPTS=5
         # total = 10 minutes wait time
 
-        EXPECTED_TAG="${LATEST_TAG}-ubi8"
         # Periodically poll if the snyk-monitor has upgraded
         for (( attempt=1; attempt<ATTEMPTS; attempt++))
         do
-          # Grab the tag of the snyk-monitor container image.
-          SNYK_MONITOR_POD=$(kubectl get pods -n snyk-monitor --no-headers | grep "snyk-monitor")
-          if [[ ! -z "${SNYK_MONITOR_POD}" ]]; then
-            VERSION=$(echo "${SNYK_MONITOR_POD}" | \
-            awk 'END { print $1 }' | \
+          # Grab the tag of the snyk-monitor container image. If snyk-monitor is not deployed for some reason, we exit immediately.
+          VERSION=$(kubectl get pods -n snyk-monitor --no-headers | \
+            grep "snyk-monitor" | \
+            awk 'END { if (NR==0) exit 1; else print $1 }' | \
             xargs '-I{}' kubectl get pod '{}' -n snyk-monitor -o 'jsonpath={..containers[*].image}' | \
-            grep -oE "[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,3}$")
-          fi
+            awk '{print $1}' | grep -oE "[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,3}$")
 
           # Break out of the polling if the tag matches the one we want to upgrade to.
-          if [[ "${VERSION}" == "${EXPECTED_TAG}" ]]; then
+          if [[ "${VERSION}" == "${LATEST_TAG}" ]]; then
             break
           fi
 
@@ -202,8 +199,8 @@ steps:
           awk 'END { if (NR==0) exit 101; else print $1 }')
 
         # If we polled for 5 minutes and the snyk-monitor still hasn't upgraded, fail the current job.
-        if [[ "${VERSION}" != "${EXPECTED_TAG}" ]]; then
-          &>2 echo "versions (${VERSION}) does not match expected (${EXPECTED_TAG})!"
+        if [[ "${VERSION}" != "${LATEST_TAG}" ]]; then
+          &>2 echo "versions (${VERSION}) does not match expected (${LATEST_TAG})!"
 
           kubectl describe pod ${SNYK_MONITOR_POD} -n snyk-monitor
           kubectl describe catalogsource snyk-operator -n openshift-marketplace


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Operator upgrade tests are currently broken. This change reverts the changes in the "Upgrade Operator and check that snyk-monitor also upgraded" step and also checks for the operator tag without -ubi suffix
