### PR TITLE
OI-471: Change repo ownership from orchestration-integrations to test-enrichment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,7 +461,7 @@ workflows:
             - security-scans:
                 name: Security Scans
                 context:
-                    - analysis_integrations
+                    - analysis_test-enrichment
                 filters:
                     branches:
                         only:
@@ -469,7 +469,7 @@ workflows:
             - publish:
                 context:
                     - team-container-integration
-                    - analysis_integrations
+                    - analysis_test-enrichment
                 requires:
                     - Security Scans
                 filters:
@@ -486,13 +486,13 @@ workflows:
     MERGE_TO_STAGING:
         jobs:
             - build_image:
-                context: analysis_integrations
+                context: analysis_test-enrichment
                 filters:
                     branches:
                         only:
                             - staging
             - unit_tests:
-                context: analysis_integrations
+                context: analysis_test-enrichment
                 filters:
                     branches:
                         only:
@@ -527,7 +527,7 @@ workflows:
                 trusted-branch: main
                 context:
                     - snyk-bot-slack
-                channel: team-integrations-alerts
+                channel: snyk-on-snyk-analysis_test-enrichment
                 filters:
                     branches:
                         ignore:
@@ -536,14 +536,14 @@ workflows:
             - security-scans:
                 name: Security Scans
                 context:
-                    - analysis_integrations
+                    - analysis_test-enrichment
                 filters:
                     branches:
                         ignore:
                             - staging
                             - master
             - build_image:
-                context: analysis_integrations
+                context: analysis_test-enrichment
                 requires:
                     - Scan repository for secrets
                     - Security Scans
@@ -553,7 +553,7 @@ workflows:
                             - staging
                             - master
             - unit_tests:
-                context: analysis_integrations
+                context: analysis_test-enrichment
                 filters:
                     branches:
                         ignore:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/orchestration-integrations
+* @snyk/test-enrichment

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,8 +4,8 @@ metadata:
   name: kubernetes-monitor
   annotations:
     github.com/project-slug: snyk/kubernetes-monitor
-    github.com/team-slug: snyk/orchestration-integrations
+    github.com/team-slug: snyk/test-enrichment
 spec:
   type: external-tooling
   lifecycle: "-"
-  owner: orchestration-integrations
+  owner: test-enrichment


### PR DESCRIPTION
OI-471: Change repo ownership from orchestration-integrations to test-enrichment in `.github/CODEOWNERS`, `.circleci/config.yml` (snyk circleci context, secrets alerts channel) and `catalog-info.yaml` (github.com/team-slug, owner)

-- 
Generated by [Octopilot](https://github.com/dailymotion-oss/octopilot) [v1.12.15](https://github.com/dailymotion-oss/octopilot/releases/tag/v1.12.15) from https://github.com/snyk/prodsec-tools-v2