### PR TITLE
fix: reduce worker count from 10 to 5

### DIFF
--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -139,7 +139,7 @@ skopeo:
     level: 6
 
 workers:
-  count: 10
+  count: 5
 sysdig:
   enabled: false
   namespace: sysdig-agent


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This should put less strain on the CPU, reduce how many images we pull concurrently, therefore it should slightly improve performance and make individual image scanning faster.

