### PR TITLE
chore: clean up namespaces after test

### DIFF
--- a/test/setup/platforms/openshift4.ts
+++ b/test/setup/platforms/openshift4.ts
@@ -148,6 +148,15 @@ export async function clean(): Promise<void> {
     kubectl
       .deleteResource('clusterrole', 'snyk-monitor', 'default')
       .catch(() => undefined),
+    kubectl
+      .deleteResource('--all', 'all,sa,cm,secret,pvc', 'services')
+      .catch(() => undefined),
+    kubectl
+      .deleteResource('--all', 'all,sa,cm,secret,pvc', 'argo-rollout')
+      .catch(() => undefined),
+    kubectl
+      .deleteResource('--all', 'all,sa,cm,secret,pvc', 'snyk-monitor')
+      .catch(() => undefined),
   ]);
 
   // Kubernetes will be stuck trying to delete these namespaces if we don't clear the finalizers.


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Clean up namespaces after test
