### PR TITLE
feat: schedule the snyk-monitor on linux worker nodes

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -52,6 +52,16 @@ spec:
                     {{- else }}
                       ["amd64"]
                     {{- end }}
+                - key: "kubernetes.io/os"
+                  operator: In
+                  values:
+                    {{- if .Values.nodeAffinity.kubernetesIoOs }}
+                      {{- with .Values.nodeAffinity.kubernetesIoOs }}
+                        {{- toYaml . | nindent 20 }}
+                      {{- end }}
+                    {{- else }}
+                      ["linux"]
+                    {{- end }}
                 {{- if not .Values.nodeAffinity.disableBetaArchNodeSelector }}
                 - key: "beta.kubernetes.io/arch"
                   operator: In
@@ -62,6 +72,16 @@ spec:
                       {{- end }}
                     {{- else }}
                       ["amd64"]
+                    {{- end }}
+                - key: "beta.kubernetes.io/os"
+                  operator: In
+                  values:
+                    {{- if .Values.nodeAffinity.kubernetesIoOs }}
+                      {{- with .Values.nodeAffinity.kubernetesIoOs }}
+                        {{- toYaml . | nindent 20 }}
+                      {{- end }}
+                    {{- else }}
+                      ["linux"]
                     {{- end }}
                 {{- end }}
       serviceAccountName: {{ include "snyk-monitor.name" . }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -104,6 +104,8 @@ nodeAffinity:
   disableBetaArchNodeSelector: false
   kubernetesIoArch:
   - amd64
+  kubernetesIoOs:
+  - linux
 
 # Additional labels and annotations for the snyk-monitor Deployment's Pod
 metadata:

--- a/test/integration/kubernetes.spec.ts
+++ b/test/integration/kubernetes.spec.ts
@@ -729,6 +729,57 @@ test('snyk-monitor has nodeSelector', async () => {
   );
 });
 
+test('snyk-monitor has nodeAffinity', async () => {
+  if (process.env['DEPLOYMENT_TYPE'] !== 'Helm') {
+    console.log(
+      "Not testing nodeAffinity because we're not installing with Helm",
+    );
+    return;
+  }
+
+  const snykMonitorDeployment = await kubectl.getDeploymentJson(
+    'snyk-monitor',
+    'snyk-monitor',
+  );
+  const snykMonitorPodSpec = snykMonitorDeployment.spec.template.spec;
+  expect(snykMonitorPodSpec).toEqual(
+    expect.objectContaining({
+      affinity: {
+        nodeAffinity: {
+          requiredDuringSchedulingIgnoredDuringExecution: {
+            nodeSelectorTerms: [
+              {
+                matchExpressions: [
+                  {
+                    key: 'kubernetes.io/arch',
+                    operator: 'In',
+                    values: ['amd64'],
+                  },
+                  {
+                    key: 'kubernetes.io/os',
+                    operator: 'In',
+                    values: ['linux'],
+                  },
+                  {
+                    key: 'beta.kubernetes.io/arch',
+                    operator: 'In',
+                    values: ['amd64'],
+                  },
+                  {
+                    key: 'beta.kubernetes.io/os',
+                    operator: 'In',
+                    values: ['linux'],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    }),
+  );
+});
+
 test('snyk-monitor secure configuration is as expected', async () => {
   const kubeConfig = new KubeConfig();
   kubeConfig.loadFromDefault();


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

We build the snyk-monitor image only for the linux/amd64 platform.

This change ensures we are scheduling the app only on worker nodes of that type.

### Notes for the reviewer

Before this change, the app could've been scheduled on Windows worker nodes, which wouldn't work as we have no Windows variant of the snyk-monitor
