### PR TITLE
chore: pr lint add

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,6 +1,6 @@
 {
   "rules": {
-    "header-max-length": [2, "always", 72],
+    "header-max-length": [2, "always", 100],
     "body-leading-blank": [2, "always"],
     "type-empty": [2, "never"],
     "type-enum": [

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,30 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  pr-title-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure the action to use conventional commit types
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            chore
+            ci
+            build
+            revert
+          # Don't require scopes
+          requireScope: false


### PR DESCRIPTION
I've done the following:
- Bump the commit message length in the linter from 72 to 100
- Added a Github Action that will validate the PR title to ensure that it starts with a tag. This will make the merge message follow conventional commits, and it won't break the build when we merge in now