### PR TITLE
feat: support scanning go:1.20 binaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "needle": "^3.0.0",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.1.0",
-        "snyk-docker-plugin": "^6.0.0",
+        "snyk-docker-plugin": "^6.2.0",
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "^4.7.4",
@@ -10107,9 +10107,9 @@
       }
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.0.0.tgz",
-      "integrity": "sha512-StsA8eivHswxylDSni1RS5Ag/rdeRTYVhTN4l0ZasU0hQ8D66iAP0uiqz7/nQtkjaTCs4AGr7oDt9X6VfXx4Rw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.2.0.tgz",
+      "integrity": "sha512-M+M78vQkyk1is1R1dU9O4nTLIDTZ6eCq3jcnnnLfwtkegqddydQttXptsAzhAWdWLZzIiofo+9asQmj1clCV5g==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.5.0",
@@ -19780,9 +19780,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.0.0.tgz",
-      "integrity": "sha512-StsA8eivHswxylDSni1RS5Ag/rdeRTYVhTN4l0ZasU0hQ8D66iAP0uiqz7/nQtkjaTCs4AGr7oDt9X6VfXx4Rw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.2.0.tgz",
+      "integrity": "sha512-M+M78vQkyk1is1R1dU9O4nTLIDTZ6eCq3jcnnnLfwtkegqddydQttXptsAzhAWdWLZzIiofo+9asQmj1clCV5g==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "needle": "^3.0.0",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.1.0",
-    "snyk-docker-plugin": "^6.0.0",
+    "snyk-docker-plugin": "^6.2.0",
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "^4.7.4",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

_Explain why this PR exists_

Update snyk-docker-plugin to support scanning go:1.20 binaries.
