### PR TITLE
fix: bump snyk-docker-plugin

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -32,4 +32,10 @@ ignore:
           No upstream fix available
         expires: 2024-12-08T12:00:00.000Z
         created: 2024-11-08T12:00:00.000Z
+    SNYK-JS-JSONPATHPLUS-7945884:
+    - '*':
+        reason: >-
+          Waiting for @kubernetes/client-node upgrade
+        expires: 2024-12-08T12:00:00.000Z
+        created: 2024-11-20T12:00:00.000Z
 patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "packageurl-js": "^1.2.1",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.3.0",
-        "snyk-docker-plugin": "6.13.0",
+        "snyk-docker-plugin": "6.13.0-hotfix",
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "4.9.5",
@@ -8868,9 +8868,9 @@
       }
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.13.0.tgz",
-      "integrity": "sha512-xgW1sXs/Y5q9Wg011t0LkA3YqrWkt5J2BEINLRssXkDQhm2ijOvu1YS7hJMt/WTLm0kvk12VmnBn11cWIIzeZg==",
+      "version": "6.13.0-hotfix",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.13.0-hotfix.tgz",
+      "integrity": "sha512-gjcvpgkvD830QpU0p3S3yhfOdI7+oAVyBoHMhrIRX+wMEII45/Gi9081YWSctdxDUR2wl6orDyGKLPS4Sk/f+w==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "packageurl-js": "^1.2.1",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.3.0",
-    "snyk-docker-plugin": "6.13.0",
+    "snyk-docker-plugin": "6.13.0-hotfix",
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "4.9.5",


### PR DESCRIPTION
fix: redhat-content-manifests content sets parsing UNIFY-387
fix: optional python dependencies that are being over connected

Note: The snyk-docker-plugin is being installed from a GitHub tag as there are changes on latest which can not be released until December.


- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Fixes RedHat images scan when the “content_sets” attribute is missing in the redhat-content-manifests file.
Optimizes Python pip dependency graphs by removing unnecessary [optional dependencies].

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### Screenshots

_Visuals that may help the reviewer_
