### PR TITLE
allow snyk-monitor to run on arm64

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -44,11 +44,17 @@ spec:
               - matchExpressions:
                 - key: "kubernetes.io/arch"
                   operator: In
-                  values: ["amd64"]
+                  values:
+                    {{- with .Values.nodeAffinity.kubernetesIoArch }}
+                      {{- toYaml . | nindent 20 }}
+                    {{- end }}
                 {{- if not .Values.nodeAffinity.disableBetaArchNodeSelector }}
                 - key: "beta.kubernetes.io/arch"
                   operator: In
-                  values: ["amd64"]
+                  values:
+                    {{- with .Values.nodeAffinity.kubernetesIoArch }}
+                      {{- toYaml . | nindent 20 }}
+                    {{- end }}
                 {{- end }}
       serviceAccountName: {{ include "snyk-monitor.name" . }}
       restartPolicy: Always

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -101,6 +101,8 @@ nodeSelector: {}
 
 nodeAffinity:
   disableBetaArchNodeSelector: false
+  kubernetesIoArch:
+  - amd64
 
 # Additional labels and annotations for the snyk-monitor Deployment's Pod
 metadata:

--- a/snyk-operator-certified/helm-charts/snyk-monitor/templates/deployment.yaml
+++ b/snyk-operator-certified/helm-charts/snyk-monitor/templates/deployment.yaml
@@ -30,10 +30,16 @@ spec:
               - matchExpressions:
                 - key: "kubernetes.io/arch"
                   operator: In
-                  values: ["amd64"]
+                  values:
+                    {{- with .Values.nodeAffinity.kubernetesIoArch }}
+                      {{- toYaml . | nindent 20 }}
+                    {{- end }}
                 - key: "beta.kubernetes.io/arch"
                   operator: In
-                  values: ["amd64"]
+                  values:
+                    {{- with .Values.nodeAffinity.kubernetesIoArch }}
+                      {{- toYaml . | nindent 20 }}
+                    {{- end }}
       serviceAccountName: {{ include "snyk-monitor.name" . }}
       restartPolicy: Always
       initContainers:

--- a/snyk-operator-certified/helm-charts/snyk-monitor/values.yaml
+++ b/snyk-operator-certified/helm-charts/snyk-monitor/values.yaml
@@ -91,5 +91,9 @@ log_level:
 
 nodeSelector: {}
 
+nodeAffinity:
+  kubernetesIoArch:
+  - amd64
+
 # Override the excluded namespaces
 excludedNamespaces:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This PR allows `snyk-monitor` to run on arm64 systems, for example MacOS M1
