### PR TITLE
chore: release to production

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -111,4 +111,11 @@ ignore:
           as SNYK-RHEL9-GLIBC-16123837. Patched RPM not yet in UBI9 stream.
         expires: 2026-08-26T12:00:00.000Z
         created: 2026-05-26T15:00:00.000Z
+  SNYK-RHEL9-GNUTLS-16353670:
+    - '*':
+        reason: >-
+          Integer Underflow in gnutls 3.8.10-4.el9_8, introduced by base image
+          registry.access.redhat.com/ubi9/ubi:9.7. No RHEL 9 fix available.
+        expires: 2026-12-02T12:00:00.000Z
+        created: 2026-06-02T15:00:00.000Z
 patch: {}


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Merges staging to master to trigger the `MERGE_TO_MASTER` CircleCI workflow, which publishes the helm chart to gh-pages and deploys to prod.

This unblocks the helm chart for customer Tessl AI (CN-1359), who is pinned on v2.22.17 due to a regression in private AWS ECR image pulls. The release includes:

- **v2.23.4**: fix for `sanitizeSkopeoErrorForLogging` swallowing non-skopeo errors (PR #1689 / CN-1360) — surfaces the actual ECR credential failure message in logs
- **v2.23.5**: yaml dependency upgrade

Once the customer upgrades, the improved error logging will let us diagnose the root cause of the ECR regression and ship the actual fix (CN-1361).

### Notes for the reviewer

Routine staging-to-master promotion. All changes have already passed CI on the staging branch. No code review needed beyond confirming the diff looks correct.

### Screenshots

N/A