### PR TITLE
chore: add snyk log labels values in deploy to dev

### DIFF
--- a/scripts/circleci-jobs/deploy_to_dev.sh
+++ b/scripts/circleci-jobs/deploy_to_dev.sh
@@ -37,6 +37,13 @@ skopeo:
 workers:
   count: 5
 
+metadata:
+  labels:
+    $SNYK_OWNER_LABEL_KEY: $SNYK_OWNER_LABEL_VALUE
+    $SNYK_LOG_DEST_LABEL_KEY: $SNYK_LOG_DEST_LABEL_VALUE
+  annotations:
+    github.com/project-slug: snyk/kubernetes-monitor
+
 EOF
 
 cat >$KUBERNETES_MONITOR_DEPLOYER_REPO/helm/values/multi-tenant-gcp-production.yaml <<EOF
@@ -59,6 +66,13 @@ skopeo:
 
 workers:
   count: 5
+
+metadata:
+  labels:
+    $SNYK_OWNER_LABEL_KEY: $SNYK_OWNER_LABEL_VALUE
+    $SNYK_LOG_DEST_LABEL_KEY: $SNYK_LOG_DEST_LABEL_VALUE
+  annotations:
+    github.com/project-slug: snyk/kubernetes-monitor
 
 EOF
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

add snyk log labels and annotation values placeholders in deploy_to_dev script to allow controlling snyk logs destinations.

