### PR TITLE
chore: fix skopeo install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -952,7 +952,7 @@ jobs:
     system_tests:
         machine:
             docker_layer_caching: true
-            image: ubuntu-2004:202111-01
+            image: ubuntu-2204:current
         steps:
             - checkout
             - setup_node16
@@ -960,11 +960,6 @@ jobs:
             - run:
                 command: |
                     export DEBIAN_FRONTEND=noninteractive
-                    sudo apt-get update
-                    sudo apt-get install -y wget gnupg
-                    . /etc/os-release
-                    sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-                    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O- | sudo apt-key add -
                     sudo apt-get update -qq
                     sudo apt-get install skopeo
                 name: Install Skopeo

--- a/.circleci/config/jobs/@jobs.yml
+++ b/.circleci/config/jobs/@jobs.yml
@@ -59,7 +59,7 @@ unit_tests:
 
 system_tests:
   machine:
-    image: ubuntu-2004:202111-01
+    image: ubuntu-2204:current
     docker_layer_caching: true
   working_directory: ~/kubernetes-monitor
   steps:
@@ -70,11 +70,6 @@ system_tests:
         name: Install Skopeo
         command: |
           export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update
-          sudo apt-get install -y wget gnupg
-          . /etc/os-release
-          sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-          wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O- | sudo apt-key add -
           sudo apt-get update -qq
           sudo apt-get install skopeo
     - run:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Skopeo was removed from the `kubic` repo, but is available from the official Ubuntu repo (from 20.10 and up). This caused the system checks to fail in CircleCI.
Upgrading the base image to Ubuntu 22.04 to fix skopeo install.


