### PR TITLE
fix: ensure http clients use timeout

### DIFF
--- a/src/data-scraper/index.ts
+++ b/src/data-scraper/index.ts
@@ -34,7 +34,9 @@ export async function validateConnectivity(): Promise<void> {
     headers: {
       authorization: header,
     },
-    timeout: 10_000,
+    open_timeout: 10_000,
+    response_timeout: 10_000,
+    read_timeout: 10_000,
   };
 
   const limit: number = 1;
@@ -61,6 +63,9 @@ export async function scrapeData(): Promise<void> {
     headers: {
       authorization: header,
     },
+    open_timeout: 10_000,
+    response_timeout: 10_000,
+    read_timeout: 10_000,
   };
 
   let cursor: string = '';

--- a/src/transmitter/index.ts
+++ b/src/transmitter/index.ts
@@ -248,6 +248,9 @@ export async function retryRequest(
     json: true,
     compressed: true,
     agent: getAgent(url),
+    open_timeout: 10_000,
+    response_timeout: 10_000,
+    read_timeout: 10_000,
     ...reqOptions,
   };
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Some recent logs suggested that connections to Kubernetes Upstream were never completed and were hanging. This fix introduces a timeout so that the connection won't infinitely stay open.