### PR TITLE
fix: allow init containers to be configured

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -52,6 +52,7 @@ spec:
                 {{- end }}
       serviceAccountName: {{ include "snyk-monitor.name" . }}
       restartPolicy: Always
+      {{- if .Values.initContainers.enabled }}
       initContainers:
         - name: volume-permissions
           image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
@@ -77,6 +78,7 @@ spec:
         {{- if .Values.extraInitContainers -}}
         {{ tpl (toYaml .Values.extraInitContainers) . | nindent 8 }}
         {{- end }}
+      {{- end }}
       containers:
         - name: {{ include "snyk-monitor.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -148,6 +148,9 @@ sysdig:
 strategy:
   type: RollingUpdate
 
+initContainers:
+  enabled: true
+
 # Additional volumes for the deployment, available to all containers
 extraVolumes: []
 #  - name: my-empty-dir


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

initContainers required to be run as root to provision pvc for temporary storage. We want to allow it to be configured, so user has the option to choose on installation.
