### PR TITLE
chore: update helm operator version

### DIFF
--- a/snyk-operator-certified/Dockerfile
+++ b/snyk-operator-certified/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/helm-operator:v1.27
+FROM quay.io/operator-framework/helm-operator:v1.28
 
 LABEL name="Snyk Operator" \
       maintainer="support@snyk.io" \

--- a/snyk-operator/build/Dockerfile
+++ b/snyk-operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/helm-operator:v1.27
+FROM quay.io/operator-framework/helm-operator:v1.28
 
 LABEL name="Snyk Operator" \
       maintainer="support@snyk.io" \


### PR DESCRIPTION
### What this does

Updates helm operator version

Resolved:

- https://security.snyk.io/vuln/SNYK-RHEL8-LIBKSBA-3232176
- https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXNETHTTP2HPACK-3358253
- https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXNETHTTP2-3323837

Waiting on upstream to resolve existing:

- https://security.snyk.io/vuln/SNYK-RHEL8-OPENSSLLIBS-3315644

### Links

- https://quay.io/repository/operator-framework/helm-operator?tab=tags
