### PR TITLE
feat: support rpm>=4.16 container images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "needle": "^3.0.0",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.1.0",
-        "snyk-docker-plugin": "^4.35.2",
+        "snyk-docker-plugin": "^4.38.0",
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "^4.5.5",
@@ -1566,11 +1566,12 @@
       }
     },
     "node_modules/@snyk/rpm-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@snyk/rpm-parser/-/rpm-parser-2.2.1.tgz",
-      "integrity": "sha512-OAON0bPf3c5fgM/GK9DX0aZErB6SnuRyYlPH0rqI1TXGsKrYnVELhaE6ctNbEfPTQuY9r6q0vM+UYDaFM/YliA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@snyk/rpm-parser/-/rpm-parser-2.3.1.tgz",
+      "integrity": "sha512-mhVLv17Yf3Hw9ftxEHVt7YprhieUS9gpMSYciwc52QtEv6RS+MuW0xgPRpRFdvqd+zHKntL997EKDFwhKDwYoA==",
       "dependencies": {
-        "event-loop-spinner": "^2.0.0"
+        "event-loop-spinner": "^2.2.0",
+        "sql.js": "^1.7.0"
       },
       "engines": {
         "node": ">=8"
@@ -2181,11 +2182,11 @@
       }
     },
     "node_modules/@yarnpkg/fslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-2.6.1.tgz",
-      "integrity": "sha512-OtxwAUeBUt0ba/YnakcEw90YtYwQH+kT8wwHTP46HR8KuvVFawFLT6kwS18l5PARTIwKbqC1QaFyOrLn9xYfKg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-2.6.2.tgz",
+      "integrity": "sha512-cg8RfRD9ZJW+0/ER2TKXJbqvtk1707XeZ1MAWHpRXRqz/SJqmM3ujy1CfnG832lgzzkZK1315cIBwqFloopq6A==",
       "dependencies": {
-        "@yarnpkg/libzip": "^2.2.3",
+        "@yarnpkg/libzip": "^2.2.4",
         "tslib": "^1.13.0"
       },
       "engines": {
@@ -2222,9 +2223,9 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
     },
     "node_modules/@yarnpkg/parsers": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-2.5.0.tgz",
