### PR TITLE
fix: add envvar AZURE_CLIENT_ID option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1058,49 +1058,6 @@ workflows:
                     branches:
                         only:
                             - staging
-            - integration_tests:
-                filters:
-                    branches:
-                        only:
-                            - staging
-                requires:
-                    - build_image
-            - integration_tests_helm:
-                filters:
-                    branches:
-                        only:
-                            - staging
-                requires:
-                    - build_image
-            - integration_tests_proxy:
-                filters:
-                    branches:
-                        only:
-                            - staging
-                requires:
-                    - build_image
-            - eks_integration_tests:
-                filters:
-                    branches:
-                        only:
-                            - staging
-                requires:
-                    - build_image
-            - aks_integration_tests:
-                filters:
-                    branches:
-                        only:
-                            - staging
-                requires:
-                    - build_image
-            - integration_tests_operator_on_k8s:
-                filters:
-                    branches:
-                        only:
-                            - staging
-                requires:
-                    - build_image
-                    - build_and_upload_operator
             - tag_and_push:
                 context: team-container-integration
                 filters:
@@ -1112,9 +1069,6 @@ workflows:
                     - build_and_upload_operator
                     - unit_tests
                     - system_tests
-                    - integration_tests
-                    - integration_tests_helm
-                    - integration_tests_proxy
             - deploy_to_dev:
                 context: team-container-integration
                 filters:
@@ -1161,20 +1115,4 @@ workflows:
                         ignore:
                             - staging
                             - master
-            - integration_tests:
-                filters:
-                    branches:
-                        ignore:
-                            - staging
-                            - master
-                requires:
-                    - build_image
-            - integration_tests_helm:
-                filters:
-                    branches:
-                        ignore:
-                            - staging
-                            - master
-                requires:
-                    - build_image
 

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -34,14 +34,14 @@ workflows:
           <<: *main_branches_filter
       - system_tests:
           <<: *main_branches_filter
-      - integration_tests:
-          requires:
-            - build_image
-          <<: *main_branches_filter
-      - integration_tests_helm:
-          requires:
-            - build_image
-          <<: *main_branches_filter
+      # - integration_tests:
+      #     requires:
+      #       - build_image
+      #     <<: *main_branches_filter
+      # - integration_tests_helm:
+      #     requires:
+      #       - build_image
+      #     <<: *main_branches_filter
 
   MERGE_TO_STAGING:
     jobs:
@@ -53,49 +53,49 @@ workflows:
           <<: *staging_branch_only_filter
       - system_tests:
           <<: *staging_branch_only_filter
-      - integration_tests:
-          requires:
-            - build_image
-          <<: *staging_branch_only_filter
-      - integration_tests_helm:
-          requires:
-            - build_image
-          <<: *staging_branch_only_filter
-      - integration_tests_proxy:
-          requires:
-            - build_image
-          <<: *staging_branch_only_filter
-      - eks_integration_tests:
-          requires:
-            - build_image
-          <<: *staging_branch_only_filter
-      - aks_integration_tests:
-          requires:
-            - build_image
-          <<: *staging_branch_only_filter
-      - integration_tests_operator_on_k8s:
-          requires:
-            - build_image
-            - build_and_upload_operator
-          <<: *staging_branch_only_filter
+      # - integration_tests:
+      #     requires:
+      #       - build_image
+      #     <<: *staging_branch_only_filter
+      # - integration_tests_helm:
+      #     requires:
+      #       - build_image
+      #     <<: *staging_branch_only_filter
+      # - integration_tests_proxy:
+      #     requires:
+      #       - build_image
+      #     <<: *staging_branch_only_filter
+      # - eks_integration_tests:
+      #     requires:
+      #       - build_image
+      #     <<: *staging_branch_only_filter
+      # - aks_integration_tests:
+      #     requires:
+      #       - build_image
+      #     <<: *staging_branch_only_filter
+      # - integration_tests_operator_on_k8s:
+      #     requires:
+      #       - build_image
+      #       - build_and_upload_operator
+      #     <<: *staging_branch_only_filter
       # - openshift4_integration_tests:
       #     requires:
       #       - build_image
       #       - build_and_upload_operator
       #     <<: *staging_branch_only_filter
       - tag_and_push:
