### PR TITLE
fix: correct pod security context block indentation

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -14,4 +14,10 @@ ignore:
           Waiting for a patch: https://security.snyk.io/vuln/SNYK-JS-MICROMATCH-6838728
         expires: 2024-12-19T12:00:00.000Z
         created: 2024-05-16T12:00:00.000Z
+    SNYK-JS-JSONPATHPLUS-7945884:
+    - '*':
+        reason: >-
+          Waiting for transient dependency to update
+        expires: 2024-12-19T12:00:00.000Z
+        created: 2024-10-23T12:00:00.000Z
 patch: {}

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -33,19 +33,19 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-    {{- with .Values.podSecurityContext }}
-    securityContext:
-    {{- $fsGroupOverride := dict }}
-    {{- if hasKey $.Values.securityContext "fsGroup" }}
-    {{- $fsGroupOverride = dict "fsGroup" (int $.Values.securityContext.fsGroup) }}
-    {{- end }}
-    {{- merge $fsGroupOverride . | toYaml | nindent 8 }}
-    {{- else }}
-    {{- if .Values.securityContext.fsGroup }}
-    securityContext:
-      fsGroup: {{ int .Values.securityContext.fsGroup }}
-    {{- end }}
-    {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+      {{- $fsGroupOverride := dict }}
+      {{- if hasKey $.Values.securityContext "fsGroup" }}
+      {{- $fsGroupOverride = dict "fsGroup" (int $.Values.securityContext.fsGroup) }}
+      {{- end }}
+      {{- merge $fsGroupOverride . | toYaml | nindent 8 }}
+      {{- else }}
+      {{- if .Values.securityContext.fsGroup }}
+      securityContext:
+        fsGroup: {{ int .Values.securityContext.fsGroup }}
+      {{- end }}
+      {{- end }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/test/integration/kubernetes.spec.ts
+++ b/test/integration/kubernetes.spec.ts
@@ -776,6 +776,15 @@ test('snyk-monitor secure configuration is as expected', async () => {
     namespace,
   );
   const deployment = response.body;
+  expect(deployment.spec?.template.spec).toEqual(
+    expect.objectContaining({
+      securityContext: {
+        fsGroup: 65534,
+        fsGroupChangePolicy: 'Always',
+      },
+    }),
+  );
+
   expect(deployment.spec?.template?.spec?.containers?.[0]).toEqual(
     expect.objectContaining({
       securityContext: {

--- a/test/setup/deployers/helm.ts
+++ b/test/setup/deployers/helm.ts
@@ -39,6 +39,7 @@ async function deployKubernetesMonitor(
       '--set rbac.serviceAccount.annotations."foo"="bar" ' +
       '--set volumes.projected.serviceAccountToken=true ' +
       '--set securityContext.fsGroup=65534 ' +
+      '--set podSecurityContext.fsGroupChangePolicy="Always" ' +
       '--set skopeo.compression.level=1 ' +
       '--set workers.count=5 ' +
       '--set sysdig.enabled=true ',


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- (n/a) Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This PR fixes the Snyk Monitor pod `securityContext` block indentation in the Helm chart.

### Notes for the reviewer

Tests have been updated to cover the use of the `podSecurityContext` and `securityContext` attributes in `values.yaml`.