### PR TITLE
chore: bump snyk-docker-plugin version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "packageurl-js": "^1.2.1",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.1.0",
-        "snyk-docker-plugin": "^6.10.0",
+        "snyk-docker-plugin": "^6.10.2",
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "4.7.4",
@@ -10208,9 +10208,9 @@
       }
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.10.0.tgz",
-      "integrity": "sha512-mbNm7atwu70rWwoOiLYA44E7xoxA9C7haqekUPx8vFUxHMhg63z+xnXFoWxuwyYIjAUc3jVoMMyF1kpH2pkOsQ==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.10.2.tgz",
+      "integrity": "sha512-PiDtLp8VhIunwwe3lwoxPLQ940LhE8ZysDZJ1Xuy4Gbgv2gdXmH3O/iAQgCTsZFK80PNVzpAEt2oyz+LG7lqfA==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "packageurl-js": "^1.2.1",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.1.0",
-    "snyk-docker-plugin": "^6.10.0",
+    "snyk-docker-plugin": "^6.10.2",
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "4.7.4",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Bump snyk-docker-plugin  version to 6.10.2 to contain the fix of supporting large files to fix an issue for customers.
For more details :https://github.com/snyk/snyk-docker-plugin/pull/569