### PR TITLE
fix for proxy variables

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -151,11 +151,11 @@ spec:
             value: /srv/app
           - name: CLOUDSDK_CONFIG
             value: /var/tmp/gcloud
-          - name: HTTP_PROXY
+          - name: http_proxy
             value: {{ .Values.http_proxy }}
-          - name: HTTPS_PROXY
+          - name: https_proxy
             value: {{ .Values.https_proxy }}
-          - name: NO_PROXY
+          - name: no_proxy
             value: {{ .Values.no_proxy }}
           - name: USE_KEEPALIVE
             value: {{ quote .Values.use_keepalive }}


### PR DESCRIPTION
all proxy variables must be lowercase, uppercase does not work

### What this does
We struggled a lot with the proxy configuration and after investigation we found out that the helm chart renders all proxy related variables in uppercase. This should be fine, at least that's what [the docs](https://support.snyk.io/hc/en-us/articles/360000925358-How-can-I-use-Snyk-behind-a-proxy-) says. But it's not. We changed the variables in the deployment to lowercase and it works.

[Here](https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/) you can see, which tool can handle uppercase and lowercase proxy vars.