### PR TITLE
fix: upgrades base image to node:22-alpine3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=secret,id=gh_token,required=true \
 #---------------------------------------------------------------------
 # STAGE 2: Build kubernetes-monitor application
 #---------------------------------------------------------------------
-FROM --platform=linux/amd64 node:22-alpine3.20
+FROM --platform=linux/amd64 node:22-alpine3.22
 
 LABEL name="Snyk Controller" \
     maintainer="support@snyk.io" \


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Upgrades base image to fix vulns in Alpine build

- node:22-alpine3.20 -> node:22-alpine3.22

### Notes for Reviewer

Vulns reported in `ubi9/ubi:9.6` look fixed in the latest version, so a rebuild should resolve these as `9.6` is a rolling tag and will pull the latest image, currently showing as vuln free...
https://catalog.redhat.com/software/containers/ubi9/ubi/615bcf606feffc5384e8452e?container-tabs=security

### Screenshots

<img width="1160" height="537" alt="Screenshot 2025-08-21 at 10 37 15" src="https://github.com/user-attachments/assets/8f848cb0-0c13-43a4-8f12-a71cdcada750" />

