### PR TITLE
chore: restore kubectl version to latest in tests

### DIFF
--- a/test/helpers/kubectl.ts
+++ b/test/helpers/kubectl.ts
@@ -13,11 +13,6 @@ import { execWrapper as exec } from './exec';
 export async function downloadKubectl(version: string): Promise<void> {
   const kubectlPath = resolve(process.cwd(), 'kubectl');
   if (existsSync(kubectlPath)) {
-    if (version === 'latest') {
-      return;
-    }
-
-    // Always start clean when requesting a specific version.
     unlinkSync(kubectlPath);
   }
 

--- a/test/system/kind.spec.ts
+++ b/test/system/kind.spec.ts
@@ -74,8 +74,7 @@ test('Kubernetes-Monitor with KinD', async () => {
     throw new Error('Please install skopeo on your machine');
   }
 
-  // pinning to this version due to https://github.com/aws/aws-cli/issues/6920
-  const kubernetesVersion = 'v1.23.5';
+  const kubernetesVersion = 'latest';
   // kubectl
   await kubectl.downloadKubectl(kubernetesVersion);
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The issue caused by Amazon for a specific kubectl version has now been fixed.

### Notes for the reviewer

https://github.com/aws/aws-cli/issues/6920
