### PR TITLE
fix: delete workload requests send data with query string

### DIFF
--- a/src/transmitter/index.ts
+++ b/src/transmitter/index.ts
@@ -200,13 +200,17 @@ export async function deleteWorkload(
   payload: IDeleteWorkloadPayload,
 ): Promise<void> {
   try {
+    const { workloadLocator, agentId } = payload;
+    const { userLocator, cluster, namespace, type, name } = workloadLocator;
+    const query = `userLocator=${userLocator}&cluster=${cluster}&namespace=${namespace}&type=${type}&name=${name}&agentId=${agentId}`;
     const request: KubernetesUpstreamRequest = {
       method: 'delete',
-      url: `${upstreamUrl}/api/v1/workload`,
+      url: `${upstreamUrl}/api/v1/workload?${query}`,
       payload,
     };
 
     const { response, attempt } = await reqQueue.pushAsync(request);
+    // TODO: Remove this check, the upstream no longer returns 404 in such cases
     if (response.statusCode === 404) {
       logger.info(
         { payload },


### PR DESCRIPTION
According to the HTTP spec, DELETE requests cannot contain a body. This change ensures we now send data via query string.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### Notes for the reviewer

- Existing integration test already covers the case where a workload is deleted and we observe the upstream no longer has this workload: test/integration/kubernetes.spec.ts:602: snyk-monitor sends deleted workload to kubernetes-upstream
- The test may fail until the upstream service deploys with the query string support - will rerun once deployed

