### PR TITLE
chore: use staging branch for npm relock

### DIFF
--- a/.github/workflows/relock.yaml
+++ b/.github/workflows/relock.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: main
+          ref: staging
 
       - name: Import Snyk Deployer GPG key
         uses: crazy-max/ghaction-import-gpg@v5


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Use staging branch for npm relock workflow.

### Notes for the reviewer

NPM relock jobs fail today on the step to checkout code from `main` branch, which does not exist. For example: https://github.com/snyk/kubernetes-monitor/actions/runs/4843210077/jobs/8630653941

### Screenshots

![image](https://user-images.githubusercontent.com/11232557/235344476-b7a60a5b-91c5-455b-87a9-3b4eeca884f3.png)