-      "integrity": "sha512-LEf3Ex+yAXSTpJKx4CEuJD1ngwDGC3pqkgPuIStThjDWpEG+p3yMDDvzES/c+9ADFQJjBQJfC0TMleV4UTNZkw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-2.5.1.tgz",
+      "integrity": "sha512-KtYN6Ez3x753vPF9rETxNTPnPjeaHY11Exlpqb4eTII7WRlnGiZ5rvvQBau4R20Ik5KBv+vS3EJEcHyCunwzzw==",
       "dependencies": {
         "js-yaml": "^3.10.0",
         "tslib": "^1.13.0"
@@ -2474,7 +2475,7 @@
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
@@ -2562,7 +2563,7 @@
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/asn1": {
       "version": "0.2.6",
@@ -3723,14 +3724,18 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dependencies": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-property": {
@@ -4996,13 +5001,13 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5275,6 +5280,17 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -7148,7 +7164,7 @@
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.constant": {
       "version": "3.0.0",
@@ -7168,7 +7184,7 @@
     "node_modules/lodash.flatmap": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
-      "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4="
+      "integrity": "sha512-/OcpcAGWlrZyoHGeHh3cAoa6nGdX6QYtmzNP84Jqol6UEQQ2gIaU3H+0eICcjcKGl0/XF8LWOujNn9lffsnaOg=="
     },
     "node_modules/lodash.foreach": {
       "version": "4.5.0",
@@ -7183,7 +7199,7 @@
     "node_modules/lodash.has": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+      "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g=="
     },
     "node_modules/lodash.invert": {
       "version": "4.3.0",
@@ -7244,7 +7260,7 @@
     "node_modules/lodash.topairs": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
-      "integrity": "sha1-O23qo31g+xFnE8RsXxfqGQ7EjWQ="
+      "integrity": "sha512-qrRMbykBSEGdOgQLJJqVSdPWMD7Q+GJJ5jMRfQYb+LTLsw3tYVIabnCzRqTJb2WTo17PG5gNzXuFaZgYH/9SAQ=="
     },
     "node_modules/lodash.transform": {
       "version": "4.6.0",
@@ -9726,13 +9742,13 @@
       }
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "4.35.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.35.2.tgz",
-      "integrity": "sha512-X2DUEUIUtco3O2UvEcnRPWYakqHRyeJBLnVQSV1/JeLomak55V5D+Qsotd3iukQ7PUaxVp6nOuh7VREShsW1Tg==",
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.38.0.tgz",
+      "integrity": "sha512-JdDz8Dnb6148k7nrnTOlwM4y1a3qIo+hqUKYB72cj3NFcAuoo2J3tBK/F0MLNlZljrZUGXEyV4utjqeZsVTkEA==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
-        "@snyk/dep-graph": "^1.28.0",
-        "@snyk/rpm-parser": "^2.0.0",
+        "@snyk/dep-graph": "^2.3.0",
+        "@snyk/rpm-parser": "^2.3.1",
         "@snyk/snyk-docker-pull": "^3.7.2",
         "adm-zip": "^0.5.5",
         "chalk": "^2.4.2",
@@ -9744,15 +9760,48 @@
         "gunzip-maybe": "^1.4.2",
         "mkdirp": "^1.0.4",
         "semver": "^7.3.4",
-        "snyk-nodejs-lockfile-parser": "1.37.3",
+        "snyk-nodejs-lockfile-parser": "1.40.0",
         "tar-stream": "^2.1.0",
         "tmp": "^0.2.1",
         "tslib": "^1",
         "uuid": "^8.2.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
+    },
+    "node_modules/snyk-docker-plugin/node_modules/@snyk/dep-graph": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.3.0.tgz",
+      "integrity": "sha512-IfHbuYNkkIYD0ExXQuS0oBM7oLoCxKAJG35V62DAfqNCF5FTPjeC5wx03G1b5UIbHmNbfevj6Y+++V5/62IW8w==",
+      "dependencies": {
+        "event-loop-spinner": "^2.1.0",
+        "lodash.clone": "^4.5.0",
+        "lodash.constant": "^3.0.0",
+        "lodash.filter": "^4.6.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.map": "^4.6.0",
+        "lodash.reduce": "^4.6.0",
+        "lodash.size": "^4.2.0",
+        "lodash.transform": "^4.6.0",
+        "lodash.union": "^4.6.0",
+        "lodash.values": "^4.3.0",
+        "object-hash": "^3.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/snyk-docker-plugin/node_modules/@snyk/dep-graph/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/snyk-docker-plugin/node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -9818,6 +9867,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/snyk-docker-plugin/node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/snyk-docker-plugin/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -9838,9 +9895,9 @@
       }
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.37.3",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.3.tgz",
-      "integrity": "sha512-kpCWluXEEOOnVh91CmwrRU9aQACLzoZ0hZDFRLshOZfDHvMiYjopw6JBq+IGXWpbzXgbQNr5Zzq5p6DcvrHFwA==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.40.0.tgz",
+      "integrity": "sha512-74bofOAZz8WSH5r2hlWs2Mvxii2WgX7D+v+iLh31d98BVCTHzxUQYibMrIWNg/5NIIOijBI87PzOtCiZ4Hr3FA==",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -10004,6 +10061,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "node_modules/sql.js": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.7.0.tgz",
+      "integrity": "sha512-qAfft3xkSgHqmmfNugWTp/59PsqIw8gbeao5TZmpmzQQsAJ49de3iDDKuxVixidYs6dkHNksY8m27v2dZNn2jw=="
     },
     "node_modules/ssh2": {
       "version": "1.9.0",
@@ -10188,7 +10250,7 @@
     "node_modules/stream-to-array": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
-      "integrity": "sha1-u/azn19D7DC8cbq8s3VXrOzzQ1M=",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
       "dependencies": {
         "any-promise": "^1.1.0"
       }
@@ -10196,7 +10258,7 @@
     "node_modules/stream-to-promise": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-to-promise/-/stream-to-promise-2.2.0.tgz",
-      "integrity": "sha1-se2y4cjLESidG1A8CNPyrvUeZQ8=",
+      "integrity": "sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==",
       "dependencies": {
         "any-promise": "~1.3.0",
         "end-of-stream": "~1.1.0",
@@ -10206,7 +10268,7 @@
     "node_modules/stream-to-promise/node_modules/end-of-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-      "integrity": "sha1-6TUyWLqpEIll78QcsO+K3i88+wc=",
+      "integrity": "sha512-EoulkdKF/1xa92q25PbjuDcgJ9RDHYU2Rs3SCIvs2/dSQ3BpmxneNHmA/M7fe60M3PrV7nNGTTNbkK62l6vXiQ==",
       "dependencies": {
         "once": "~1.3.0"
       }
@@ -10214,7 +10276,7 @@
     "node_modules/stream-to-promise/node_modules/once": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+      "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
       "dependencies": {
         "wrappy": "1"
       }
@@ -12610,11 +12672,12 @@
       }
     },
     "@snyk/rpm-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@snyk/rpm-parser/-/rpm-parser-2.2.1.tgz",
