### PR TITLE
chore: release v2.23.5 to production

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -69,4 +69,46 @@ ignore:
           https://access.redhat.com/security/cve/CVE-2026-24842
         expires: 2026-11-14T12:00:00.000Z
         created: 2026-01-29T16:33:39.950Z
+  SNYK-RHEL9-GDBGDBSERVER-16125157:
+    - '*':
+        reason: >-
+          Heap-based buffer overflow in gdb-gdbserver 16.3-3.el9, introduced by
+          base image registry.access.redhat.com/ubi9/ubi:9.7. No RHEL 9 fix
+          available from Red Hat. Low exploitability — requires processing a
+          crafted binary; gdb-gdbserver is not on any application code path.
+        expires: 2026-11-26T12:00:00.000Z
+        created: 2026-05-26T15:00:00.000Z
+  SNYK-RHEL9-GLIBC-16123837:
+    - '*':
+        reason: >-
+          Buffer overflow (CVE-2026-0861) in glibc 2.34-266.el9_8, introduced
+          by base image ubi9:9.7. RHSA-2026:2786 issued but patched RPM not
+          yet available in the UBI9 container stream. Will be resolved on next
+          base image rebuild.
+        expires: 2026-08-26T12:00:00.000Z
+        created: 2026-05-26T15:00:00.000Z
+  SNYK-RHEL9-GLIBCCOMMON-16123609:
+    - '*':
+        reason: >-
+          Buffer overflow (CVE-2026-0861) in glibc-common 2.34-266.el9_8,
+          introduced by base image ubi9:9.7. Same root cause as
+          SNYK-RHEL9-GLIBC-16123837. Patched RPM not yet in UBI9 stream.
+        expires: 2026-08-26T12:00:00.000Z
+        created: 2026-05-26T15:00:00.000Z
+  SNYK-RHEL9-GLIBCLANGPACKEN-16123517:
+    - '*':
+        reason: >-
+          Buffer overflow (CVE-2026-0861) in glibc-langpack-en 2.34-266.el9_8,
+          introduced by base image ubi9:9.7. Same root cause as
+          SNYK-RHEL9-GLIBC-16123837. Patched RPM not yet in UBI9 stream.
+        expires: 2026-08-26T12:00:00.000Z
+        created: 2026-05-26T15:00:00.000Z
+  SNYK-RHEL9-GLIBCMINIMALLANGPACK-16123875:
+    - '*':
+        reason: >-
+          Buffer overflow (CVE-2026-0861) in glibc-minimal-langpack
+          2.34-266.el9_8, introduced by base image ubi9:9.7. Same root cause
+          as SNYK-RHEL9-GLIBC-16123837. Patched RPM not yet in UBI9 stream.
+        expires: 2026-08-26T12:00:00.000Z
+        created: 2026-05-26T15:00:00.000Z
 patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "4.9.5",
-        "yaml": "^2.8.3"
+        "yaml": "^2.8.4"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
@@ -11383,9 +11383,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "4.9.5",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.4"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/src/scanner/images/index.ts
+++ b/src/scanner/images/index.ts
@@ -63,11 +63,56 @@ export async function pullImages(
   return pulledImages;
 }
 
-function sanitizeSkopeoErrorForLogging(error) {
-  delete error.stack;
-  delete error.message;
-  delete error.childProcess;
-  return error;
+/**
+ * Returns a copy of the error suitable for logging.
+ *
+ * For skopeo `ChildProcessError`s (identified by a populated `stderr` field)
+ * we strip `message` because it includes the full skopeo command line and
+ * therefore contains credentials passed via `--src-creds <user:pass>`. We
+ * also drop `childProcess` (noisy) and `stack` (low signal here). `stderr`
+ * is preserved because it carries the actual skopeo failure detail.
+ *
+ * For every other error (e.g. credential-resolution failures that happen
+ * before skopeo is invoked) we keep `message` so the underlying cause is
+ * not lost in the logs. `childProcess` and `stack` are still dropped
+ * defensively.
+ *
+ * The original error object is not mutated; callers receive a new object.
+ */
+// Exported for testing
+export function sanitizeSkopeoErrorForLogging(error: unknown): object {
+  if (error === null || typeof error !== 'object') {
+    return { error };
+  }
+
+  const source = error as Record<string, unknown> & {
+    stderr?: unknown;
+    message?: unknown;
+    childProcess?: unknown;
+    stack?: unknown;
+  };
+
+  const isSkopeoChildProcessError =
+    typeof source.stderr === 'string' && source.stderr.length > 0;
+
+  // Spread copies own enumerable properties only. `Error.message` / `name`
+  // are non-enumerable, so pull them across explicitly when present.
+  const sanitized: Record<string, unknown> = { ...source };
+  if (error instanceof Error) {
+    if (typeof error.name === 'string' && sanitized.name === undefined) {
+      sanitized.name = error.name;
+    }
+    if (typeof error.message === 'string' && sanitized.message === undefined) {
+      sanitized.message = error.message;
+    }
+  }
+
+  delete sanitized.stack;
+  delete sanitized.childProcess;
+  if (isSkopeoChildProcessError) {
+    delete sanitized.message;
+  }
+  return sanitized;
 }
 
 export function getImagesWithFileSystemPath(

--- a/test/unit/scanner/images.spec.ts
+++ b/test/unit/scanner/images.spec.ts
@@ -67,6 +67,79 @@ describe('pullImages()', () => {
   });
 });
 
