### PR TITLE
[CIT-76] chore: use different argo rollout version for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1122,13 +1122,6 @@ workflows:
                             - staging
                 requires:
                     - tag_and_push
-            - deploy_to_sysdig_integration_cluster:
-                filters:
-                    branches:
-                        only:
-                            - staging
-                requires:
-                    - tag_and_push
     PR_TO_STAGING:
         jobs:
             - build_image:

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -99,10 +99,11 @@ workflows:
           requires:
             - tag_and_push
           <<: *staging_branch_only_filter
-      - deploy_to_sysdig_integration_cluster:
-          requires:
-            - tag_and_push
-          <<: *staging_branch_only_filter
+      # TODO: Uncomment the step once we resolve the kubeconfig problem
+      # - deploy_to_sysdig_integration_cluster:
+      #     requires:
+      #       - tag_and_push
+      #     <<: *staging_branch_only_filter
 
   MERGE_TO_MASTER:
     jobs:

--- a/test/integration/kubernetes.spec.ts
+++ b/test/integration/kubernetes.spec.ts
@@ -98,7 +98,9 @@ test('deploy sample workloads', async () => {
       .createNamespace(argoNamespace)
       .then(() =>
         kubectl.applyK8sYaml(
-          'https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml',
+          //TODO: We pin to a earlier version due to a bug in Argo Rollout, we will revert to latest once the bug is fixed.
+          // https://github.com/argoproj/argo-rollouts/issues/2568
+          'https://github.com/argoproj/argo-rollouts/releases/download/v1.3.2/install.yaml',
           argoNamespace,
         ),
       )


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Attempt to fix `eks` and `aks` integration test, we pinned the Argo Rollout version in the test to an earlier version due to a [bug](https://github.com/argoproj/argo-rollouts/issues/2568)
