### PR TITLE
fix: container python app scan errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "needle": "^3.0.0",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.1.0",
-        "snyk-docker-plugin": "^5.4.0",
+        "snyk-docker-plugin": "^5.4.1",
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "^4.7.4",
@@ -10125,9 +10125,9 @@
       }
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.4.0.tgz",
-      "integrity": "sha512-9aba6EJqmbJBfYUoYMbqz/ghV2xt02hl8LbFC8OzooXIyu4z72BBRUSfs3geRuLnhSYUIp4etzsOryCuqQdG2g==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.4.1.tgz",
+      "integrity": "sha512-x0erNrYCc72ZCj81LL85xibmU763otQACLW8aSUEAsLnSFpoKoE+tnQG5Z9BiEXYbSNXRsll/eS82gzhpHcFKQ==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",
@@ -19777,9 +19777,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.4.0.tgz",
-      "integrity": "sha512-9aba6EJqmbJBfYUoYMbqz/ghV2xt02hl8LbFC8OzooXIyu4z72BBRUSfs3geRuLnhSYUIp4etzsOryCuqQdG2g==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.4.1.tgz",
+      "integrity": "sha512-x0erNrYCc72ZCj81LL85xibmU763otQACLW8aSUEAsLnSFpoKoE+tnQG5Z9BiEXYbSNXRsll/eS82gzhpHcFKQ==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "needle": "^3.0.0",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.1.0",
-    "snyk-docker-plugin": "^5.4.0",
+    "snyk-docker-plugin": "^5.4.1",
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "^4.7.4",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This dependency bump should fix the "Invalid version" error we're seeing when scanning some Python projects

