### PR TITLE
[OI-670] fix: use appropriate builder images for docker credential helpers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 #---------------------------------------------------------------------
 # STAGE 1: Build credential helpers inside a temporary container
 #---------------------------------------------------------------------
-FROM --platform=linux/amd64 golang:1.23 AS cred-helpers-build
+FROM --platform=linux/amd64 golang:1.23-alpine AS cred-helpers-build
 
+RUN apk add git
 RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@bef5bd9384b752e5c645659165746d5af23a098a
 RUN --mount=type=secret,id=gh_token,required=true \
     git config --global url."https://$(cat /run/secrets/gh_token):x-oauth-basic@github.com/snyk".insteadOf "https://github.com/snyk" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN apk update
 RUN apk upgrade
 RUN apk --no-cache add dumb-init skopeo curl bash python3
 
+RUN npm install -g npm@v10.9.2
+
 RUN addgroup -S -g 10001 snyk
 RUN adduser -S -G snyk -h /srv/app -u 10001 snyk
 

--- a/Dockerfile.ubi9
+++ b/Dockerfile.ubi9
@@ -1,13 +1,13 @@
 #---------------------------------------------------------------------
 # STAGE 1: Build credential helpers inside a temporary container
 #---------------------------------------------------------------------
-FROM --platform=linux/amd64 golang:1.23 as cred-helpers-build
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset:9.5 as cred-helpers-build
 
-RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@bef5bd9384b752e5c645659165746d5af23a098a
-RUN --mount=type=secret,id=gh_token,required=true \
+RUN GOTOOLCHAIN=go1.23.4 go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@bef5bd9384b752e5c645659165746d5af23a098a
+RUN --mount=type=secret,id=gh_token,uid=1001,required=true \
     git config --global url."https://$(cat /run/secrets/gh_token):x-oauth-basic@github.com/snyk".insteadOf "https://github.com/snyk" && \
     go env -w GOPRIVATE=github.com/snyk && \
-    go install github.com/snyk/docker-credential-acr-env@8fa416c5b20b174e9032df1899843b4ebe2adda8 && \
+    GOTOOLCHAIN=go1.23.4 go install github.com/snyk/docker-credential-acr-env@8fa416c5b20b174e9032df1899843b4ebe2adda8 && \
     git config --global --unset url."https://$(cat /run/secrets/gh_token):x-oauth-basic@github.com/snyk".insteadOf
 
 #---------------------------------------------------------------------
@@ -80,8 +80,8 @@ COPY --chown=snyk:snyk --from=containers-common /etc/containers/registries.d/def
 COPY --chown=snyk:snyk --from=containers-common /etc/containers/policy.json /etc/containers/policy.json
 
 # Install credential helpers
-COPY --chown=snyk:snyk --from=cred-helpers-build /go/bin/docker-credential-ecr-login /usr/bin/docker-credential-ecr-login
-COPY --chown=snyk:snyk --from=cred-helpers-build /go/bin/docker-credential-acr-env /usr/local/bin/docker-credential-acr-env
+COPY --chown=snyk:snyk --from=cred-helpers-build /opt/app-root/src/go/bin/docker-credential-ecr-login /usr/bin/docker-credential-ecr-login
+COPY --chown=snyk:snyk --from=cred-helpers-build /opt/app-root/src/go/bin/docker-credential-acr-env /usr/bin/docker-credential-acr-env
 
 # Install gcloud
 RUN curl -sSfL https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir=/ && \


### PR DESCRIPTION
- (n/a) Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- (n/a) Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This change ensures that the docker credential helper binaries listed below can be executed on the Alpine and UBI9 production images.
- `docker-credential-ecr-login`
- `docker-credential-acr-env`

Prior to this change, the binaries were built using the `golang:1.23` image. This would normally be okay, because Go by default produces statically linked binaries. _However_, the helpers both make use of the dependency `github.com/docker/docker-credential-helpers`, which forces CGO because of it's usage of system libraries to interact with local keychains. As a result, the binaries were dynamically linked, but without cross compilation, which meant they were linked appropriately for the `golang:1.23` image, but _not_ the final production images.

In Alpine, this manifested in the rather unhelpful `not found` error message when attempting to execute the binary. This is actually an error from the musl linker, stating that it did not find a dynamically linked library, but can be easily misinterpreted as stating that the binary was not found.