### PR TITLE
chore: set disableBetaArchNodeSelector to true

### DIFF
--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -109,7 +109,7 @@ log_level:
 nodeSelector: {}
 
 nodeAffinity:
-  disableBetaArchNodeSelector: false
+  disableBetaArchNodeSelector: true
   kubernetesIoArch:
   - amd64
   kubernetesIoOs:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Closes #1341.

Deprecated since v1.14: https://github.com/kubernetes/kubernetes/pull/108554/files#diff-2ae36f29c051a5b09a934647b62e2374b20d8048a6e2b80d03871e4f7c0d4b5aR29-R30
