### PR TITLE
test: fix openshift4 flakes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,7 +392,7 @@ jobs:
     openshift4_integration_tests:
         machine:
             docker_layer_caching: true
-            image: ubuntu-2004:202111-02
+            image: ubuntu-2204:current
             resource_class: large
         steps:
             - checkout

--- a/.circleci/config/jobs/openshift4_integration_tests.yml
+++ b/.circleci/config/jobs/openshift4_integration_tests.yml
@@ -1,6 +1,7 @@
 machine:
   resource_class: large
-  image: ubuntu-2004:202111-02
+  # https://circleci.com/developer/machine/image/ubuntu-2204
+  image: ubuntu-2204:current
   docker_layer_caching: true
 working_directory: ~/kubernetes-monitor
 steps:

--- a/test/setup/index.ts
+++ b/test/setup/index.ts
@@ -196,7 +196,16 @@ export async function deployMonitor(): Promise<string> {
       pullPolicy: imagePullPolicy,
     };
     await deployers[deploymentType].deploy(deploymentImageOptions);
-    await kubectl.waitForDeployment('snyk-monitor', namespace);
+    for (let attempt = 0; attempt < 180; attempt++) {
+      try {
+        await exec(
+          `./kubectl get deployment.apps/snyk-monitor -n ${namespace}`,
+        );
+        break;
+      } catch {
+        await sleep(1000);
+      }
+    }
 
     console.log(
       `Deployed the snyk-monitor with integration ID ${integrationId}`,

--- a/test/setup/platforms/openshift4.ts
+++ b/test/setup/platforms/openshift4.ts
@@ -152,10 +152,14 @@ export async function clean(): Promise<void> {
       .deleteResource('--all', 'all,sa,cm,secret,pvc,rollouts', 'services')
       .catch(() => undefined),
     kubectl
-      .deleteResource('--all', 'all,sa,cm,secret,pvc', 'argo-rollout')
+      .deleteResource('--all', 'all,sa,cm,secret,pvc,rollouts', 'argo-rollouts')
       .catch(() => undefined),
     kubectl
-      .deleteResource('--all', 'all,sa,cm,secret,pvc', 'snyk-monitor')
+      .deleteResource(
+        '--all',
+        'all,sa,cm,secret,pvc,subscription,installplan,csv',
+        'snyk-monitor',
+      )
       .catch(() => undefined),
   ]);
 


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

For some reason `kubectl wait --for=condition=available` does not work only in CircleCI and only for OpenShift tests, causing failures. Replacing this with a `sleep()` seems to fix it. I can't reproduce the problem locally and I'm out of ideas on how to fix it other than by sleep()-ing...

