### PR TITLE
Add image pull secrets, so that private registries can be used ex art…

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.securityContext.fsGroup }}
       securityContext:
         fsGroup: {{ int . }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -28,6 +28,9 @@ scope: Cluster
 # The endpoint that being used to transmit monitored information
 integrationApi: ""
 
+# Secrets to use when pulling images from private registries ex artifactory
+imagePullSecrets: []
+
 # The registry from which to pull the snyk-monitor image.
 image:
   repository: snyk/kubernetes-monitor


### PR DESCRIPTION
…ifactory

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This PR updates the snyke-monitor Helm chart to include imagePullSecrets configuration. This enhancement allows for the use of private image registries or pull-through registries, ensuring a more secure and flexible image pulling process.

### Notes for the reviewer

Context: The addition of imagePullSecrets to the snyke-monitor Helm chart is intended to facilitate deployments that use private or pull-through registries, addressing a common need in various deployment scenarios.

Location of Changes: Primary modifications can be found in the values.yaml file and the corresponding deployment templates where the imagePullSecrets configuration is added.

Testing Considerations: It would be beneficial to test the Helm chart in an environment that requires access to a private registry. The goal is to ensure successful image pulls when the correct imagePullSecrets is provided.

Backward Compatibility: The additions have been designed to be optional. In scenarios where no imagePullSecrets are specified, the behavior remains consistent with previous versions, thus maintaining backward compatibility.

### Screenshots

_Visuals that may help the reviewer_
