### PR TITLE
Save packages after updating

### DIFF
--- a/.github/workflows/relock.yaml
+++ b/.github/workflows/relock.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Run npm update
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-          npm update
+          npm update --save
           rm -f .npmrc
 
       - name: Create Signed Commit


### PR DESCRIPTION
### What this does

Also updates `package.json` with the upgraded packages. See https://github.com/snyk/docker-deps/pull/1366 for an example.

This makes it very easy to read which direct dependencies changed when reviewing the PRs created by the `Update and relock NPM packages` job. 

### Notes for the reviewer

Only looking at the `package-lock.json` was hard because it's impossible to understand the diff for a normal human.

### Screenshots

#### Before

<img width="2513" alt="image" src="https://github.com/snyk/docker-deps/assets/11149800/095dfd5c-9613-4686-ae13-ef56f9261527">


#### After

<img width="2513" alt="image" src="https://github.com/snyk/docker-deps/assets/11149800/313c88f2-2d85-4cb6-bda5-73011d1c0787">

