### PR TITLE
chore: disable flaky openshift tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1020,21 +1020,6 @@ staging_branch_only_filter:
                 - staging
 version: 2.1
 workflows:
-    MANUAL_OPENSHIFT_RELEASE:
-        jobs:
-            - hold:
-                filters:
-                    branches:
-                        only:
-                            - master
-                type: approval
-            - operator_upgrade_tests:
-                filters:
-                    branches:
-                        only:
-                            - master
-                requires:
-                    - hold
     MERGE_TO_MASTER:
         jobs:
             - publish:
@@ -1115,14 +1100,6 @@ workflows:
                 requires:
                     - build_image
                     - build_and_upload_operator
-            - openshift4_integration_tests:
-                filters:
-                    branches:
-                        only:
-                            - staging
-                requires:
-                    - build_image
-                    - build_and_upload_operator
             - tag_and_push:
                 context: nodejs-app-release-public
                 filters:
@@ -1152,26 +1129,6 @@ workflows:
                             - staging
                 requires:
                     - tag_and_push
-    MONTHLY:
-        jobs:
-            - operator_upgrade_tests
-        triggers:
-            - schedule:
-                cron: 0 5 3 * *
-                filters:
-                    branches:
-                        only:
-                            - master
-    NIGHTLY:
-        jobs:
-            - operator_upgrade_tests
-        triggers:
-            - schedule:
-                cron: 0 1 * * *
-                filters:
-                    branches:
-                        only:
-                            - master
     PR_TO_STAGING:
         jobs:
             - build_image:

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -78,11 +78,11 @@ workflows:
             - build_image
             - build_and_upload_operator
           <<: *staging_branch_only_filter
-      - openshift4_integration_tests:
-          requires:
-            - build_image
-            - build_and_upload_operator
-          <<: *staging_branch_only_filter
+      # - openshift4_integration_tests:
+      #     requires:
+      #       - build_image
+      #       - build_and_upload_operator
+      #     <<: *staging_branch_only_filter
       - tag_and_push:
           context: nodejs-app-release-public
           requires:
@@ -114,56 +114,56 @@ workflows:
             - publish
           <<: *master_branch_only_filter
 
-  NIGHTLY:
-    triggers:
-      - schedule:
-          cron: "0 1 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - operator_upgrade_tests
+  # NIGHTLY:
+  #   triggers:
+  #     - schedule:
+  #         cron: "0 1 * * *"
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #   jobs:
+  #     - operator_upgrade_tests
 
-  MONTHLY:
-    triggers:
-      - schedule:
-          cron: "0 5 3 * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - operator_upgrade_tests
-      # - push_operator_to_embedded_community_operators:
-      #     requires:
-      #       - operator_upgrade_tests
-      # - push_operator_to_community_operators:
-      #     requires:
-      #       - operator_upgrade_tests
+  # MONTHLY:
+  #   triggers:
+  #     - schedule:
+  #         cron: "0 5 3 * *"
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #   jobs:
+  #     - operator_upgrade_tests
+  #     - push_operator_to_embedded_community_operators:
+  #         requires:
+  #           - operator_upgrade_tests
+  #     - push_operator_to_community_operators:
+  #         requires:
+  #           - operator_upgrade_tests
 
-  MANUAL_OPENSHIFT_RELEASE:
-    jobs:
-      - hold:
-          <<: *master_branch_only_filter
-          type: approval
-      - operator_upgrade_tests:
-          <<: *master_branch_only_filter
-          requires:
-            - hold
-      # - sync_embedded_community_operators_with_snyk_fork:
-      #     <<: *master_branch_only_filter
-      #     requires:
-      #       - operator_upgrade_tests
-      # - push_operator_to_embedded_community_operators:
-      #     <<: *master_branch_only_filter
-      #     requires:
-      #       - sync_embedded_community_operators_with_snyk_fork
-      # - sync_community_operators_with_snyk_fork:
-      #     <<: *master_branch_only_filter
-      #     requires:
-      #       - push_operator_to_embedded_community_operators
-      # - push_operator_to_community_operators:
-      #     <<: *master_branch_only_filter
-      #     requires:
-      #       - sync_community_operators_with_snyk_fork
+  # MANUAL_OPENSHIFT_RELEASE:
+  #   jobs:
+  #     - hold:
+  #         <<: *master_branch_only_filter
+  #         type: approval
+  #     - operator_upgrade_tests:
+  #         <<: *master_branch_only_filter
+  #         requires:
+  #           - hold
+  #     - sync_embedded_community_operators_with_snyk_fork:
+  #         <<: *master_branch_only_filter
+  #         requires:
+  #           - operator_upgrade_tests
+  #     - push_operator_to_embedded_community_operators:
+  #         <<: *master_branch_only_filter
+  #         requires:
+  #           - sync_embedded_community_operators_with_snyk_fork
+  #     - sync_community_operators_with_snyk_fork:
+  #         <<: *master_branch_only_filter
+  #         requires:
+  #           - push_operator_to_embedded_community_operators
+  #     - push_operator_to_community_operators:
+  #         <<: *master_branch_only_filter
+  #         requires:
+  #           - sync_community_operators_with_snyk_fork


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Temporarily disable the tests until we have time to review the failures. The problem seems to be stemming from our integration cluster.
