### PR TITLE
fix: SNYK-RHEL9-GNUTLS-16416190

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -111,4 +111,11 @@ ignore:
           as SNYK-RHEL9-GLIBC-16123837. Patched RPM not yet in UBI9 stream.
         expires: 2026-08-26T12:00:00.000Z
         created: 2026-05-26T15:00:00.000Z
+  SNYK-RHEL9-GNUTLS-16353670:
+    - '*':
+        reason: >-
+          Integer Underflow in gnutls 3.8.10-4.el9_8, introduced by base image
+          registry.access.redhat.com/ubi9/ubi:9.7. No RHEL 9 fix available.
+        expires: 2026-12-02T12:00:00.000Z
+        created: 2026-06-02T15:00:00.000Z
 patch: {}


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds a Snyk ignore for `SNYK-RHEL9-GNUTLS-16353670` (Integer Underflow in gnutls 3.8.10-4.el9_8), which is a base image vuln introduced by `registry.access.redhat.com/ubi9/ubi:9.7` with no RHEL 9 fix available. This vuln crossed the 30-day remediation SLA and is blocking the container security gate on the staging-to-master merge pipeline.

Unblocking this merge is needed to publish the helm chart for v2.23.5, which includes the skopeo error logging fix (PR #1689 / CN-1360) required for the Tessl AI ECR regression investigation (CN-1359).

Ignore expires Dec 2026.

### Notes for the reviewer

Policy-only change — no code changes. The vuln has no upstream fix; once Red Hat ships a patched gnutls RPM in the UBI9 stream, a base image rebuild will resolve it.

### Screenshots

N/A