### PR TITLE
test: jest fail-fast when any test fails

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,9 @@ module.exports = {
   clearMocks: true,
   errorOnDeprecated: true,
 
+  /** https://github.com/facebook/jest/issues/2867#issuecomment-546592968 */
+  setupFilesAfterEnv: ["./jest.setup-after-env.js"],
+
   // TODO: This is here until a bug in Jest (which in turn affects ts-jest) is resolved.
   // It affects our CI/CD runs and makes the machine run out of memory.
   // https://github.com/facebook/jest/issues/10550

--- a/jest.setup-after-env.js
+++ b/jest.setup-after-env.js
@@ -1,0 +1,4 @@
+const failFast = require("jasmine-fail-fast");
+
+const jasmineEnv = jasmine.getEnv();
+jasmineEnv.addReporter(failFast.init());

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^3.4.1",
         "fadge": "^0.0.1",
+        "jasmine-fail-fast": "^2.0.1",
         "jest": "^26.6.3",
         "nock": "^13.0.11",
         "prettier": "^2.4.1",
@@ -6271,6 +6272,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jasmine-fail-fast": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jasmine-fail-fast/-/jasmine-fail-fast-2.0.1.tgz",
+      "integrity": "sha512-En8ONwvDQOV+jyiZEZvbvUSLWSdJFj9HiWjhLdGq/V/gxs4XyST730ooe928BbRxv4bfy05OpykKuoOU4aLC5w==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15"
       }
     },
     "node_modules/jest": {
@@ -16757,6 +16767,15 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "jasmine-fail-fast": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jasmine-fail-fast/-/jasmine-fail-fast-2.0.1.tgz",
+      "integrity": "sha512-En8ONwvDQOV+jyiZEZvbvUSLWSdJFj9HiWjhLdGq/V/gxs4XyST730ooe928BbRxv4bfy05OpykKuoOU4aLC5w==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
       }
     },
     "jest": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.1",
     "fadge": "^0.0.1",
+    "jasmine-fail-fast": "^2.0.1",
     "jest": "^26.6.3",
     "nock": "^13.0.11",
     "prettier": "^2.4.1",

--- a/test/integration/kubernetes.spec.ts
+++ b/test/integration/kubernetes.spec.ts
@@ -29,8 +29,9 @@ async function teardown(): Promise<void> {
   console.log('Removed "kind" network');
 }
 
-beforeAll(teardown);
 afterAll(teardown);
+
+test('clean up environment on start', teardown);
 
 // Make sure this runs first -- deploying the monitor for the next tests
 test('deploy snyk-monitor', async () => {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Since Jest doesn't stop as soon as any test fails, we sometimes see weird errors and alerts because of an incorrectly configured test setup sending bad data.

This change ensures Jest fails fast on first error encountered.
