### PR TITLE
fix: remove the stack, message and childProcess from the skopeo error…

### DIFF
--- a/src/scanner/images/index.ts
+++ b/src/scanner/images/index.ts
@@ -50,12 +50,22 @@ export async function pullImages(
       pulledImages.push(pulledImage);
     } catch (error) {
       logger.error(
-        { error, image: image.imageWithDigest ?? image.imageName },
+        {
+          error: sanitizeSkopeoErrorForLogging(error),
+          image: image.imageWithDigest ?? image.imageName,
+        },
         'failed to pull image docker/oci archive image',
       );
     }
   }
   return pulledImages;
+}
+
+function sanitizeSkopeoErrorForLogging(error) {
+  delete error.stack;
+  delete error.message;
+  delete error.childProcess;
+  return error;
 }
 
 export function getImagesWithFileSystemPath(


### PR DESCRIPTION
### What this does

Remove the `stack`, `message` and `childProcess` from the skopeo error logs.
All the skopeo args were being logged in the `stack` and `message`, which can include `-src-creds`.

The `stack` and the `message` are assembled inside the `bunyan` logger lib. When the stack and the message are deleted, the `childProcess` is then logged so this has also been removed from the error.

The loggable args are already logged here: https://github.com/snyk/kubernetes-monitor/blob/26ac1bbfdcb08c05d28243708b20b61acc3ec1c9/src/common/process.ts#L40 so the `stack` and the `message` were not adding any value. 

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
