### PR TITLE
[CIT-75] test: use unique cluster name in integration tests

### DIFF
--- a/test/fixtures/operator/custom-resource-k8s.yaml
+++ b/test/fixtures/operator/custom-resource-k8s.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   integrationApi: https://kubernetes-upstream.dev.snyk.io
   temporaryStorageSize: 20Gi
+  clusterName: ""
   pvc:
     enabled: true
     create: true

--- a/test/fixtures/operator/custom-resource.yaml
+++ b/test/fixtures/operator/custom-resource.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   integrationApi: https://kubernetes-upstream.dev.snyk.io
   temporaryStorageSize: 20Gi
+  clusterName: ""
   pvc:
     enabled: true
     create: true

--- a/test/setup/deployers/helm-with-proxy.ts
+++ b/test/setup/deployers/helm-with-proxy.ts
@@ -1,7 +1,7 @@
 import { platform } from 'os';
 import { existsSync, chmodSync } from 'fs';
 
-import { IDeployer, IImageOptions } from './types';
+import { IDeployer, IDeployOptions, IImageOptions } from './types';
 import * as kubectl from '../../helpers/kubectl';
 import { execWrapper as exec } from '../../helpers/exec';
 
@@ -15,6 +15,7 @@ export const helmWithProxyDeployer: IDeployer = {
 
 async function deployKubernetesMonitor(
   imageOptions: IImageOptions,
+  deployOptions: IDeployOptions,
 ): Promise<void> {
   if (!existsSync(helmPath)) {
     await downloadHelm();
@@ -37,6 +38,7 @@ async function deployKubernetesMonitor(
       `--set image.tag=${imageTag} ` +
       `--set image.pullPolicy=${imagePullPolicy} ` +
       '--set integrationApi=https://kubernetes-upstream.dev.snyk.io ' +
+      `--set clusterName=${deployOptions.clusterName} ` +
       '--set https_proxy=http://forwarding-proxy:8080',
   );
   console.log(

--- a/test/setup/deployers/helm.ts
+++ b/test/setup/deployers/helm.ts
@@ -1,7 +1,7 @@
 import { platform } from 'os';
 import { existsSync, chmodSync } from 'fs';
 
-import { IDeployer, IImageOptions } from './types';
+import { IDeployer, IDeployOptions, IImageOptions } from './types';
 import { execWrapper as exec } from '../../helpers/exec';
 
 const helmVersion = '3.0.0';
@@ -14,6 +14,7 @@ export const helmDeployer: IDeployer = {
 
 async function deployKubernetesMonitor(
   imageOptions: IImageOptions,
+  deployOptions: IDeployOptions,
 ): Promise<void> {
   if (!existsSync(helmPath)) {
     await downloadHelm();
@@ -30,6 +31,7 @@ async function deployKubernetesMonitor(
       `--set image.tag=${imageTag} ` +
       `--set image.pullPolicy=${imagePullPolicy} ` +
       '--set integrationApi=https://kubernetes-upstream.dev.snyk.io ' +
+      `--set clusterName=${deployOptions.clusterName} ` +
       '--set nodeSelector."kubernetes\\.io/os"=linux ' +
       '--set pvc.enabled=true ' +
       '--set pvc.create=true ' +

--- a/test/setup/deployers/types.ts
+++ b/test/setup/deployers/types.ts
@@ -3,6 +3,13 @@ export interface IImageOptions {
   pullPolicy: 'Never' | 'Always' | 'IfPresent';
 }
 
+export interface IDeployOptions {
+  clusterName: string;
+}
+
 export interface IDeployer {
-  deploy: (imageOptions: IImageOptions) => Promise<void>;
+  deploy: (
+    imageOptions: IImageOptions,
+    deployOptions: IDeployOptions,
+  ) => Promise<void>;
 }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This PR sets a unique cluster name for each integration test run.

### Notes for the reviewer

This is done as a preliminary step for a future change, where we will use the same integration ID in all integration tests. This change would ensure that in the future change, the tests will not affect each other.

