### PR TITLE
[SUP-1884][SUP-1973] fix: avoid calling deprecated batch apis

### DIFF
--- a/src/supervisor/watchers/handlers/cron-job.ts
+++ b/src/supervisor/watchers/handlers/cron-job.ts
@@ -134,7 +134,7 @@ export async function cronJobWatchHandler(
   );
 }
 
-export async function isNamespacedCronJobSupported(
+async function isNamespacedCronJobSupportedWithClient(
   workloadKind: WorkloadKind,
   namespace: string,
   client: BatchV1Api | BatchV1beta1Api,
@@ -179,7 +179,29 @@ export async function isNamespacedCronJobSupported(
   }
 }
 
-export async function isClusterCronJobSupported(
+export async function isNamespacedCronJobSupported(
+  workloadKind: WorkloadKind,
+  namespace: string,
+): Promise<boolean> {
+  const isSupported = await isNamespacedCronJobSupportedWithClient(
+    workloadKind,
+    namespace,
+    k8sApi.batchClient,
+  );
+  if (workloadKind == WorkloadKind.CronJob) {
+    return isSupported;
+  }
+  if (workloadKind == WorkloadKind.CronJobV1Beta1 && isSupported) {
+    return false;
+  }
+  return await isNamespacedCronJobSupportedWithClient(
+    workloadKind,
+    namespace,
+    k8sApi.batchUnstableClient,
+  );
+}
+
+export async function isClusterCronJobSupportedWithClient(
   workloadKind: WorkloadKind,
   client: BatchV1Api | BatchV1beta1Api,
 ): Promise<boolean> {
@@ -220,4 +242,23 @@ export async function isClusterCronJobSupported(
     );
     return false;
   }
+}
+
+export async function isClusterCronJobSupported(
+  workloadKind: WorkloadKind,
+): Promise<boolean> {
+  const isSupported = await isClusterCronJobSupportedWithClient(
+    workloadKind,
+    k8sApi.batchClient,
+  );
+  if (workloadKind == WorkloadKind.CronJob) {
+    return isSupported;
+  }
+  if (workloadKind == WorkloadKind.CronJobV1Beta1 && isSupported) {
+    return false;
+  }
+  return await isClusterCronJobSupportedWithClient(
+    workloadKind,
+    k8sApi.batchUnstableClient,
+  );
 }

--- a/src/supervisor/watchers/handlers/index.ts
+++ b/src/supervisor/watchers/handlers/index.ts
@@ -5,7 +5,7 @@ import { WorkloadKind } from '../../types';
 import * as cronJob from './cron-job';
 import * as deploymentConfig from './deployment-config';
 import * as rollout from './argo-rollout';
-import { k8sApi, kubeConfig } from '../../cluster';
+import { kubeConfig } from '../../cluster';
 import * as kubernetesApiWrappers from '../../kuberenetes-api-wrappers';
 import { FALSY_WORKLOAD_NAME_MARKER, KubernetesInformerVerb } from './types';
 import { workloadWatchMetadata } from './informer-config';
@@ -27,13 +27,11 @@ async function isSupportedNamespacedWorkload(
       return await cronJob.isNamespacedCronJobSupported(
         workloadKind,
         namespace,
-        k8sApi.batchUnstableClient,
       );
     case WorkloadKind.CronJob:
       return await cronJob.isNamespacedCronJobSupported(
         workloadKind,
         namespace,
-        k8sApi.batchClient,
       );
     default:
       return true;
@@ -49,15 +47,9 @@ async function isSupportedClusterWorkload(
     case WorkloadKind.ArgoRollout:
       return await rollout.isClusterArgoRolloutSupported();
     case WorkloadKind.CronJobV1Beta1:
-      return await cronJob.isClusterCronJobSupported(
-        workloadKind,
-        k8sApi.batchUnstableClient,
-      );
+      return await cronJob.isClusterCronJobSupported(workloadKind);
     case WorkloadKind.CronJob:
-      return await cronJob.isClusterCronJobSupported(
-        workloadKind,
-        k8sApi.batchClient,
-      );
+      return await cronJob.isClusterCronJobSupported(workloadKind);
     default:
       return true;
   }


### PR DESCRIPTION
- (to be manually tested) Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This PR implements an adjustment to the checks for supported Kubernetes Batch API versions. If request is made to determine whether the deprecated `batch/v1beta1` API is supported, support for `batch/v1` will be first be checked, and if found, the response will indicated `batch/v1beta1` is not supported. This avoids making any calls to `batch/v1beta1` API endpoints if `batch/v1` is supported.

### Notes for the reviewer

This needs to be manually tested before it can be merged! As a team, @snyk/container-integration made the decision that it's not worth implementing a suite of automated tests to check this behaviour - because K8s v3 will be out soon, and the time is better spent there.