### PR TITLE
fix: bump jsonpath-plus to 10.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7138,9 +7138,9 @@
       ]
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
-      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
       "dependencies": {
         "@jsep-plugin/assignment": "^1.3.0",
         "@jsep-plugin/regex": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
       "ws": "8.17.1",
       "tough-cookie": "4.1.3"
     },
-    "cross-spawn": "^7.0.5"
+    "cross-spawn": "^7.0.5",
+    "jsonpath-plus": "10.3.0"
   }
 }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Bumps `jsonpath-plus` to fix a vulnerability found in version 10.2.0.