### PR TITLE
feat: Initial support for parsing ArgoCD rollout CRD definitions

### DIFF
--- a/snyk-monitor/templates/clusterrole.yaml
+++ b/snyk-monitor/templates/clusterrole.yaml
@@ -61,6 +61,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch
 {{- if .Values.psp.enabled }}
 - apiGroups:
   - policy

--- a/snyk-monitor/templates/role.yaml
+++ b/snyk-monitor/templates/role.yaml
@@ -61,6 +61,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch
 {{- if .Values.psp.enabled }}
 - apiGroups:
   - policy

--- a/src/supervisor/types.ts
+++ b/src/supervisor/types.ts
@@ -25,6 +25,7 @@ export enum WorkloadKind {
   ReplicationController = 'ReplicationController',
   Pod = 'Pod',
   DeploymentConfig = 'DeploymentConfig',
+  ArgoRollout = 'Rollout',
 }
 
 export interface IRequestError {

--- a/src/supervisor/watchers/handlers/argo-rollout.ts
+++ b/src/supervisor/watchers/handlers/argo-rollout.ts
@@ -1,0 +1,209 @@
+import { IncomingMessage } from 'http';
+import { deleteWorkload } from './workload';
+import { WorkloadKind } from '../../types';
+import { FALSY_WORKLOAD_NAME_MARKER, Rollout, RolloutList } from './types';
+import { paginatedClusterList, paginatedNamespacedList } from './pagination';
+import { k8sApi } from '../../cluster';
+import {
+  deleteWorkloadAlreadyScanned,
+  deleteWorkloadImagesAlreadyScanned,
+  kubernetesObjectToWorkloadAlreadyScanned,
+} from '../../../state';
+import { retryKubernetesApiRequest } from '../../kuberenetes-api-wrappers';
+import { logger } from '../../../common/logger';
+import { deleteWorkloadFromScanQueue } from './queue';
+import { trimWorkload } from '../../workload-sanitization';
+
+export async function paginatedNamespacedArgoRolloutList(
+  namespace: string,
+): Promise<{
+  response: IncomingMessage;
+  body: RolloutList;
+}> {
+  const rolloutList = new RolloutList();
+  rolloutList.apiVersion = 'argoproj.io/v1alpha1';
+  rolloutList.kind = 'RolloutList';
+  rolloutList.items = new Array<Rollout>();
+
+  return await paginatedNamespacedList(
+    namespace,
+    rolloutList,
+    async (
+      namespace: string,
+      pretty?: string,
+      _allowWatchBookmarks?: boolean,
+      _continue?: string,
+      fieldSelector?: string,
+      labelSelector?: string,
+      limit?: number,
+    ) =>
+      k8sApi.customObjectsClient.listNamespacedCustomObject(
+        'argoproj.io',
+        'v1alpha1',
+        namespace,
+        'rollouts',
+        pretty,
+        _continue,
+        fieldSelector,
+        labelSelector,
+        limit,
+        // TODO: Why any?
+      ) as any,
+  );
+}
+
+export async function paginatedClusterArgoRolloutList(): Promise<{
+  response: IncomingMessage;
+  body: RolloutList;
+}> {
+  const rolloutList = new RolloutList();
+  rolloutList.apiVersion = 'argoproj.io/v1';
+  rolloutList.kind = 'RolloutList';
+  rolloutList.items = new Array<Rollout>();
+
+  return await paginatedClusterList(
+    rolloutList,
+    async (
+      _allowWatchBookmarks?: boolean,
+      _continue?: string,
+      fieldSelector?: string,
+      labelSelector?: string,
+      limit?: number,
+      pretty?: string,
+    ) =>
+      k8sApi.customObjectsClient.listClusterCustomObject(
+        'argoproj.io',
+        'v1alpha1',
+        'rollouts',
+        pretty,
+        _continue,
+        fieldSelector,
+        labelSelector,
+        limit,
+      ) as any,
+  );
+}
+
+export async function ArgoRolloutWatchHandler(rollout: Rollout): Promise<void> {
+  rollout = trimWorkload(rollout);
+
+  if (
+    !rollout.metadata ||
+    !rollout.spec ||
+    !rollout.spec.template.metadata ||
+    !rollout.spec.template.spec ||
+    !rollout.status
+  ) {
+    return;
+  }
+
+  const workloadAlreadyScanned =
+    kubernetesObjectToWorkloadAlreadyScanned(rollout);
+  if (workloadAlreadyScanned !== undefined) {
+    await Promise.all([
+      deleteWorkloadAlreadyScanned(workloadAlreadyScanned),
+      deleteWorkloadImagesAlreadyScanned({
+        ...workloadAlreadyScanned,
+        imageIds: rollout.spec.template.spec.containers
+          .filter((container) => container.image !== undefined)
+          .map((container) => container.image!),
+      }),
+      deleteWorkloadFromScanQueue(workloadAlreadyScanned),
+    ]);
+  }
+
+  const workloadName = rollout.metadata.name || FALSY_WORKLOAD_NAME_MARKER;
+
+  await deleteWorkload(
+    {
+      kind: WorkloadKind.ArgoRollout,
+      objectMeta: rollout.metadata,
+      specMeta: rollout.spec.template.metadata,
+      ownerRefs: rollout.metadata.ownerReferences,
+      revision: rollout.status.observedGeneration,
+      podSpec: rollout.spec.template.spec,
+    },
+    workloadName,
+  );
+}
+
+export async function isNamespacedArgoRolloutSupported(
+  namespace: string,
+): Promise<boolean> {
+  try {
+    const pretty = undefined;
+    const continueToken = undefined;
+    const fieldSelector = undefined;
+    const labelSelector = undefined;
+    const limit = 1; // Try to grab only a single object
+    const resourceVersion = undefined; // List anything in the cluster
+    const timeoutSeconds = 10; // Don't block the snyk-monitor indefinitely
+    const attemptedApiCall = await retryKubernetesApiRequest(() =>
+      k8sApi.customObjectsClient.listNamespacedCustomObject(
+        'argoproj.io',
+        'v1alpha1',
+        namespace,
+        'rollouts',
+        pretty,
+        continueToken,
+        fieldSelector,
+        labelSelector,
+        limit,
+        resourceVersion,
+        timeoutSeconds,
+      ),
+    );
+    return (
+      attemptedApiCall !== undefined &&
+      attemptedApiCall.response !== undefined &&
+      attemptedApiCall.response.statusCode !== undefined &&
+      attemptedApiCall.response.statusCode >= 200 &&
+      attemptedApiCall.response.statusCode < 300
+    );
+  } catch (error) {
+    logger.debug(
+      { error, workloadKind: WorkloadKind.ArgoRollout },
+      'Failed on Kubernetes API call to list namespaced argoproj.io/Rollout',
+    );
+    return false;
+  }
+}
+
+export async function isClusterArgoRolloutSupported(): Promise<boolean> {
+  try {
+    const pretty = undefined;
+    const continueToken = undefined;
+    const fieldSelector = undefined;
+    const labelSelector = undefined;
+    const limit = 1; // Try to grab only a single object
+    const resourceVersion = undefined; // List anything in the cluster
+    const timeoutSeconds = 10; // Don't block the snyk-monitor indefinitely
+    const attemptedApiCall = await retryKubernetesApiRequest(() =>
+      k8sApi.customObjectsClient.listClusterCustomObject(
+        'argoproj.io',
+        'v1alpha1',
+        'rollouts',
+        pretty,
+        continueToken,
+        fieldSelector,
+        labelSelector,
+        limit,
+        resourceVersion,
+        timeoutSeconds,
+      ),
+    );
+    return (
+      attemptedApiCall !== undefined &&
+      attemptedApiCall.response !== undefined &&
+      attemptedApiCall.response.statusCode !== undefined &&
+      attemptedApiCall.response.statusCode >= 200 &&
+      attemptedApiCall.response.statusCode < 300
+    );
+  } catch (error) {
+    logger.debug(
+      { error, workloadKind: WorkloadKind.ArgoRollout },
+      'Failed on Kubernetes API call to list cluster argoproj.io/Rollout',
+    );
+    return false;
+  }
+}

--- a/src/supervisor/watchers/handlers/index.ts
+++ b/src/supervisor/watchers/handlers/index.ts
@@ -4,6 +4,7 @@ import { logger } from '../../../common/logger';
 import { WorkloadKind } from '../../types';
 import * as cronJob from './cron-job';
 import * as deploymentConfig from './deployment-config';
+import * as rollout from './argo-rollout';
 import { k8sApi, kubeConfig } from '../../cluster';
 import * as kubernetesApiWrappers from '../../kuberenetes-api-wrappers';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
@@ -16,6 +17,8 @@ async function isSupportedNamespacedWorkload(
   workloadKind: WorkloadKind,
 ): Promise<boolean> {
   switch (workloadKind) {
+    case WorkloadKind.ArgoRollout:
+      return await rollout.isNamespacedArgoRolloutSupported(namespace);
     case WorkloadKind.DeploymentConfig:
       return await deploymentConfig.isNamespacedDeploymentConfigSupported(
         namespace,
@@ -43,6 +46,8 @@ async function isSupportedClusterWorkload(
   switch (workloadKind) {
     case WorkloadKind.DeploymentConfig:
       return await deploymentConfig.isClusterDeploymentConfigSupported();
+    case WorkloadKind.ArgoRollout:
+      return await rollout.isClusterArgoRolloutSupported();
     case WorkloadKind.CronJobV1Beta1:
       return await cronJob.isClusterCronJobSupported(
         workloadKind,

--- a/src/supervisor/watchers/handlers/informer-config.ts
+++ b/src/supervisor/watchers/handlers/informer-config.ts
@@ -10,6 +10,7 @@ import * as replicaSet from './replica-set';
 import * as replicationController from './replication-controller';
 import * as statefulSet from './stateful-set';
 import * as deploymentConfig from './deployment-config';
+import * as rollout from './argo-rollout';
 import { IWorkloadWatchMetadata } from './types';
 
 /**
@@ -145,5 +146,16 @@ export const workloadWatchMetadata: Readonly<IWorkloadWatchMetadata> = {
       deploymentConfig.paginatedClusterDeploymentConfigList(),
     namespacedListFactory: (namespace) => () =>
       deploymentConfig.paginatedNamespacedDeploymentConfigList(namespace),
+  },
+  [WorkloadKind.ArgoRollout]: {
+    clusterEndpoint: '/apis/argoproj.io/v1alpha1/rollouts',
+    namespacedEndpoint:
+      '/apis/argoproj.io/v1alpha1/watch/namespaces/{namespace}/rollouts',
+    handlers: {
+      [DELETE]: rollout.ArgoRolloutWatchHandler,
+    },
+    clusterListFactory: () => () => rollout.paginatedClusterArgoRolloutList(),
+    namespacedListFactory: (namespace) => () =>
+      rollout.paginatedNamespacedArgoRolloutList(namespace),
   },
 };

--- a/src/supervisor/watchers/handlers/types.ts
+++ b/src/supervisor/watchers/handlers/types.ts
@@ -60,6 +60,29 @@ export interface V1DeploymentConfigStatus {
   observedGeneration?: number;
 }
 
+export class RolloutList implements KubernetesListObject<Rollout> {
+  'apiVersion'?: string;
+  'items': Array<Rollout>;
+  'kind'?: string;
+  'metadata'?: V1ListMeta;
+}
+
+export interface Rollout extends KubernetesObject {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: V1ObjectMeta;
+  spec?: RolloutSpec;
+  status?: RolloutStatus;
+}
+
+export interface RolloutSpec {
+  template: V1PodTemplateSpec;
+}
+
+export interface RolloutStatus {
+  observedGeneration?: number;
+}
+
 export type V1ClusterList<T> = (
   allowWatchBookmarks?: boolean,
   _continue?: string,

--- a/src/transmitter/payload.ts
+++ b/src/transmitter/payload.ts
@@ -150,6 +150,7 @@ const workloadKindMap = {
   replicationcontroller: 'ReplicationController',
   deploymentconfig: 'DeploymentConfig',
   pod: 'Pod',
+  rollout: 'Rollout', // TODO: Verify if supported
 };
 export function constructRuntimeData(
   runtimeResults: IRuntimeImage[],


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The current behavior when Kubernetes Monitor scans workloads that are managed by Argo Rollout definitions is that it will only track the replicaset, which is unique per deployment. This leads to a large number of Snyk projects that are eventually deleted when there is a new deployment. Argo Rollouts are structurally very similar to Deployment definitions, but support additional rollout strategies. This PR adds recognition for Argo Rollout definitions to be recognized as the parent of replicasets when scanning images.

### Notes for the reviewer

The links for PR expectations are broken and so there may be additional cleanup required. I modeled this effort largely upon the DeploymentConfig definitions. For testing, I'm not sure if you would want to test this up with an integration test (which would require setting up Argo within the kind cluster), or if a unit test would be sufficient.

### Screenshots

![Partial snapshot of a Rollout project that has been imported via Kubernetes monitor](https://user-images.githubusercontent.com/2453456/172064516-f5d04413-a731-4631-9900-953709c91d9b.png)

