### PR TITLE
RUN-2459 feat: pass image id to snyk docker plugin 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "child-process-promise": "^2.2.1",
         "fs-extra": "^10.1.0",
         "lru-cache": "^6.0.0",
-        "minipass": "3.3.6",
         "needle": "^3.0.0",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "child-process-promise": "^2.2.1",
     "fs-extra": "^10.1.0",
     "lru-cache": "^6.0.0",
-    "minipass": "3.3.6",
     "needle": "^3.0.0",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.1.0",

--- a/src/scanner/images/index.ts
+++ b/src/scanner/images/index.ts
@@ -123,6 +123,7 @@ export async function scanImages(
       const pluginResponse = await scan({
         path: archivePath,
         imageNameAndTag: imageName,
+        imageNameAndDigest: imageWithDigest,
       });
 
       if (

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -103,7 +103,7 @@ export function getUniqueImages(workloadMetadata: IWorkload[]): IScanImage[] {
 
     accum[meta.imageName] = {
       imageWithDigest: digest && `${imageName}@${digest}`,
-      imageName: meta.imageName, // Image name with tag
+      imageName: meta.imageName, // Image name with tag or digest, according to metadata image field declaration
       skopeoRepoType: SkopeoRepositoryType.DockerArchive,
     };
 

--- a/test/system/kind.spec.ts
+++ b/test/system/kind.spec.ts
@@ -247,6 +247,13 @@ test('Kubernetes-Monitor with KinD', async () => {
               { type: 'imageLayers', data: expect.any(Array) },
               { type: 'rootFs', data: expect.any(Array) },
               { type: 'imageOsReleasePrettyName', data: expect.any(String) },
+              {
+                type: 'imageNames',
+                data: [
+                  'docker.io/library/openjdk:latest',
+                  expect.stringContaining('docker.io/library/openjdk@sha256:'),
+                ],
+              },
             ]),
             target: { image: 'docker-image|docker.io/library/openjdk' },
             identity: { type: 'rpm', args: { platform: 'linux/amd64' } },

--- a/test/unit/scanner/images.spec.ts
+++ b/test/unit/scanner/images.spec.ts
@@ -133,7 +133,7 @@ describe('getImageParts()', () => {
           .imageName,
       ).toEqual('kind-registry:5000/python-27');
     });
-    it('removed repository/image:tag contining dashes', () => {
+    it('removed repository/image:tag continuing dashes', () => {
       expect(
         scannerImages.getImageParts(
           'kind-registry:5000/test/python-27:rc-buster',


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Pass workload metadata image Id when available to Snyk Docker Plugin to collect image names as a new fact.

