### PR TITLE
fix: don't remove anthoscli anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN adduser -S -G snyk -h /srv/app -u 10001 snyk
 
 # Install gcloud
 RUN curl -sL https://sdk.cloud.google.com > /install.sh
-RUN bash /install.sh --disable-prompts --install-dir=/ && rm /google-cloud-sdk/bin/anthoscli && rm -rf /google-cloud-sdk/platform
+RUN bash /install.sh --disable-prompts --install-dir=/ && rm -rf /google-cloud-sdk/platform
 ENV PATH=/google-cloud-sdk/bin:$PATH
 RUN rm /install.sh
 RUN apk del curl bash


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

`anthoscli` is not there anymore and build was failing when trying to remove it. According to a previous commit, it was removed from the image because we weren't using it and it used ~120MB. Now it's not present anymore by default. I built the new image locally and there's no `anthoscli` (searched with `find` utility).