### PR TITLE
fix: Add support for Argo Rollouts that use workloadRef definitions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,12 +77,7 @@ async function setupSysdigIntegration(): Promise<void> {
     ) &&
     !(config.SYSDIG_ENDPOINT && config.SYSDIG_TOKEN)
   ) {
-    console.log(
-      config.SYSDIG_REGION_URL,
-      config.SYSDIG_RISK_SPOTLIGHT_TOKEN,
-      config.SYSDIG_CLUSTER_NAME,
-    );
-    console.log('Sysdig integration not enabled');
+    logger.info({}, 'Sysdig integration not enabled');
     return;
   }
 

--- a/src/supervisor/watchers/handlers/argo-rollout.ts
+++ b/src/supervisor/watchers/handlers/argo-rollout.ts
@@ -101,13 +101,46 @@ export async function paginatedClusterArgoRolloutList(): Promise<{
 export async function argoRolloutWatchHandler(
   rollout: V1alpha1Rollout,
 ): Promise<void> {
+  if (rollout.spec?.workloadRef && rollout.metadata?.namespace) {
+    // Attempt to load workloadRef if a template is not directly defined
+    const workloadName = rollout.spec.workloadRef.name;
+    const namespace = rollout.metadata.namespace;
+    switch (rollout.spec.workloadRef.kind) {
+      // Perform lookup for known supported kinds: https://github.com/argoproj/argo-rollouts/blob/master/rollout/templateref.go#L40-L52
+      case 'Deployment': {
+        const deployResult = await retryKubernetesApiRequest(() =>
+          k8sApi.appsClient.readNamespacedDeployment(workloadName, namespace),
+        );
+        rollout.spec.template = deployResult.body.spec?.template;
+        break;
+      }
+      case 'ReplicaSet': {
+        const replicaSetResult = await retryKubernetesApiRequest(() =>
+          k8sApi.appsClient.readNamespacedReplicaSet(workloadName, namespace),
+        );
+        rollout.spec.template = replicaSetResult.body.spec?.template;
+        break;
+      }
+      case 'PodTemplate': {
+        const podTemplateResult = await retryKubernetesApiRequest(() =>
+          k8sApi.coreClient.readNamespacedPodTemplate(workloadName, namespace),
+        );
+        rollout.spec.template = podTemplateResult.body.template;
+        break;
+      }
+      default:
+        logger.debug(
+          { workloadKind: WorkloadKind.ArgoRollout },
+          'Unsupported workloadRef kind specified',
+        );
+    }
+  }
   rollout = trimWorkload(rollout);
 
   if (
     !rollout.metadata ||
-    !rollout.spec ||
-    !rollout.spec.template.metadata ||
-    !rollout.spec.template.spec ||
+    !rollout.spec?.template?.metadata ||
+    !rollout.spec?.template?.spec ||
     !rollout.status
   ) {
     return;

--- a/src/supervisor/watchers/handlers/types.ts
+++ b/src/supervisor/watchers/handlers/types.ts
@@ -85,11 +85,18 @@ export interface V1alpha1Rollout extends KubernetesObject {
 }
 
 export interface V1alpha1RolloutSpec {
-  template: V1PodTemplateSpec;
+  template?: V1PodTemplateSpec;
+  workloadRef?: V1alpha1RolloutWorkloadRef;
 }
 
 export interface V1alpha1RolloutStatus {
   observedGeneration?: number;
+}
+
+export interface V1alpha1RolloutWorkloadRef {
+  apiVersion: string;
+  kind: string;
+  name: string;
 }
 
 export type V1ClusterList<T> = (

--- a/src/supervisor/workload-reader.ts
+++ b/src/supervisor/workload-reader.ts
@@ -338,11 +338,21 @@ const argoRolloutReader: IWorkloadReaderFunc = async (
   );
   const rollout: V1alpha1Rollout = trimWorkload(rolloutResult.body);
 
+  if (rollout.spec?.workloadRef && rollout.metadata?.namespace) {
+    // Lookup child template metadata when a workloadRef is defined
+    const workloadReader = getWorkloadReader(rollout.spec.workloadRef.kind);
+    const workloadMetadata = await workloadReader(
+      rollout.spec.workloadRef.name,
+      rollout.metadata.namespace,
+    );
+    rollout.spec.template = {
+      metadata: workloadMetadata?.specMeta,
+    };
+  }
+
   if (
     !rollout.metadata ||
-    !rollout.spec ||
-    !rollout.spec.template.metadata ||
-    !rollout.spec.template.spec ||
+    !rollout.spec?.template?.metadata ||
     !rollout.status
   ) {
     logIncompleteWorkload(workloadName, namespace);

--- a/test/fixtures/argo-rollout.yaml
+++ b/test/fixtures/argo-rollout.yaml
@@ -31,3 +31,53 @@ spec:
             requests:
               memory: 32Mi
               cpu: 5m
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: argo-rollout-workload-ref
+  namespace: services
+spec:
+  replicas: 1
+  strategy:
+    canary:
+      steps:
+        - setWeight: 100
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: rollouts-workload-demo
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: argo-rollout-workload-deployment
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argo-rollout-workload-deployment
+  namespace: services
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: rollouts-workload-demo
+  template:
+    metadata:
+      labels:
+        app: rollouts-workload-demo
+    spec:
+      imagePullSecrets:
+        - name: docker-io
+      containers:
+        - name: rollouts-workload-demo
+          image: argoproj/rollouts-demo:blue
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              memory: 32Mi
+              cpu: 5m

--- a/test/integration/kubernetes.spec.ts
+++ b/test/integration/kubernetes.spec.ts
@@ -299,6 +299,22 @@ test('snyk-monitor sends data to kubernetes-upstream', async () => {
       },
       expect.any(Object),
     ]);
+
+    const scanResultsArgoRolloutWorkloadRef = await getUpstreamResponseBody(
+      `api/v1/scan-results/${integrationId}/${clusterName}/services/Rollout/argo-rollout-workload-ref`,
+    );
+    expect(
+      scanResultsArgoRolloutWorkloadRef.workloadScanResults[
+        'argoproj/rollouts-demo'
+      ],
+    ).toEqual<ScanResult[]>([
+      {
+        identity: { type: 'linux', args: { platform: 'linux/amd64' } },
+        facts: expect.any(Array),
+        target: { image: 'docker-image|argoproj/rollouts-demo' },
+      },
+      expect.any(Object),
+    ]);
   }
 });
 

--- a/test/unit/supervisor/workload-reader.spec.ts
+++ b/test/unit/supervisor/workload-reader.spec.ts
@@ -15,6 +15,7 @@ describe('workload reader tests', () => {
     expect(
       SupportedWorkloadTypes.indexOf('ReplicationController') > -1,
     ).toEqual(true);
+    expect(SupportedWorkloadTypes.indexOf('Rollout') > -1).toEqual(true);
   });
 
   test.concurrent('getSupportedWorkload()', async () => {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Argo Rollouts support defining pod templates directly within a rollout or by referencing a separate Deployment, ReplicaSet, or PodTemplate resource. Currently, if the template is not directly defined, a TypeError is raised:

```
{
  "name": "kubernetes-monitor",
  "hostname": "snyk-monitor-84f889474c-6vlkv",
  "pid": 31,
  "level": 50,
  "error": {
    "message": "Cannot read properties of undefined (reading 'metadata')",
    "name": "TypeError",
    "stack": "TypeError: Cannot read properties of undefined (reading 'metadata')\n    at argoRolloutReader (/srv/app/src/supervisor/workload-reader.ts:355:28)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at findParentWorkload (/srv/app/src/supervisor/metadata-extractor.ts:100:32)\n    at buildMetadataForWorkload (/srv/app/src/supervisor/metadata-extractor.ts:211:53)\n    at Object.podWatchHandler (/srv/app/src/supervisor/watchers/handlers/pod.ts:133:30)\n    at /srv/app/src/supervisor/watchers/handlers/index.ts:174:11"
  },
  "podName": "example-pod-6688748c8-2zvb4",
  "msg": "could not build image metadata for pod",
  "time": "2023-12-22T21:48:07.440Z",
  "v": 0
}
```

### Notes for the reviewer

Documentation: [Argo Rollout specification](https://argo-rollouts.readthedocs.io/en/stable/features/specification/) that indicates template or workloadRef should be defined (not both)

Closes #1433 