### PR TITLE
Helm chart extensibility

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -191,6 +191,7 @@ spec:
         - name: docker-config
           secret:
             secretName: {{ .Values.monitorSecrets }}
+            optional: true
             items:
               - key: dockercfg.json
                 path: config.json
@@ -219,7 +220,7 @@ spec:
           projected:
             sources:
             - serviceAccountToken:
-                path: token  
+                path: token
         {{- end }}
         - name: registries-conf
           configMap:

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
             capabilities:
               drop:
                 - ALL
+        {{- if .Values.extraInitContainers -}}
+        {{ tpl (toYaml .Values.extraInitContainers) . | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ include "snyk-monitor.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -96,6 +99,9 @@ spec:
           {{- if .Values.excludedNamespaces }}
           - name: excluded-namespaces
             mountPath: "/etc/config"
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          {{- toYaml .Values.extraVolumeMounts | nindent 10 }}
           {{- end }}
           env:
           - name: NODE_EXTRA_CA_CERTS
@@ -223,6 +229,9 @@ spec:
         - name: excluded-namespaces
           configMap:
             name: {{ .Release.Name }}-excluded-namespaces
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -128,7 +128,7 @@ excludedNamespaces:
 #         fsGroup: <-- here
 securityContext:
   fsGroup:
-  
+
 # Set node tolerations for snyk-monitor
 tolerations: []
 
@@ -151,3 +151,20 @@ sysdig:
 
 strategy:
   type: RollingUpdate
+
+# Additional volumes for the deployment, available to all containers
+extraVolumes: []
+#  - name: my-empty-dir
+#    emptyDir: {}
+
+# Additional volume mounts for the snyk-monitor container
+extraVolumeMounts: []
+#  - name: extras
+#    mountPath: /mnt/my-empty-dir
+#    readOnly: true
+
+# Additional init containers, templated
+extraInitContainers: []
+#  - name: wait-for-condition
+#    image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+#    command: ['sh', '-c', 'sleep 10 || :']


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

closes #1165 

From the commit messages:
- add extensibility: This adds support from additional volumes, volume mounts and init containers. See [snyk-monitor/README.md](snyk-monitor/README.md) for details and documentation.
- making the docker-config secret optional allows the containers to boot even though the secret is not yet available. This enables use-cases like where a custom init container can be made responsible for creating the secret before the main snyk-monitor container is booted.


### Notes for the reviewer

This does not affect the helm chart default behavior. You are able to deploy snyk-monitor into a Kubernetes cluster in the same way as before this change. Only when configuring one or more of `extraVolumes`, `extraVolumeMounts` and `extraInitContainers`, the behavior of the chart (and resulting deployment) changes depending on the use-case.

My own use-case for implementing this extensibility is the ability to have the docker configuration secret created asynchronously after the helm chart is applied. I have configured an init container to hold off booting the snyk-monitor main container until the secret is created.
