### PR TITLE
fix: update snyk-docker-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "needle": "^3.0.0",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.1.0",
-        "snyk-docker-plugin": "^5.6.3",
+        "snyk-docker-plugin": "^5.6.4",
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "^4.7.4",
@@ -10100,9 +10100,9 @@
       }
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.3.tgz",
-      "integrity": "sha512-NhMB1mZN3Rr3FJso9gtC30lOUKnomJvGZxDNWVLnQ/hgT6vOArC0VcG68RYyws73JpL2w9jXEoqSheUdrPFzQQ==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.4.tgz",
+      "integrity": "sha512-cdzJT747CN66TkU+3zBlJ3V7X1X404YB3TYnJTvxg4DL/0kZ9LvVpZ2AXWlGtd/lcr91gO/O//dAsl4tJwKUFg==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",
@@ -19738,9 +19738,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.3.tgz",
-      "integrity": "sha512-NhMB1mZN3Rr3FJso9gtC30lOUKnomJvGZxDNWVLnQ/hgT6vOArC0VcG68RYyws73JpL2w9jXEoqSheUdrPFzQQ==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.4.tgz",
+      "integrity": "sha512-cdzJT747CN66TkU+3zBlJ3V7X1X404YB3TYnJTvxg4DL/0kZ9LvVpZ2AXWlGtd/lcr91gO/O//dAsl4tJwKUFg==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "needle": "^3.0.0",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.1.0",
-    "snyk-docker-plugin": "^5.6.3",
+    "snyk-docker-plugin": "^5.6.4",
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "^4.7.4",


### PR DESCRIPTION
### What does this PR do?

fix: use full version of go modules in dep-graph

### What are the relevant tickets?

- https://github.com/snyk/snyk-docker-plugin/pull/462
- https://github.com/snyk/snyk-docker-plugin/releases/tag/v5.6.4