### PR TITLE
[RUN-2210] Scrape for runtime data after 20 mins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,18 @@ async function setupSysdigIntegration(): Promise<void> {
     return;
   }
 
+  const initialInterval: number = 20 * 60 * 1000; // 20 mins in milliseconds
+  setTimeout(async () => {
+    try {
+      await scrapeData();
+    } catch (error) {
+      logger.error(
+        { error },
+        'an error occurred while scraping initial runtime data',
+      );
+    }
+  }, initialInterval).unref();
+
   const interval: number = 4 * 60 * 60 * 1000; // 4 hours in milliseconds
   setInterval(async () => {
     try {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
According to Sysdig, the runtime packages info gets processed within 15 minutes.
Do initial scrape after 20 mins to get Sysdig data into Snyk system earlier.
Further scrapes will still have 4 hour interval.
