### PR TITLE
Install latest docker-credential-acr-env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk upgrade
 RUN apk --no-cache add git
 
 RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@69c85dc22db6511932bbf119e1a0cc5c90c69a7f
-RUN go install github.com/chrismellard/docker-credential-acr-env@fb789970a885098fb386e1d938499d9eb9449821
+RUN go install github.com/chrismellard/docker-credential-acr-env@82a0ddb2758901b711d9d1614755b77e401598a1
 
 #---------------------------------------------------------------------
 # STAGE 2: Build the kubernetes-monitor

--- a/Dockerfile.ubi8
+++ b/Dockerfile.ubi8
@@ -15,7 +15,7 @@ RUN apk upgrade
 RUN apk --no-cache add git
 
 RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@69c85dc22db6511932bbf119e1a0cc5c90c69a7f
-RUN go install github.com/chrismellard/docker-credential-acr-env@fb789970a885098fb386e1d938499d9eb9449821
+RUN go install github.com/chrismellard/docker-credential-acr-env@82a0ddb2758901b711d9d1614755b77e401598a1
 
 #---------------------------------------------------------------------
 # STAGE 3: Build kubernetes-monitor application


### PR DESCRIPTION
### What this does

This version of docker-credential-acr-env is needed for OIDC authentication via Azure Workload Identity.

See https://github.com/snyk/kubernetes-monitor/issues/1223