-      "integrity": "sha512-OAON0bPf3c5fgM/GK9DX0aZErB6SnuRyYlPH0rqI1TXGsKrYnVELhaE6ctNbEfPTQuY9r6q0vM+UYDaFM/YliA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@snyk/rpm-parser/-/rpm-parser-2.3.1.tgz",
+      "integrity": "sha512-mhVLv17Yf3Hw9ftxEHVt7YprhieUS9gpMSYciwc52QtEv6RS+MuW0xgPRpRFdvqd+zHKntL997EKDFwhKDwYoA==",
       "requires": {
-        "event-loop-spinner": "^2.0.0"
+        "event-loop-spinner": "^2.2.0",
+        "sql.js": "^1.7.0"
       }
     },
     "@snyk/snyk-docker-pull": {
@@ -13120,11 +13183,11 @@
       }
     },
     "@yarnpkg/fslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-2.6.1.tgz",
-      "integrity": "sha512-OtxwAUeBUt0ba/YnakcEw90YtYwQH+kT8wwHTP46HR8KuvVFawFLT6kwS18l5PARTIwKbqC1QaFyOrLn9xYfKg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-2.6.2.tgz",
+      "integrity": "sha512-cg8RfRD9ZJW+0/ER2TKXJbqvtk1707XeZ1MAWHpRXRqz/SJqmM3ujy1CfnG832lgzzkZK1315cIBwqFloopq6A==",
       "requires": {
-        "@yarnpkg/libzip": "^2.2.3",
+        "@yarnpkg/libzip": "^2.2.4",
         "tslib": "^1.13.0"
       }
     },
@@ -13152,9 +13215,9 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
     },
     "@yarnpkg/parsers": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-2.5.0.tgz",
