### PR TITLE
[CIT-75] Add optional service acc token env var

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -113,6 +113,12 @@ spec:
               secretKeyRef:
                 name: {{ .Values.monitorSecrets }}
                 key: integrationId
+          - name: SNYK_SERVICE_ACCOUNT_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.monitorSecrets }}
+                key: serviceAccountApiToken
+                optional: true
           - name: SNYK_WATCH_NAMESPACE
             value: {{ include "snyk-monitor.scope" . }}
           - name: SNYK_DEPLOYMENT_NAMESPACE


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds new optional env var `SNYK_SERVICE_ACCOUNT_API_TOKEN` to helm chart.
