### PR TITLE
feat: make network resource monitoring configurable

### DIFF
--- a/snyk-monitor/templates/clusterrole.yaml
+++ b/snyk-monitor/templates/clusterrole.yaml
@@ -13,7 +13,9 @@ rules:
   - ""
   resources:
   - pods
+{{- if .Values.scan_networking_resources }}
   - services
+{{- end }}
   verbs:
   - get
   - list
@@ -54,6 +56,7 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.scan_networking_resources }}
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -62,6 +65,7 @@ rules:
   - get
   - list
   - watch
+{{- end }}
 - apiGroups:
   - apps.openshift.io
   resources:

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -143,6 +143,8 @@ spec:
             value: {{ .Values.log_level }}
           - name: SKIP_K8S_JOBS
             value: {{ quote .Values.skip_k8s_jobs }}
+          - name: SCAN_NETWORKING_RESOURCES
+            value: {{ quote .Values.scan_networking_resources }}
           - name: SNYK_SKOPEO_COMPRESSION_LEVEL
             value: {{ quote .Values.skopeo.compression.level }}
           - name: SNYK_WORKERS_COUNT

--- a/snyk-monitor/templates/role.yaml
+++ b/snyk-monitor/templates/role.yaml
@@ -13,7 +13,9 @@ rules:
   - ""
   resources:
   - pods
+{{- if .Values.scan_networking_resources }}
   - services
+{{- end }}
   verbs:
   - get
   - list
@@ -54,6 +56,7 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.scan_networking_resources }}
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -62,6 +65,7 @@ rules:
   - get
   - list
   - watch
+{{- end }}
 - apiGroups:
   - apps.openshift.io
   resources:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -94,6 +94,9 @@ no_proxy:
 use_keepalive: true
 skip_k8s_jobs:
 
+# Scan networking resources (Service, Ingress, Networking CRDs)
+scan_networking_resources: false
+
 # Override default (INFO) log level if less verbosity needed
 log_level:
 

--- a/snyk-operator-certified/helm-charts/snyk-monitor/templates/deployment.yaml
+++ b/snyk-operator-certified/helm-charts/snyk-monitor/templates/deployment.yaml
@@ -117,6 +117,8 @@ spec:
             value: {{ .Values.log_level }}
           - name: SKIP_K8S_JOBS
             value: {{ quote .Values.skip_k8s_jobs }}
+          - name: SCAN_NETWORKING_RESOURCES
+            value: {{ quote .Values.scan_networking_resources }}
           {{- with .Values.envs }}
           {{- toYaml . | trim | nindent 10 -}}
           {{ end }}

--- a/snyk-operator-certified/helm-charts/snyk-monitor/values.yaml
+++ b/snyk-operator-certified/helm-charts/snyk-monitor/values.yaml
@@ -86,6 +86,9 @@ no_proxy:
 use_keepalive: true
 skip_k8s_jobs:
 
+# Scan networking resources (Service, Ingress, Networking CRDs)
+scan_networking_resources: false
+
 # Override default (INFO) log level if less verbosity needed
 log_level:
 

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -65,5 +65,7 @@ delete process.env['HTTP_PROXY'];
 delete process.env['NO_PROXY'];
 
 config.SKIP_K8S_JOBS = process.env.SKIP_K8S_JOBS === 'true';
+config.SCAN_NETWORKING_RESOURCES =
+  process.env.SCAN_NETWORKING_RESOURCES === 'true';
 
 export { config };

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -37,6 +37,7 @@ export interface Config {
   NO_PROXY: string | undefined;
   USE_KEEPALIVE: boolean;
   SKIP_K8S_JOBS: boolean;
+  SCAN_NETWORKING_RESOURCES: boolean;
   DEPLOYMENT_NAME: string;
   DEPLOYMENT_NAMESPACE: string;
   WATCH_NAMESPACE: string;

--- a/src/supervisor/watchers/handlers/index.ts
+++ b/src/supervisor/watchers/handlers/index.ts
@@ -81,6 +81,10 @@ export async function setupNamespacedInformer(
   }
 
   const workloadMetadata = workloadWatchMetadata[workloadKind];
+  if (!workloadMetadata) {
+    logger.debug(logContext, 'Workload kind is not monitored');
+    return;
+  }
   const endpoint = workloadMetadata.namespacedEndpoint.replace(
     '{namespace}',
     namespace,
@@ -161,6 +165,10 @@ export async function setupClusterInformer(
   }
 
   const workloadMetadata = workloadWatchMetadata[workloadKind];
+  if (!workloadMetadata) {
+    logger.debug(logContext, 'Workload kind is not monitored');
+    return;
+  }
   const endpoint = workloadMetadata.clusterEndpoint;
 
   const listMethod = workloadMetadata.clusterListFactory();

--- a/test/unit/informer-config.spec.ts
+++ b/test/unit/informer-config.spec.ts
@@ -1,0 +1,37 @@
+import { WorkloadKind } from '../../src/supervisor/types';
+
+describe('workloadWatchMetadata is loaded based on config.SCAN_NETWORKING_RESOURCES', () => {
+  const OLD_ENV = process.env;
+  beforeEach(() => {
+    process.env = { ...OLD_ENV };
+    jest.resetModules();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  test('ensure networking resources are not loaded when config.SCAN_NETWORKING_RESOURCES is not true', async () => {
+    process.env.SCAN_NETWORKING_RESOURCES = '';
+    const {
+      workloadWatchMetadata,
+    } = require('../../src/supervisor/watchers/handlers/informer-config');
+
+    // Workload resources such as Deployment should be loaded
+    expect(workloadWatchMetadata[WorkloadKind.Deployment]).toBeDefined();
+    // Networking resources should not be loaded
+    expect(workloadWatchMetadata[WorkloadKind.Service]).toBeUndefined();
+    expect(workloadWatchMetadata[WorkloadKind.Ingress]).toBeUndefined();
+  });
+  test('ensure networking resources are loaded when config.SCAN_NETWORKING_RESOURCES is true', async () => {
+    process.env.SCAN_NETWORKING_RESOURCES = 'true';
+    const {
+      workloadWatchMetadata,
+    } = require('../../src/supervisor/watchers/handlers/informer-config');
+    // Workload resources such as Deployment should be loaded
+    expect(workloadWatchMetadata[WorkloadKind.Deployment]).toBeDefined();
+    // Networking resources should be loaded because of SCAN_NETWORKING_RESOURCES
+    expect(workloadWatchMetadata[WorkloadKind.Service]).toBeDefined();
+    expect(workloadWatchMetadata[WorkloadKind.Ingress]).toBeDefined();
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This change enables network resource monitoring when it's explicitly enabled during installation. 
By default network resource monitoring is disabled.

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### Screenshots

_Visuals that may help the reviewer_
