### PR TITLE
[RUN-2214] trim DeploymentConfig on delete

### DIFF
--- a/src/supervisor/watchers/handlers/deployment-config.ts
+++ b/src/supervisor/watchers/handlers/deployment-config.ts
@@ -16,6 +16,7 @@ import {
 import { retryKubernetesApiRequest } from '../../kuberenetes-api-wrappers';
 import { logger } from '../../../common/logger';
 import { deleteWorkloadFromScanQueue } from './queue';
+import { trimWorkload } from '../../workload-sanitization';
 
 export async function paginatedNamespacedDeploymentConfigList(
   namespace: string,
@@ -212,9 +213,4 @@ export async function isClusterDeploymentConfigSupported(): Promise<boolean> {
     );
     return false;
   }
-}
-function trimWorkload(
-  deploymentConfig: V1DeploymentConfig,
-): V1DeploymentConfig {
-  throw new Error('Function not implemented.');
 }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Import and use the trimWorkload function which was previously not implemented for DeploymentConfig for delete requests.
