### PR TITLE
fix: update ignores

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -13,7 +13,7 @@ ignore:
           Container scan: skopeo binary embeds google.golang.org/grpc until
           distro package provides fix (>= 1.79.3). Not network-exposed as a
           gRPC server in this image. Re-check when skopeo/apk updates.
-        expires: 2026-04-14T12:00:00.000Z
+        expires: 2026-07-21T12:00:00.000Z
         created: 2026-03-24T12:00:00.000Z
   SNYK-GOLANG-GITHUBCOMGOJOSEGOJOSEV4-15875221:
     - '*':


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Update the ignore for k8s to publish 2.22.16

https://app.circleci.com/pipelines/gh/snyk/kubernetes-monitor/7032/workflows/22e758ae-cbd9-4b46-92c4-648ca0266b54/jobs/38634 
