### PR TITLE
fix: bump snyk-docker-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "needle": "^3.0.0",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.1.0",
-        "snyk-docker-plugin": "^5.6.2",
+        "snyk-docker-plugin": "^5.6.3",
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "^4.7.4",
@@ -10100,9 +10100,9 @@
       }
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.2.tgz",
-      "integrity": "sha512-LRvYGzbEU+rZ1Sgi7uuh4u61ZolDiwYmK84ZqVCgeyJzEtc6nkCmwk6jqtXg2nUohyWE5SlGerl4GU9l0TX3gQ==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.3.tgz",
+      "integrity": "sha512-NhMB1mZN3Rr3FJso9gtC30lOUKnomJvGZxDNWVLnQ/hgT6vOArC0VcG68RYyws73JpL2w9jXEoqSheUdrPFzQQ==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",
@@ -19738,9 +19738,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.2.tgz",
-      "integrity": "sha512-LRvYGzbEU+rZ1Sgi7uuh4u61ZolDiwYmK84ZqVCgeyJzEtc6nkCmwk6jqtXg2nUohyWE5SlGerl4GU9l0TX3gQ==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.3.tgz",
+      "integrity": "sha512-NhMB1mZN3Rr3FJso9gtC30lOUKnomJvGZxDNWVLnQ/hgT6vOArC0VcG68RYyws73JpL2w9jXEoqSheUdrPFzQQ==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "needle": "^3.0.0",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.1.0",
-    "snyk-docker-plugin": "^5.6.2",
+    "snyk-docker-plugin": "^5.6.3",
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "^4.7.4",


### PR DESCRIPTION
Contains a fix for Go app vuln scanning, see [snyk/snyk-docker-plugin#461](https://github.com/snyk/snyk-docker-plugin/pull/461)

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

_Explain why this PR exists_

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### Screenshots

_Visuals that may help the reviewer_