-          context: nodejs-app-release-public
+          context: team-container-integration
           requires:
             - build_image
             - build_and_upload_operator
             - unit_tests
             - system_tests
-            - integration_tests
-            - integration_tests_helm
-            - integration_tests_proxy
+            # - integration_tests
+            # - integration_tests_helm
+            # - integration_tests_proxy
           <<: *staging_branch_only_filter
       - deploy_to_dev:
-          context: nodejs-app-release-public
+          context: team-container-integration
           requires:
             - tag_and_push
           <<: *staging_branch_only_filter
@@ -108,7 +108,7 @@ workflows:
   MERGE_TO_MASTER:
     jobs:
       - publish:
-          context: nodejs-app-release-public
+          context: team-container-integration
           <<: *master_branch_only_filter
       - deploy_to_prod:
           requires:

--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -308,6 +308,25 @@ helm upgrade --install snyk-monitor snyk-charts/snyk-monitor \
   --set volumes.projected.serviceAccountToken=true
 ```
 
+## Using AKS with Managed Identities
+
+For the particular case when you are using AKS with user-managed identities to authorize access to ACR and there are multiple identities that assign the `AcrPull` role to the VM scale set, you must also specify the Client ID of the desired user-managed identity to be used. This value must be set as an override, in `.Values.azureEnvVars`:
+```yaml
+azureEnvVars:
+  - name: AZURE_CLIENT_ID
+    value: "abcd1234-abcd-1234-abcd-1234abcd1234"
+```
+
+With the YAML above saved in `override.yaml`, run the following:
+
+```shell
+helm upgrade --install snyk-monitor snyk-charts/snyk-monitor \
+  --namespace snyk-monitor \
+  -f override.yaml
+```
+
+By default, this value is an empty string, and it will not be used as such.
+
 ## Configuring resources
 
 If more resources is required in order to deploy snyk-monitor, you can configure the helm charts default value for requests and limits with the `--set` flag.

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -204,6 +204,15 @@ spec:
           {{- with .Values.envs }}
           {{- toYaml . | trim | nindent 10 -}}
           {{- end }}
+          {{- with .Values.nodeEnvVars }}
+          {{- toYaml . | trim | nindent 10 -}}
+          {{- end }}
+          {{- range $v := .Values.azureEnvVars }}
+          {{- if $v.value }}
+          - name: {{ $v.name }}
+            value: {{ quote $v.value }}
+          {{- end }}
+          {{- end }}
           resources:
             {{- with .Values.requests }}
             requests:

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -69,14 +69,22 @@ rbac:
     annotations: {}
     labels: {}
 
-# Node.js in-container process memory enhancements
+# General-purpose environment variables
 envs:
+
+# Node.js in-container process memory enhancements
+nodeEnvVars:
   - name: V8_MAX_OLD_SPACE_SIZE
     value: "2048"
   - name: UV_THREADPOOL_SIZE
     value: "24"
   - name: NODE_OPTIONS
     value: --max_old_space_size=2048
+
+# Variables related to AKS
+azureEnvVars:
+  - name: AZURE_CLIENT_ID
+    value: ""
 
 extraCaCerts: /srv/app/certs/ca.pem
 


### PR DESCRIPTION
Add envvar AZURE_CLIENT_ID that allows specifying a managed identity to be used when pulling images for scanning.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Updated Helm chart to add AZURE_CLIENT_ID envvar to `snyk-monitor` container, when needed (not empty string). The envvar is needed to avoid conflicting managed identities that allow the `snyk-monitor` to pull images from the container registry, therefore explicitly saying which of the identities to be used (by specifying its Client ID). 

### Notes for the reviewer

Will update documentation about setting up `kubernetes-monitor` in Azure.

### Screenshots

N/A
