### PR TITLE
chore: upgrade deprecated k8s api for fixture

### DIFF
--- a/test/fixtures/sidecar-containers/deployment.yaml
+++ b/test/fixtures/sidecar-containers/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -11,7 +11,7 @@ metadata:
   name: hello-world
   namespace: security-tools
   resourceVersion: "55787967"
-  selfLink: /apis/extensions/v1beta1/namespaces/security-tools/deployments/hello-world
+  selfLink: /apis/apps/v1/namespaces/security-tools/deployments/hello-world
   uid: d2006330-0f86-11ea-ae05-4201c0a88014
 spec:
   progressDeadlineSeconds: 2147483647


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The extensions/v1beta1 would be deprecated after k8s v1.22
 https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122 
We want to update this to prevent having flaky tests in the future.
