### PR TITLE
fix: helm chart when kubernetesIoArch value is missing

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -45,15 +45,23 @@ spec:
                 - key: "kubernetes.io/arch"
                   operator: In
                   values:
-                    {{- with .Values.nodeAffinity.kubernetesIoArch }}
-                      {{- toYaml . | nindent 20 }}
+                    {{- if .Values.nodeAffinity.kubernetesIoArch }}
+                      {{- with .Values.nodeAffinity.kubernetesIoArch }}
+                        {{- toYaml . | nindent 20 }}
+                      {{- end }}
+                    {{- else }}
+                      ["amd64"]
                     {{- end }}
                 {{- if not .Values.nodeAffinity.disableBetaArchNodeSelector }}
                 - key: "beta.kubernetes.io/arch"
                   operator: In
                   values:
-                    {{- with .Values.nodeAffinity.kubernetesIoArch }}
-                      {{- toYaml . | nindent 20 }}
+                    {{- if .Values.nodeAffinity.kubernetesIoArch }}
+                      {{- with .Values.nodeAffinity.kubernetesIoArch }}
+                        {{- toYaml . | nindent 20 }}
+                      {{- end }}
+                    {{- else }}
+                      ["amd64"]
                     {{- end }}
                 {{- end }}
       serviceAccountName: {{ include "snyk-monitor.name" . }}

--- a/snyk-operator-certified/helm-charts/snyk-monitor/templates/deployment.yaml
+++ b/snyk-operator-certified/helm-charts/snyk-monitor/templates/deployment.yaml
@@ -31,14 +31,22 @@ spec:
                 - key: "kubernetes.io/arch"
                   operator: In
                   values:
-                    {{- with .Values.nodeAffinity.kubernetesIoArch }}
-                      {{- toYaml . | nindent 20 }}
+                    {{- if .Values.nodeAffinity.kubernetesIoArch }}
+                      {{- with .Values.nodeAffinity.kubernetesIoArch }}
+                        {{- toYaml . | nindent 20 }}
+                      {{- end }}
+                    {{- else }}
+                      ["amd64"]
                     {{- end }}
                 - key: "beta.kubernetes.io/arch"
                   operator: In
                   values:
-                    {{- with .Values.nodeAffinity.kubernetesIoArch }}
-                      {{- toYaml . | nindent 20 }}
+                    {{- if .Values.nodeAffinity.kubernetesIoArch }}
+                      {{- with .Values.nodeAffinity.kubernetesIoArch }}
+                        {{- toYaml . | nindent 20 }}
+                      {{- end }}
+                    {{- else }}
+                      ["amd64"]
                     {{- end }}
       serviceAccountName: {{ include "snyk-monitor.name" . }}
       restartPolicy: Always


### PR DESCRIPTION
The current Kubernetes helm chart assumes that the value of kubernetesIoArch is set. If the parameter is not set, the creation of the helm chart fails with `Required value: must be specified when operatoris 'In' or 'NotIn'`

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Fixes https://github.com/snyk/kubernetes-monitor/issues/1277

### Notes for the reviewer

To reproduce the issue, you need to delete the following lines: https://github.com/snyk/kubernetes-monitor/blob/staging/snyk-monitor/values.yaml#L105-L106
