### PR TITLE
fix: vuln fixes — on-call sweep [CN-1323]

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -138,4 +138,19 @@ ignore:
           npm/apk update. Re-verify on image refresh.
         expires: 2026-04-23T12:00:00.000Z
         created: 2026-03-24T12:00:00.000Z
+  SNYK-JS-INFLIGHT-6095116:
+    - '*':
+        reason: "No non-major fix available as of 2026-05-19; revisit in 7 days"
+        expires: '2026-05-26T00:00:00.000Z'
+        created: '2026-05-19T00:00:00.000Z'
+  SNYK-JS-REQUEST-3361831:
+    - '*':
+        reason: "No fix available as of 2026-05-19; request package is deprecated and unmaintained; revisit in 7 days"
+        expires: '2026-05-26T00:00:00.000Z'
+        created: '2026-05-19T00:00:00.000Z'
+  SNYK-JS-UUID-16133035:
+    - '*':
+        reason: "No non-major fix available as of 2026-05-19; fixedIn versions 11.1.1 and 14.0.0 are major bumps from v3; revisit in 7 days"
+        expires: '2026-05-26T00:00:00.000Z'
+        created: '2026-05-19T00:00:00.000Z'
 patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4410,9 +4410,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5991,9 +5991,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -6004,12 +6004,13 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -6018,7 +6019,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -9592,9 +9594,9 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -11323,9 +11325,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11340,6 +11343,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -96,18 +96,23 @@
   "snyk": true,
   "overrides": {
     "@kubernetes/client-node": {
-      "ws": "8.17.1",
+      "ws": "^8.20.1",
       "tough-cookie": "4.1.3",
       "form-data": "2.5.5",
-      "qs": "^6.14.2",
-      "ajv": "8.18.0"
+      "qs": "^6.15.2",
+      "ajv": "8.18.0",
+      "fast-uri": "^3.1.2"
     },
     "cross-spawn": "^7.0.5",
     "jsonpath-plus": "10.3.0",
-    "qs": "^6.14.2",
+    "qs": "^6.15.2",
     "fast-xml-parser": "^5.3.6",
+    "fast-xml-builder": "^1.1.7",
     "minimatch": "^10.2.3",
+    "brace-expansion": "^5.0.6",
     "tar": "^7.5.11",
-    "path-to-regexp@^8": "^8.4.0"
+    "path-to-regexp@^8": "^8.4.0",
+    "fast-uri": "^3.1.2",
+    "ws": "^8.20.1"
   }
 }


### PR DESCRIPTION
## Security vulnerability fixes

Tracks: [CN-1323](https://snyksec.atlassian.net/browse/CN-1323)

### Vulnerabilities fixed

| Vuln ID | Package | Severity | Fix |
|---------|---------|----------|-----|
| SNYK-JS-BRACEEXPANSION-16755174 | brace-expansion@5.0.5 | high | new override → ^5.0.6 |
| SNYK-JS-FASTURI-16642394 | fast-uri@3.0.6 | high | new override → ^3.1.2 |
| SNYK-JS-FASTURI-16642399 | fast-uri@3.0.6 | high | new override → ^3.1.2 |
| SNYK-JS-FASTXMLBUILDER-16540557 | fast-xml-builder@1.1.5 | medium | new override → ^1.1.7 |
| SNYK-JS-FASTXMLBUILDER-16540558 | fast-xml-builder@1.1.5 | medium | new override → ^1.1.7 |
| SNYK-JS-QS-16721866 | qs@6.15.0 | medium | override bumped → ^6.15.2 |
| SNYK-JS-WS-16722635 | ws@8.17.1 | medium | override bumped → ^8.20.1 |

### Snoozed (7-day ignore, expires 2026-05-26)

| Vuln ID | Package | Reason |
|---------|---------|--------|
| SNYK-JS-INFLIGHT-6095116 | inflight@1.0.6 | No fix available |
| SNYK-JS-REQUEST-3361831 | request@2.88.2 | Package is deprecated/unmaintained, no fix available |
| SNYK-JS-UUID-16133035 | uuid@3.4.0 | Fix requires major upgrade to v11 or v14 |

### Base image updates

No updates needed — Dockerfiles in this repo use public images (`node:22-alpine`, `ubi9`, `debian:buster-slim`), not snyk-base-images.

### Verification

`snyk test --severity-threshold=medium` reports **0 vulnerabilities** after these changes.

[CN-1323]: https://snyksec.atlassian.net/browse/CN-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