-      "integrity": "sha512-LEf3Ex+yAXSTpJKx4CEuJD1ngwDGC3pqkgPuIStThjDWpEG+p3yMDDvzES/c+9ADFQJjBQJfC0TMleV4UTNZkw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-2.5.1.tgz",
+      "integrity": "sha512-KtYN6Ez3x753vPF9rETxNTPnPjeaHY11Exlpqb4eTII7WRlnGiZ5rvvQBau4R20Ik5KBv+vS3EJEcHyCunwzzw==",
       "requires": {
         "js-yaml": "^3.10.0",
         "tslib": "^1.13.0"
@@ -13340,7 +13403,7 @@
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "anymatch": {
       "version": "3.1.2",
@@ -13407,7 +13470,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "asn1": {
       "version": "0.2.6",
@@ -14301,11 +14364,12 @@
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
     },
     "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "requires": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       }
     },
     "define-property": {
@@ -15294,13 +15358,13 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
     },
     "get-package-type": {
@@ -15506,6 +15570,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
     },
     "has-symbols": {
       "version": "1.0.3",
@@ -16944,7 +17016,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "lodash.constant": {
       "version": "3.0.0",
@@ -16964,7 +17036,7 @@
     "lodash.flatmap": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
-      "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4="
+      "integrity": "sha512-/OcpcAGWlrZyoHGeHh3cAoa6nGdX6QYtmzNP84Jqol6UEQQ2gIaU3H+0eICcjcKGl0/XF8LWOujNn9lffsnaOg=="
     },
     "lodash.foreach": {
       "version": "4.5.0",
@@ -16979,7 +17051,7 @@
     "lodash.has": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+      "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g=="
     },
     "lodash.invert": {
       "version": "4.3.0",
@@ -17040,7 +17112,7 @@
     "lodash.topairs": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
-      "integrity": "sha1-O23qo31g+xFnE8RsXxfqGQ7EjWQ="
+      "integrity": "sha512-qrRMbykBSEGdOgQLJJqVSdPWMD7Q+GJJ5jMRfQYb+LTLsw3tYVIabnCzRqTJb2WTo17PG5gNzXuFaZgYH/9SAQ=="
     },
     "lodash.transform": {
       "version": "4.6.0",
@@ -18941,13 +19013,13 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.35.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.35.2.tgz",
-      "integrity": "sha512-X2DUEUIUtco3O2UvEcnRPWYakqHRyeJBLnVQSV1/JeLomak55V5D+Qsotd3iukQ7PUaxVp6nOuh7VREShsW1Tg==",
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.38.0.tgz",
+      "integrity": "sha512-JdDz8Dnb6148k7nrnTOlwM4y1a3qIo+hqUKYB72cj3NFcAuoo2J3tBK/F0MLNlZljrZUGXEyV4utjqeZsVTkEA==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
-        "@snyk/dep-graph": "^1.28.0",
-        "@snyk/rpm-parser": "^2.0.0",
+        "@snyk/dep-graph": "^2.3.0",
+        "@snyk/rpm-parser": "^2.3.1",
         "@snyk/snyk-docker-pull": "^3.7.2",
         "adm-zip": "^0.5.5",
         "chalk": "^2.4.2",
@@ -18959,13 +19031,45 @@
         "gunzip-maybe": "^1.4.2",
         "mkdirp": "^1.0.4",
         "semver": "^7.3.4",
-        "snyk-nodejs-lockfile-parser": "1.37.3",
+        "snyk-nodejs-lockfile-parser": "1.40.0",
         "tar-stream": "^2.1.0",
         "tmp": "^0.2.1",
         "tslib": "^1",
         "uuid": "^8.2.0"
       },
       "dependencies": {
+        "@snyk/dep-graph": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.3.0.tgz",
+          "integrity": "sha512-IfHbuYNkkIYD0ExXQuS0oBM7oLoCxKAJG35V62DAfqNCF5FTPjeC5wx03G1b5UIbHmNbfevj6Y+++V5/62IW8w==",
+          "requires": {
+            "event-loop-spinner": "^2.1.0",
+            "lodash.clone": "^4.5.0",
+            "lodash.constant": "^3.0.0",
+            "lodash.filter": "^4.6.0",
+            "lodash.foreach": "^4.5.0",
+            "lodash.isempty": "^4.4.0",
+            "lodash.isequal": "^4.5.0",
+            "lodash.isfunction": "^3.0.9",
+            "lodash.isundefined": "^3.0.1",
+            "lodash.map": "^4.6.0",
+            "lodash.reduce": "^4.6.0",
+            "lodash.size": "^4.2.0",
+            "lodash.transform": "^4.6.0",
+            "lodash.union": "^4.6.0",
+            "lodash.values": "^4.3.0",
+            "object-hash": "^3.0.0",
+            "semver": "^7.0.0",
+            "tslib": "^2"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+              "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+            }
+          }
+        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -19012,6 +19116,11 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
+        "object-hash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+          "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -19028,9 +19137,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.37.3",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.3.tgz",
-      "integrity": "sha512-kpCWluXEEOOnVh91CmwrRU9aQACLzoZ0hZDFRLshOZfDHvMiYjopw6JBq+IGXWpbzXgbQNr5Zzq5p6DcvrHFwA==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.40.0.tgz",
+      "integrity": "sha512-74bofOAZz8WSH5r2hlWs2Mvxii2WgX7D+v+iLh31d98BVCTHzxUQYibMrIWNg/5NIIOijBI87PzOtCiZ4Hr3FA==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -19176,6 +19285,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "sql.js": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.7.0.tgz",
+      "integrity": "sha512-qAfft3xkSgHqmmfNugWTp/59PsqIw8gbeao5TZmpmzQQsAJ49de3iDDKuxVixidYs6dkHNksY8m27v2dZNn2jw=="
+    },
     "ssh2": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.9.0.tgz",
@@ -19320,7 +19434,7 @@
     "stream-to-array": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
-      "integrity": "sha1-u/azn19D7DC8cbq8s3VXrOzzQ1M=",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
       "requires": {
         "any-promise": "^1.1.0"
       }
@@ -19328,7 +19442,7 @@
     "stream-to-promise": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-to-promise/-/stream-to-promise-2.2.0.tgz",
-      "integrity": "sha1-se2y4cjLESidG1A8CNPyrvUeZQ8=",
+      "integrity": "sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==",
       "requires": {
         "any-promise": "~1.3.0",
         "end-of-stream": "~1.1.0",
@@ -19338,7 +19452,7 @@
         "end-of-stream": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-          "integrity": "sha1-6TUyWLqpEIll78QcsO+K3i88+wc=",
+          "integrity": "sha512-EoulkdKF/1xa92q25PbjuDcgJ9RDHYU2Rs3SCIvs2/dSQ3BpmxneNHmA/M7fe60M3PrV7nNGTTNbkK62l6vXiQ==",
           "requires": {
             "once": "~1.3.0"
           }
@@ -19346,7 +19460,7 @@
         "once": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
           "requires": {
             "wrappy": "1"
           }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "needle": "^3.0.0",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.1.0",
-    "snyk-docker-plugin": "^4.35.2",
+    "snyk-docker-plugin": "^4.38.0",
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "^4.5.5",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Bumping the plugin with support for RPM 4.16.
Stating from this version, rpm moved to use an SQLite DB instead of Berkley DB. 
Due to a limitation in the CLI, had to switch the library we use to read the DB from `sqlite` to `sql.js`
