### PR TITLE
feat: fix max CPU usage and memory leak

### DIFF
--- a/src/supervisor/watchers/handlers/namespace.ts
+++ b/src/supervisor/watchers/handlers/namespace.ts
@@ -85,13 +85,13 @@ export async function trackNamespace(namespace: string): Promise<void> {
   const loggedListMethod = async () => {
     try {
       return await retryKubernetesApiRequest(async () => {
+        logger.info({}, 'retrying k8s api request');
         const reply = await k8sApi.coreClient.readNamespace(namespace);
         const list = new V1NamespaceList();
         list.apiVersion = 'v1';
         list.kind = 'NamespaceList';
         list.items = new Array<V1Namespace>(reply.body);
         list.metadata = new V1ListMeta();
-        list.metadata.resourceVersion = reply.body.metadata?.resourceVersion;
         return {
           response: reply.response,
           body: list,


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Duplicate of #1506 
closes #1506

What this does
Fixes https://snyk.zendesk.com/agent/tickets/80279

The crux of the issue is this:
```bash
➜  kubernetes-monitor git:(master) ✗ kubectl get --raw "/api/v1/watch/namespaces/services" | jq .
{
  // Irrelevant fields omitted, note the resourceVersion

  "type": "ADDED",
  "object": {
    "kind": "Namespace",
    "apiVersion": "v1",
    "metadata": {
      "resourceVersion": "616",
    },
}
```

```bash
➜  kubernetes-monitor git:(master) ✗ kubectl get --raw "/api/v1/watch/namespaces/services?resourceVersion=616" | jq .
{
  "type": "ERROR",
  "object": {
    "kind": "Status",
    "apiVersion": "v1",
    "metadata": {},
    "status": "Failure",
    "message": "The resourceVersion for the provided watch is too old.",
    "reason": "Expired",
    "code": 410
  }
}
```
version 616, is valid, it’s still 616 after making the second call, it’s not become stale and a new one replaced it.

For some reason, calls to watch-namespaces always fails when the resourceVersion is specified.

This behaviour causes the kubernetes/client-node informer class to go into an infinite loop trying to watch at a specific version. The fix is to omit the resourceVersion parameter (which was added to fix a different issue, it wasn’t added because we need to restrict to only the later versions, here https://github.com/snyk/kubernetes-monitor/commit/250f9e45477c17161fd333a174d9001712ad7bd9).

