### PR TITLE
RUN-2499 chore: fix debian GCR fixture that crashes in a loop

### DIFF
--- a/test/fixtures/private-registries/debian-deployment-gcr-io.yaml
+++ b/test/fixtures/private-registries/debian-deployment-gcr-io.yaml
@@ -19,4 +19,4 @@ spec:
         image: gcr.io/snyk-k8s-fixtures/debian:10
         imagePullPolicy: Always
         securityContext: {}
-        command: ["true"]
+        command: ['sh', '-c', 'echo Hello from GCR pod! && sleep 360000']


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