+describe('sanitizeSkopeoErrorForLogging()', () => {
+  it('strips message (which may contain --src-creds) when error has stderr', () => {
+    const skopeoError = {
+      name: 'ChildProcessError',
+      message:
+        'Command failed: skopeo copy --src-creds user:supersecret docker://example/image:tag docker-archive:/tmp/x.tar',
+      stderr:
+        'time="2025-01-01" level=fatal msg="unable to retrieve auth token"',
+      stdout: '',
+      childProcess: { pid: 1234 },
+      stack: 'Error: Command failed\n    at ...',
+      exitCode: 1,
+    };
+    const originalMessage = skopeoError.message;
+
+    const result = scannerImages.sanitizeSkopeoErrorForLogging(
+      skopeoError,
+    ) as Record<string, unknown>;
+
+    expect(result).not.toBe(skopeoError);
+    expect(result.message).toBeUndefined();
+    expect(result.childProcess).toBeUndefined();
+    expect(result.stack).toBeUndefined();
+    expect(result.stderr).toEqual(skopeoError.stderr);
+    expect(result.exitCode).toEqual(1);
+    expect(result.name).toEqual('ChildProcessError');
+    expect(JSON.stringify(result)).not.toContain('--src-creds');
+    expect(JSON.stringify(result)).not.toContain('supersecret');
+    // original error is not mutated
+    expect(skopeoError.message).toEqual(originalMessage);
+    expect(skopeoError.childProcess).toBeDefined();
+  });
+
+  it('preserves message for non-skopeo errors (no stderr field)', () => {
+    const credentialError = new Error('ECR token fetch failed');
+
+    const result = scannerImages.sanitizeSkopeoErrorForLogging(
+      credentialError,
+    ) as Record<string, unknown>;
+
+    expect(result.message).toEqual('ECR token fetch failed');
+    expect(result.stack).toBeUndefined();
+    expect(result.childProcess).toBeUndefined();
+  });
+
+  it('preserves message when stderr is present but empty', () => {
+    const error = {
+      message: 'something exploded before skopeo ran',
+      stderr: '',
+      childProcess: { pid: 1 },
+      stack: 'stack trace',
+    };
+
+    const result = scannerImages.sanitizeSkopeoErrorForLogging(error) as Record<
+      string,
+      unknown
+    >;
+
+    expect(result.message).toEqual('something exploded before skopeo ran');
+    expect(result.childProcess).toBeUndefined();
+    expect(result.stack).toBeUndefined();
+  });
+
+  it('handles non-object errors safely', () => {
+    expect(scannerImages.sanitizeSkopeoErrorForLogging('boom')).toEqual({
+      error: 'boom',
+    });
+    expect(scannerImages.sanitizeSkopeoErrorForLogging(null)).toEqual({
+      error: null,
+    });
+  });
+});
+
 describe('getImageParts()', () => {
   it('image digest is returned', () => {
     const imageWithSha =


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Merges staging to master to trigger the `MERGE_TO_MASTER` CircleCI workflow, which publishes the helm chart to gh-pages and deploys to prod.

This unblocks the helm chart for customer Tessl AI (CN-1359), who is pinned on v2.22.17 due to a regression in private AWS ECR image pulls. The release includes:

- **v2.23.4**: fix for `sanitizeSkopeoErrorForLogging` swallowing non-skopeo errors (PR #1689 / CN-1360) — surfaces the actual ECR credential failure message in logs
- **v2.23.5**: yaml dependency upgrade

Once the customer upgrades, the improved error logging will let us diagnose the root cause of the ECR regression and ship the actual fix (CN-1361).

### Notes for the reviewer

Routine staging-to-master promotion. All changes have already passed CI on the staging branch. No code review needed beyond confirming the diff looks correct.

### Screenshots

N/A