### PR TITLE
feat: Add includedNamespaces options for snyk-monitor

### DIFF
--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -235,7 +235,7 @@ helm upgrade --install snyk-monitor snyk-charts/snyk-monitor \
   --set psp.enabled=true
 ```
 
-## Configuring excluded namespaces ##
+## Configuring excluded namespaces
 
 By default, `snyk-monitor` does not scan containers that are internal to Kubernetes, in the following namespaces:
 * `kube-node-lease`
@@ -247,6 +247,17 @@ If you prefer to override this, you can add your own list of namespaces to exclu
 ```yaml
 --set excludedNamespaces="{kube-node-lease,kube-public,local-path-storage,some_namespace}"
 ```
+
+## Configuring included namespaces
+
+Sometimes targeting specific namespaces may make more sense than trying to exclude all the ones you do not want.
+
+You can add your own list of namespaces to include by setting the `includedNamespaces` option. For example:
+```yaml
+--set includedNamespaces="{some_namespace}"
+```
+
+This option takes precidence over the `excludedNamespaces` option, so if a namespace is both marked for inclusion and exclusion, it will be included.
 
 ## Using EKS without assigning an IAM role to a Node Group
 

--- a/snyk-monitor/templates/configmap.yaml
+++ b/snyk-monitor/templates/configmap.yaml
@@ -1,3 +1,19 @@
+{{ if .Values.includedNamespaces }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-included-namespaces
+  labels:
+    app.kubernetes.io/name: {{ include "snyk-monitor.name" . }}
+    helm.sh/chart: {{ include "snyk-monitor.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  includedNamespaces: |-
+    {{- range .Values.includedNamespaces }}
+    {{ . }}
+    {{- end }}
+{{ end }}
 {{ if .Values.excludedNamespaces }}
 apiVersion: v1
 kind: ConfigMap

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -96,9 +96,13 @@ spec:
             readOnly: true
           - name: registries-conf
             mountPath: "/srv/app/.config/containers"
+          {{- if .Values.includedNamespaces }}
+          - name: included-namespaces
+            mountPath: "/etc/config/included-namespaces"
+          {{- end }}
           {{- if .Values.excludedNamespaces }}
           - name: excluded-namespaces
-            mountPath: "/etc/config"
+            mountPath: "/etc/config/excluded-namespaces"
           {{- end }}
           {{- if .Values.extraVolumeMounts }}
           {{- toYaml .Values.extraVolumeMounts | nindent 10 }}
@@ -226,6 +230,11 @@ spec:
           configMap:
             name: {{ .Values.registriesConfConfigMap }}
             optional: true
+        {{- if .Values.includedNamespaces }}
+        - name: included-namespaces
+          configMap:
+            name: {{ .Release.Name }}-included-namespaces
+        {{- end }}
         {{- if .Values.excludedNamespaces }}
         - name: excluded-namespaces
           configMap:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -117,6 +117,9 @@ psp:
   enabled: false
   name: ""
 
+# Override the included namespaces
+includedNamespaces:
+
 # Override the excluded namespaces
 excludedNamespaces:
 

--- a/snyk-operator-certified/helm-charts/snyk-monitor/templates/deployment.yaml
+++ b/snyk-operator-certified/helm-charts/snyk-monitor/templates/deployment.yaml
@@ -77,9 +77,13 @@ spec:
             readOnly: true
           - name: registries-conf
             mountPath: "/srv/app/.config/containers"
-           {{- if .Values.excludedNamespaces }}
+          {{- if .Values.includedNamespaces }}
+          - name: included-namespaces
+            mountPath: "/etc/config/included-namespaces"
+          {{- end }}
+          {{- if .Values.excludedNamespaces }}
           - name: excluded-namespaces
-            mountPath: "/etc/config"
+            mountPath: "/etc/config/excluded-namespaces"
           {{- end }}
           env:
           - name: NODE_EXTRA_CA_CERTS
@@ -170,6 +174,11 @@ spec:
           configMap:
             name: {{ .Values.registriesConfConfigMap }}
             optional: true
+        {{- if .Values.includedNamespaces }}
+        - name: included-namespaces
+          configMap:
+            name: {{ .Release.Name }}-included-namespaces
+        {{- end }}
         {{- if .Values.excludedNamespaces }}
         - name: excluded-namespaces
           configMap:

--- a/snyk-operator-certified/helm-charts/snyk-monitor/values.yaml
+++ b/snyk-operator-certified/helm-charts/snyk-monitor/values.yaml
@@ -95,5 +95,8 @@ psp:
   enabled: false
   name: ""
 
+# Override the included namespaces
+includedNamespaces:
+
 # Override the excluded namespaces
 excludedNamespaces:

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -7,11 +7,20 @@ const config = loadConfig(__dirname + '/../..', {
   secretConfig: process.env.CONFIG_SECRET_FILE,
 }) as unknown as Config;
 
-const namespacesFilePath = '/etc/config/excludedNamespaces';
 
 function loadExcludedNamespaces(): string[] | null {
+  const namespacesFilePath = '/etc/config/excluded-namespaces/excludedNamespaces';
+  return loadNamespaces(namespacesFilePath);
+}
+
+function loadIncludedNamespaces(): string[] | null {
+  const namespacesFilePath = '/etc/config/included-namespaces/includedNamespaces';
+  return loadNamespaces(namespacesFilePath);
+}
+
+function loadNamespaces(filePath: string): string[] | null {
   try {
-    const data = readFileSync(namespacesFilePath, 'utf-8');
+    const data = readFileSync(filePath, 'utf-8');
     const namespaces: string[] = data.split(/\r?\n/);
     return namespaces;
   } catch (err) {
@@ -42,6 +51,7 @@ config.INTEGRATION_ID = config.INTEGRATION_ID.trim();
 config.CLUSTER_NAME = getClusterName();
 config.IMAGE_STORAGE_ROOT = '/var/tmp';
 config.POLICIES_STORAGE_ROOT = '/tmp/policies';
+config.INCLUDED_NAMESPACES = loadIncludedNamespaces();
 config.EXCLUDED_NAMESPACES = loadExcludedNamespaces();
 config.WORKERS_COUNT = Number(config.WORKERS_COUNT) || 10;
 config.SKOPEO_COMPRESSION_LEVEL = Number(config.SKOPEO_COMPRESSION_LEVEL) || 6;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -24,6 +24,7 @@ export interface Config {
   AGENT_ID: string;
   IMAGE_STORAGE_ROOT: '/var/tmp';
   POLICIES_STORAGE_ROOT: '/tmp/policies';
+  INCLUDED_NAMESPACES: string[] | null;
   EXCLUDED_NAMESPACES: string[] | null;
   SKOPEO_COMPRESSION_LEVEL: number;
   SYSDIG_ENDPOINT: string;

--- a/src/supervisor/watchers/internal-namespaces.ts
+++ b/src/supervisor/watchers/internal-namespaces.ts
@@ -103,11 +103,18 @@ export function extractNamespaceName(namespace: V1Namespace): string {
 }
 
 export function isExcludedNamespace(namespace: string): boolean {
-  return (
-    (config.EXCLUDED_NAMESPACES
-      ? config.EXCLUDED_NAMESPACES.includes(namespace)
-      : kubernetesInternalNamespaces.has(namespace)) ||
-    // always check openshift excluded namespaces
-    openshiftInternalNamespaces.has(namespace)
-  );
+  if (openshiftInternalNamespaces.has(namespace)) {
+    return true; // always exclude openshift
+  }
+
+  // if explicitly specified to be included, do not exclude it
+  if (config.INCLUDED_NAMESPACES) {
+    return !config.INCLUDED_NAMESPACES.includes(namespace);
+  }
+
+  if (config.EXCLUDED_NAMESPACES) {
+    return config.EXCLUDED_NAMESPACES.includes(namespace);
+  }
+
+  return kubernetesInternalNamespaces.has(namespace);
 }

--- a/test/common/config.spec.ts
+++ b/test/common/config.spec.ts
@@ -70,6 +70,7 @@ describe('extractNamespaceName()', () => {
     expect(config.INTEGRATION_ID).toEqual(expect.any(String));
     expect(config.CLUSTER_NAME).toEqual('Default cluster');
     expect(config.IMAGE_STORAGE_ROOT).toEqual('/var/tmp');
+    expect(config.INCLUDED_NAMESPACES).toBeNull();
     expect(config.EXCLUDED_NAMESPACES).toBeNull();
     expect(config.HTTPS_PROXY).toBeUndefined();
     expect(config.HTTP_PROXY).toBeUndefined();

--- a/test/unit/supervisor/watchers.spec.ts
+++ b/test/unit/supervisor/watchers.spec.ts
@@ -103,3 +103,33 @@ describe('isExcludedNamespace() excluded namespaces from config', () => {
     },
   );
 });
+
+describe('isExcludedNamespace() included namespaces from config', () => {
+  const includedNamespacesFromConfig = ['one', 'two', 'three'];
+  beforeAll(() => {
+    config.INCLUDED_NAMESPACES = includedNamespacesFromConfig;
+  });
+
+  afterAll(() => {
+    config.INCLUDED_NAMESPACES = null;
+  });
+
+  includedNamespacesFromConfig.forEach((namespace) => {
+    test(`[excluded namespaces from config] isExcludedNamespace(${namespace}) -> false`, () => {
+      expect(isExcludedNamespace(namespace)).toEqual(false);
+    });
+  });
+
+  for (const internalNamespace of openshiftInternalNamespaces) {
+    test(`[openshift internal namespaces] isExcludedNamespace(${internalNamespace}) -> true`, () => {
+      expect(isExcludedNamespace(internalNamespace)).toEqual(true);
+    });
+  }
+
+  test.each([['kube-system']['egg'], [''], [undefined as unknown as string]])(
+    'isExcludedNamespace(%s) -> true',
+    (input) => {
+      expect(isExcludedNamespace(input)).toEqual(true);
+    },
+  );
+});

--- a/test/unit/transmitter-payload.spec.ts
+++ b/test/unit/transmitter-payload.spec.ts
@@ -297,4 +297,54 @@ describe('transmitter payload tests', () => {
       });
     },
   );
+
+  test.concurrent(
+    'constructRuntimeData with included namespace happy flow',
+    async () => {
+      config.INCLUDED_NAMESPACES = ['test'];
+      const runtimeDataPayload = payload.constructRuntimeData([
+        {
+          imageID: 'something',
+          namespace: 'sysdig',
+          workloadName: 'workload',
+          workloadKind: 'deployment',
+          container: 'box',
+          packages: [],
+        },
+        {
+          imageID: 'something',
+          namespace: 'test',
+          workloadName: 'workload',
+          workloadKind: 'deployment',
+          container: 'box',
+          packages: [],
+        },
+      ]);
+      expect(runtimeDataPayload).toEqual<IRuntimeDataPayload>({
+        identity: {
+          type: 'sysdig',
+        },
+        target: {
+          userLocator: expect.any(String),
+          cluster: 'Default cluster',
+          agentId: expect.any(String),
+        },
+        facts: [
+          {
+            type: 'loadedPackages',
+            data: [
+              {
+                imageID: 'something',
+                namespace: 'test',
+                workloadName: 'workload',
+                workloadKind: 'Deployment',
+                container: 'box',
+                packages: [],
+              },
+            ],
+          },
+        ],
+      });
+    },
+  );
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
#1172 

### Notes for the reviewer

Can now specify `includedNamespaces` during helm install and it should create a config map for it (similar to the `excludedNamespaces`.

