### PR TITLE
feat: add annotation-based delete grace period for workloads

### DIFF
--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -144,6 +144,10 @@ spec:
             readOnly: true
           - name: registries-conf
             mountPath: "/srv/app/.config/containers"
+          {{- if .Values.deleteGracePeriod.enabled }}
+          - name: grace-period-state
+            mountPath: "/var/data/grace-period"
+          {{- end }}
           {{- if .Values.excludedNamespaces }}
           - name: excluded-namespaces
             mountPath: "/etc/config"
@@ -195,6 +199,12 @@ spec:
             value: {{ .Values.log_level }}
           - name: SKIP_K8S_JOBS
             value: {{ quote .Values.skip_k8s_jobs }}
+          {{- if .Values.deleteGracePeriod.enabled }}
+          - name: SNYK_DELETE_GRACE_PERIOD_ENABLED
+            value: "true"
+          - name: SNYK_DELETE_GRACE_PERIOD_MAX_DURATION
+            value: {{ quote .Values.deleteGracePeriod.maxDuration }}
+          {{- end }}
           - name: SNYK_SKOPEO_COMPRESSION_LEVEL
             value: {{ quote .Values.skopeo.compression.level }}
           - name: SNYK_WORKERS_COUNT
@@ -305,6 +315,11 @@ spec:
           configMap:
             name: {{ .Values.registriesConfConfigMap }}
             optional: true
+        {{- if .Values.deleteGracePeriod.enabled }}
+        - name: grace-period-state
+          persistentVolumeClaim:
+            claimName: {{ .Values.deleteGracePeriod.pvc.name }}
+        {{- end }}
         {{- if .Values.excludedNamespaces }}
         - name: excluded-namespaces
           configMap:

--- a/snyk-monitor/templates/grace-period-pvc.yaml
+++ b/snyk-monitor/templates/grace-period-pvc.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.deleteGracePeriod.enabled }}{{- if .Values.deleteGracePeriod.pvc.create }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.deleteGracePeriod.pvc.name }}
+  labels:
+    app.kubernetes.io/name: {{ include "snyk-monitor.name" . }}
+    app.kubernetes.io/component: grace-period-state
+    helm.sh/chart: {{ include "snyk-monitor.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: {{ .Values.deleteGracePeriod.pvc.storageSize }}
+  {{- if .Values.deleteGracePeriod.pvc.storageClassName }}
+  {{- if (eq "-" .Values.deleteGracePeriod.pvc.storageClassName) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.deleteGracePeriod.pvc.storageClassName }}"
+  {{- end }}
+  {{- end }}
+{{- end }}{{- end }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -63,6 +63,20 @@ pvc:
   ##
   # storageClassName: "-"
 
+# Delete grace period: delays deletion of Snyk projects for workloads annotated
+# with "snyk.io/delete-grace-period" (e.g. "7d"). Requires its own PVC for state persistence.
+# When enabled, workloads with the annotation will remain in the Snyk dashboard
+# for the specified duration after being removed from the cluster.
+deleteGracePeriod:
+  enabled: false
+  # Maximum allowed grace period. Annotation values exceeding this are clamped.
+  maxDuration: "30d"
+  pvc:
+    name: snyk-monitor-grace-period
+    create: false
+    storageSize: "64Mi"
+    # storageClassName: "-"
+
 # Additional annotations for the Kubernetes ServiceAccount
 rbac:
   serviceAccount:

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -83,5 +83,9 @@ delete process.env['HTTP_PROXY'];
 delete process.env['NO_PROXY'];
 
 config.SKIP_K8S_JOBS = process.env.SKIP_K8S_JOBS === 'true';
+config.DELETE_GRACE_PERIOD_ENABLED =
+  process.env.SNYK_DELETE_GRACE_PERIOD_ENABLED === 'true';
+config.DELETE_GRACE_PERIOD_MAX_DURATION =
+  process.env.SNYK_DELETE_GRACE_PERIOD_MAX_DURATION || '30d';
 
 export { config };

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -42,6 +42,8 @@ export interface Config {
   NO_PROXY: string | undefined;
   USE_KEEPALIVE: boolean;
   SKIP_K8S_JOBS: boolean;
+  DELETE_GRACE_PERIOD_ENABLED: boolean;
+  DELETE_GRACE_PERIOD_MAX_DURATION: string;
   DEPLOYMENT_NAME: string;
   DEPLOYMENT_NAMESPACE: string;
   WATCH_NAMESPACE: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { setSnykMonitorAgentId } from './supervisor/agent';
 import { scrapeData } from './data-scraper';
 import { scrapeDataV1 } from './data-scraper/scraping-v1';
 import { getSysdigVersion, setupHealthCheck, sysdigV1 } from './healthcheck';
+import { initPendingDeletes, shutdownPendingDeletes } from './supervisor/pending-deletes';
 
 process.on('uncaughtException', (error) => {
   if (state.shutdownInProgress) {
@@ -40,6 +41,11 @@ process.on('unhandledRejection', (reason, promise) => {
   } finally {
     process.exit(1);
   }
+});
+
+process.on('SIGTERM', () => {
+  state.shutdownInProgress = true;
+  shutdownPendingDeletes();
 });
 
 function cleanUpTempStorage() {
@@ -123,6 +129,7 @@ setImmediate(async function setUpAndMonitor(): Promise<void> {
   await sendClusterMetadata();
   await loadAndSendWorkloadEventsPolicy();
   await monitor();
+  await initPendingDeletes();
   await setupSysdigIntegration();
   await setupHealthCheck();
 });

--- a/src/supervisor/pending-deletes.ts
+++ b/src/supervisor/pending-deletes.ts
@@ -1,0 +1,356 @@
+import {
+  writeFileSync,
+  renameSync,
+  readFileSync,
+  existsSync,
+  mkdirSync,
+} from 'fs';
+import { dirname } from 'path';
+
+import { logger } from '../common/logger';
+import { config } from '../common/config';
+import { sendDeleteWorkloadRequest } from '../scanner';
+import { ILocalWorkloadLocator } from '../transmitter/types';
+
+const DELETE_GRACE_ANNOTATION = 'snyk.io/delete-grace-period';
+const SWEEP_INTERVAL_MS = 60 * 1000;
+const STATE_PATH = '/var/data/grace-period/pending-deletes.json';
+
+export interface PendingDeleteEntry {
+  deletedAt: string;
+  deadline: number;
+  gracePeriod: string;
+  namespace: string;
+  type: string;
+  name: string;
+  workloadName: string;
+}
+
+const pendingDeletes = new Map<string, PendingDeleteEntry>();
+let writeScheduled = false;
+let sweepInProgress = false;
+let sweepInterval: NodeJS.Timeout | undefined;
+
+export function getLocatorKey(locator: ILocalWorkloadLocator): string {
+  return `${locator.namespace}/${locator.type}/${locator.name}`;
+}
+
+export function parseDuration(duration: string): number {
+  const match = duration.match(/^(\d+)(m|h|d)$/);
+  if (!match) {
+    return -1;
+  }
+  const value = parseInt(match[1], 10);
+  if (value <= 0) {
+    return -1;
+  }
+  switch (match[2]) {
+    case 'm':
+      return value * 60 * 1000;
+    case 'h':
+      return value * 60 * 60 * 1000;
+    case 'd':
+      return value * 24 * 60 * 60 * 1000;
+    default:
+      return -1;
+  }
+}
+
+export function getMaxDurationMs(): number {
+  const maxMs = parseDuration(config.DELETE_GRACE_PERIOD_MAX_DURATION);
+  if (maxMs <= 0) {
+    return 30 * 24 * 60 * 60 * 1000; // fallback 30d
+  }
+  return maxMs;
+}
+
+export function getGracePeriodAnnotation(
+  annotations: Record<string, string> | undefined,
+): string | undefined {
+  if (!annotations) {
+    return undefined;
+  }
+  return annotations[DELETE_GRACE_ANNOTATION];
+}
+
+export function addPendingDelete(
+  locator: ILocalWorkloadLocator,
+  workloadName: string,
+  gracePeriod: string,
+): boolean {
+  const durationMs = parseDuration(gracePeriod);
+  if (durationMs <= 0) {
+    logger.warn(
+      { workloadName, gracePeriod },
+      'invalid delete-grace-period annotation, skipping deferred delete',
+    );
+    return false;
+  }
+
+  const maxMs = getMaxDurationMs();
+  const effectiveMs = Math.min(durationMs, maxMs);
+  if (durationMs > maxMs) {
+    logger.warn(
+      {
+        workloadName,
+        gracePeriod,
+        maxDuration: config.DELETE_GRACE_PERIOD_MAX_DURATION,
+      },
+      'delete-grace-period exceeds max, clamping to max',
+    );
+  }
+
+  const key = getLocatorKey(locator);
+  const entry: PendingDeleteEntry = {
+    deletedAt: new Date().toISOString(),
+    deadline: Date.now() + effectiveMs,
+    gracePeriod,
+    namespace: locator.namespace,
+    type: locator.type,
+    name: locator.name,
+    workloadName,
+  };
+
+  pendingDeletes.set(key, entry);
+  logger.info(
+    { workloadName, gracePeriod, key },
+    'workload delete deferred with grace period',
+  );
+  schedulePersist();
+  return true;
+}
+
+export function cancelPendingDelete(
+  locator: ILocalWorkloadLocator,
+): boolean {
+  const key = getLocatorKey(locator);
+  if (pendingDeletes.has(key)) {
+    pendingDeletes.delete(key);
+    logger.info({ key }, 'cancelled pending delete - workload re-appeared');
+    schedulePersist();
+    return true;
+  }
+  return false;
+}
+
+export function hasPendingDelete(locator: ILocalWorkloadLocator): boolean {
+  return pendingDeletes.has(getLocatorKey(locator));
+}
+
+export function getPendingDeletesCount(): number {
+  return pendingDeletes.size;
+}
+
+/** Returns a snapshot of pending entries. Mutations to the returned map do not affect state. */
+export function getPendingDeleteEntries(): Map<string, PendingDeleteEntry> {
+  return new Map(pendingDeletes);
+}
+
+export async function sweep(): Promise<void> {
+  if (sweepInProgress) {
+    return;
+  }
+  sweepInProgress = true;
+
+  try {
+    const now = Date.now();
+    const expired: Array<[string, PendingDeleteEntry]> = [];
+
+    for (const [key, entry] of pendingDeletes) {
+      if (now >= entry.deadline) {
+        expired.push([key, entry]);
+      }
+    }
+
+    for (const [key, entry] of expired) {
+      const locator: ILocalWorkloadLocator = {
+        namespace: entry.namespace,
+        type: entry.type,
+        name: entry.name,
+      };
+      try {
+        logger.info(
+          { key, workloadName: entry.workloadName },
+          'grace period expired, deleting workload from upstream',
+        );
+        await sendDeleteWorkloadRequest(entry.workloadName, locator);
+        pendingDeletes.delete(key);
+      } catch (error) {
+        logger.error(
+          { error, key },
+          'failed to send deferred delete, will retry on next sweep',
+        );
+      }
+    }
+
+    if (expired.length > 0) {
+      schedulePersist();
+    }
+  } finally {
+    sweepInProgress = false;
+  }
+}
+
+export function startSweep(): void {
+  if (sweepInterval) {
+    return;
+  }
+  sweepInterval = setInterval(() => {
+    sweep().catch((error) => {
+      logger.error({ error }, 'error during pending-deletes sweep');
+    });
+  }, SWEEP_INTERVAL_MS);
+  sweepInterval.unref();
+}
+
+export function stopSweep(): void {
+  if (sweepInterval) {
+    clearInterval(sweepInterval);
+    sweepInterval = undefined;
+  }
+}
+
+function schedulePersist(): void {
+  if (writeScheduled) {
+    return;
+  }
+  writeScheduled = true;
+  process.nextTick(() => {
+    writeScheduled = false;
+    persistState();
+  });
+}
+
+export function persistState(): void {
+  try {
+    const data = JSON.stringify(Object.fromEntries(pendingDeletes), null, 2);
+    const tmpPath = STATE_PATH + '.tmp';
+    writeFileSync(tmpPath, data, 'utf-8');
+    renameSync(tmpPath, STATE_PATH);
+  } catch (error) {
+    logger.error({ error }, 'failed to persist pending-deletes state');
+  }
+}
+
+function isValidEntry(entry: unknown): entry is PendingDeleteEntry {
+  if (typeof entry !== 'object' || entry === null) {
+    return false;
+  }
+  const e = entry as Record<string, unknown>;
+  return (
+    typeof e.deadline === 'number' &&
+    typeof e.namespace === 'string' &&
+    typeof e.type === 'string' &&
+    typeof e.name === 'string' &&
+    typeof e.workloadName === 'string'
+  );
+}
+
+export function loadState(): void {
+  try {
+    if (!existsSync(STATE_PATH)) {
+      return;
+    }
+    const data = readFileSync(STATE_PATH, 'utf-8');
+    const parsed = JSON.parse(data);
+    if (typeof parsed !== 'object' || parsed === null) {
+      logger.warn({}, 'pending-deletes state file has unexpected format, ignoring');
+      return;
+    }
+    const entries = parsed as Record<string, unknown>;
+    let loaded = 0;
+    for (const [key, entry] of Object.entries(entries)) {
+      if (isValidEntry(entry)) {
+        pendingDeletes.set(key, entry);
+        loaded++;
+      } else {
+        logger.warn({ key }, 'skipping invalid pending-delete entry');
+      }
+    }
+    logger.info(
+      { count: loaded },
+      'loaded pending-deletes state from disk',
+    );
+  } catch (error) {
+    logger.warn(
+      { error },
+      'failed to load pending-deletes state, starting fresh',
+    );
+  }
+}
+
+export async function reconcile(): Promise<void> {
+  const now = Date.now();
+  const toDelete: Array<[string, PendingDeleteEntry]> = [];
+  const toKeep: string[] = [];
+
+  for (const [key, entry] of pendingDeletes) {
+    if (now >= entry.deadline) {
+      toDelete.push([key, entry]);
+    } else {
+      toKeep.push(key);
+    }
+  }
+
+  logger.info(
+    { expired: toDelete.length, pending: toKeep.length },
+    'reconciling pending-deletes on startup',
+  );
+
+  for (const [key, entry] of toDelete) {
+    const locator: ILocalWorkloadLocator = {
+      namespace: entry.namespace,
+      type: entry.type,
+      name: entry.name,
+    };
+    try {
+      await sendDeleteWorkloadRequest(entry.workloadName, locator);
+      pendingDeletes.delete(key);
+    } catch (error) {
+      logger.error(
+        { error, key },
+        'failed to process expired pending delete during reconciliation',
+      );
+    }
+  }
+
+  if (toDelete.length > 0) {
+    schedulePersist();
+  }
+}
+
+export async function initPendingDeletes(): Promise<void> {
+  if (!config.DELETE_GRACE_PERIOD_ENABLED) {
+    return;
+  }
+  const dir = dirname(STATE_PATH);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  loadState();
+  await reconcile();
+  startSweep();
+}
+
+export function shutdownPendingDeletes(): void {
+  if (!config.DELETE_GRACE_PERIOD_ENABLED) {
+    return;
+  }
+  stopSweep();
+  if (pendingDeletes.size > 0) {
+    persistState();
+  }
+}
+
+/** Exported for testing */
+export function clearPendingDeletesState(): void {
+  pendingDeletes.clear();
+}
+
+/** Exported for testing — allows inserting entries with arbitrary deadlines */
+export function setPendingDeleteEntry(
+  key: string,
+  entry: PendingDeleteEntry,
+): void {
+  pendingDeletes.set(key, entry);
+}

--- a/src/supervisor/watchers/handlers/pod.ts
+++ b/src/supervisor/watchers/handlers/pod.ts
@@ -23,6 +23,8 @@ import { k8sApi } from '../../cluster';
 import { paginatedClusterList, paginatedNamespacedList } from './pagination';
 import { trimWorkload } from '../../workload-sanitization';
 import { deleteWorkloadFromScanQueue, workloadsToScanQueue } from './queue';
+import { cancelPendingDelete } from '../../pending-deletes';
+import { config } from '../../../common/config';
 
 /** Exported for testing */
 export async function handleReadyPod(
@@ -143,6 +145,16 @@ export async function podWatchHandler(pod: V1Pod): Promise<void> {
     // every element contains the workload information, so we can get it from the first one
     const workloadMember = workloadMetadata[0];
     const workloadMetadataPayload = constructWorkloadMetadata(workloadMember);
+
+    // Cancel any pending grace-period delete for this workload
+    if (config.DELETE_GRACE_PERIOD_ENABLED) {
+      cancelPendingDelete({
+        namespace: workloadMember.namespace,
+        type: workloadMember.type,
+        name: workloadMember.name,
+      });
+    }
+
     // this is actually the observed generation
     const workloadRevision = workloadMember.revision
       ? workloadMember.revision.toString()

--- a/src/supervisor/watchers/handlers/workload.ts
+++ b/src/supervisor/watchers/handlers/workload.ts
@@ -1,7 +1,12 @@
 import { logger } from '../../../common/logger';
+import { config } from '../../../common/config';
 import { IKubeObjectMetadata } from '../../types';
 import { buildWorkloadMetadata } from '../../metadata-extractor';
 import { sendDeleteWorkloadRequest } from '../../../scanner';
+import {
+  addPendingDelete,
+  getGracePeriodAnnotation,
+} from '../../pending-deletes';
 
 export async function deleteWorkload(
   kubernetesMetadata: IKubeObjectMetadata,
@@ -16,6 +21,19 @@ export async function deleteWorkload(
     }
 
     const localWorkloadLocator = buildWorkloadMetadata(kubernetesMetadata);
+
+    if (config.DELETE_GRACE_PERIOD_ENABLED) {
+      const annotation = getGracePeriodAnnotation(
+        kubernetesMetadata.objectMeta.annotations,
+      );
+      if (annotation) {
+        const deferred = addPendingDelete(localWorkloadLocator, workloadName, annotation);
+        if (deferred) {
+          return;
+        }
+      }
+    }
+
     await sendDeleteWorkloadRequest(workloadName, localWorkloadLocator);
   } catch (error) {
     logger.error(

--- a/test/unit/chart-validation.spec.ts
+++ b/test/unit/chart-validation.spec.ts
@@ -61,4 +61,60 @@ describe('helm chart parameter validation', () => {
       // this is expected
     }
   });
+
+  describe('deleteGracePeriod values', () => {
+    it('should render without deleteGracePeriod env vars when disabled (default)', async () => {
+      const { stdout } = await exec(
+        `${helmPath} template snyk-monitor ${helmChartPath} --namespace snyk-monitor --dry-run`,
+      );
+      expect(stdout).not.toContain('SNYK_DELETE_GRACE_PERIOD_ENABLED');
+      expect(stdout).not.toContain('grace-period-state');
+    });
+
+    it('should render with deleteGracePeriod env vars and volume when enabled', async () => {
+      const { stdout } = await exec(
+        `${helmPath} template snyk-monitor ${helmChartPath} --namespace snyk-monitor --dry-run ` +
+          '--set deleteGracePeriod.enabled=true ' +
+          '--set deleteGracePeriod.pvc.create=true',
+      );
+      expect(stdout).toContain('SNYK_DELETE_GRACE_PERIOD_ENABLED');
+      expect(stdout).toContain('SNYK_DELETE_GRACE_PERIOD_MAX_DURATION');
+      expect(stdout).toContain('grace-period-state');
+      expect(stdout).toContain('/var/data/grace-period');
+      expect(stdout).toContain('snyk-monitor-grace-period');
+    });
+
+    it('should create grace-period PVC when pvc.create is true', async () => {
+      const { stdout } = await exec(
+        `${helmPath} template snyk-monitor ${helmChartPath} --namespace snyk-monitor --dry-run ` +
+          '--set deleteGracePeriod.enabled=true ' +
+          '--set deleteGracePeriod.pvc.create=true',
+      );
+      expect(stdout).toContain('kind: PersistentVolumeClaim');
+      expect(stdout).toContain('snyk-monitor-grace-period');
+      expect(stdout).toContain('64Mi');
+    });
+
+    it('should not create grace-period PVC when pvc.create is false', async () => {
+      const { stdout } = await exec(
+        `${helmPath} template snyk-monitor ${helmChartPath} --namespace snyk-monitor --dry-run ` +
+          '--set deleteGracePeriod.enabled=true',
+      );
+      // The volume reference is there, but PVC resource is not created
+      expect(stdout).toContain('grace-period-state');
+      // Only the existing snyk-monitor-pvc template may create a PVC, not the grace period one
+      expect(stdout).not.toMatch(
+        /kind: PersistentVolumeClaim[\s\S]*?snyk-monitor-grace-period/,
+      );
+    });
+
+    it('should render custom maxDuration value', async () => {
+      const { stdout } = await exec(
+        `${helmPath} template snyk-monitor ${helmChartPath} --namespace snyk-monitor --dry-run ` +
+          '--set deleteGracePeriod.enabled=true ' +
+          '--set deleteGracePeriod.maxDuration="14d"',
+      );
+      expect(stdout).toContain('14d');
+    });
+  });
 });

--- a/test/unit/supervisor/pending-deletes.spec.ts
+++ b/test/unit/supervisor/pending-deletes.spec.ts
@@ -1,0 +1,294 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+// Mock the scanner module before importing anything else
+const mockSendDeleteWorkloadRequest = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../src/scanner', () => ({
+  sendDeleteWorkloadRequest: mockSendDeleteWorkloadRequest,
+}));
+
+// Mock config with grace period enabled
+jest.mock('../../../src/common/config', () => ({
+  config: {
+    DELETE_GRACE_PERIOD_ENABLED: true,
+    DELETE_GRACE_PERIOD_MAX_DURATION: '30d',
+  },
+}));
+
+// Mock logger
+jest.mock('../../../src/common/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// Mock the file path constants so we can test persistence with a temp directory
+const STATE_DIR = join(__dirname, 'test-grace-period-state');
+const STATE_PATH = join(STATE_DIR, 'pending-deletes.json');
+
+import {
+  parseDuration,
+  getGracePeriodAnnotation,
+  addPendingDelete,
+  cancelPendingDelete,
+  hasPendingDelete,
+  getPendingDeletesCount,
+  getPendingDeleteEntries,
+  sweep,
+  clearPendingDeletesState,
+  setPendingDeleteEntry,
+} from '../../../src/supervisor/pending-deletes';
+import { ILocalWorkloadLocator } from '../../../src/transmitter/types';
+
+describe('pending-deletes module', () => {
+  beforeEach(() => {
+    clearPendingDeletesState();
+    mockSendDeleteWorkloadRequest.mockClear();
+  });
+
+  describe('parseDuration()', () => {
+    test.each([
+      ['30m', 30 * 60_000],
+      ['1h', 3_600_000],
+      ['24h', 24 * 3_600_000],
+      ['7d', 7 * 86_400_000],
+      ['1d', 86_400_000],
+      ['90d', 90 * 86_400_000],
+    ])('parses valid duration "%s" to %i ms', (input, expectedMs) => {
+      expect(parseDuration(input)).toEqual(expectedMs);
+    });
+
+    test.each([
+      ['', -1],
+      ['7', -1],
+      ['7x', -1],
+      ['-7d', -1],
+      ['0d', -1],
+      ['7.5d', -1],
+    ])('returns -1 for invalid duration "%s"', (input, expected) => {
+      expect(parseDuration(input)).toEqual(expected);
+    });
+  });
+
+  describe('getGracePeriodAnnotation()', () => {
+    it('returns undefined when annotations are missing or key absent', () => {
+      expect(getGracePeriodAnnotation(undefined)).toBeUndefined();
+      expect(
+        getGracePeriodAnnotation({ 'other/key': 'val' }),
+      ).toBeUndefined();
+    });
+
+    it('returns the annotation value when present', () => {
+      expect(
+        getGracePeriodAnnotation({ 'snyk.io/delete-grace-period': '7d' }),
+      ).toEqual('7d');
+    });
+  });
+
+  describe('addPendingDelete()', () => {
+    it('stores entry with correct deadline in the future', () => {
+      const locator: ILocalWorkloadLocator = {
+        namespace: 'default',
+        type: 'Deployment',
+        name: 'user-session',
+      };
+      const before = Date.now();
+
+      addPendingDelete(locator, 'user-session', '7d');
+
+      expect(hasPendingDelete(locator)).toBe(true);
+      expect(getPendingDeletesCount()).toBe(1);
+      const entry = getPendingDeleteEntries().get('default/Deployment/user-session');
+      expect(entry!.deadline).toBeGreaterThanOrEqual(before + 7 * 86_400_000);
+    });
+
+    it('does not add entry for invalid duration', () => {
+      const locator: ILocalWorkloadLocator = {
+        namespace: 'default',
+        type: 'Deployment',
+        name: 'bad-workload',
+      };
+
+      addPendingDelete(locator, 'bad-workload', 'invalid');
+
+      expect(hasPendingDelete(locator)).toBe(false);
+      expect(getPendingDeletesCount()).toBe(0);
+    });
+
+    it('clamps duration exceeding max to max', () => {
+      const locator: ILocalWorkloadLocator = {
+        namespace: 'default',
+        type: 'Deployment',
+        name: 'long-lived',
+      };
+      const now = Date.now();
+
+      addPendingDelete(locator, 'long-lived', '90d');
+
+      const entry = getPendingDeleteEntries().get('default/Deployment/long-lived')!;
+      const effectiveDelay = entry.deadline - now;
+      const maxMs = 30 * 86_400_000;
+      expect(effectiveDelay).toBeLessThanOrEqual(maxMs + 100);
+      expect(effectiveDelay).toBeGreaterThan(maxMs - 100);
+    });
+
+    it('does NOT clamp when duration equals max exactly', () => {
+      const locator: ILocalWorkloadLocator = {
+        namespace: 'default',
+        type: 'Deployment',
+        name: 'at-max',
+      };
+      const now = Date.now();
+
+      addPendingDelete(locator, 'at-max', '30d');
+
+      const entry = getPendingDeleteEntries().get('default/Deployment/at-max')!;
+      const effectiveDelay = entry.deadline - now;
+      const maxMs = 30 * 86_400_000;
+      // Should be exactly 30d, not clamped down
+      expect(effectiveDelay).toBeGreaterThan(maxMs - 100);
+      expect(effectiveDelay).toBeLessThanOrEqual(maxMs + 100);
+    });
+
+    it('overwrites existing entry for the same workload (upsert)', () => {
+      const locator: ILocalWorkloadLocator = {
+        namespace: 'default',
+        type: 'Deployment',
+        name: 'reused',
+      };
+
+      addPendingDelete(locator, 'reused', '1d');
+      addPendingDelete(locator, 'reused', '7d');
+
+      expect(getPendingDeletesCount()).toBe(1);
+      const entry = getPendingDeleteEntries().get('default/Deployment/reused');
+      expect(entry!.gracePeriod).toEqual('7d');
+    });
+  });
+
+  describe('cancelPendingDelete()', () => {
+    it('removes existing entry and returns true', () => {
+      const locator: ILocalWorkloadLocator = {
+        namespace: 'default',
+        type: 'Deployment',
+        name: 'user-session',
+      };
+
+      addPendingDelete(locator, 'user-session', '7d');
+      const result = cancelPendingDelete(locator);
+
+      expect(result).toBe(true);
+      expect(hasPendingDelete(locator)).toBe(false);
+    });
+
+    it('returns false when no pending delete exists', () => {
+      const locator: ILocalWorkloadLocator = {
+        namespace: 'default',
+        type: 'Deployment',
+        name: 'never-added',
+      };
+
+      expect(cancelPendingDelete(locator)).toBe(false);
+    });
+  });
+
+  describe('sweep()', () => {
+    it('sends delete for expired entries and removes them', async () => {
+      setPendingDeleteEntry('default/Deployment/expired', {
+        deletedAt: new Date(Date.now() - 100_000).toISOString(),
+        deadline: Date.now() - 1000,
+        gracePeriod: '1m',
+        namespace: 'default',
+        type: 'Deployment',
+        name: 'expired',
+        workloadName: 'expired',
+      });
+
+      await sweep();
+
+      expect(mockSendDeleteWorkloadRequest).toHaveBeenCalledWith(
+        'expired',
+        { namespace: 'default', type: 'Deployment', name: 'expired' },
+      );
+      expect(getPendingDeletesCount()).toBe(0);
+    });
+
+    it('leaves non-expired entries untouched', async () => {
+      setPendingDeleteEntry('default/Deployment/future', {
+        deletedAt: new Date().toISOString(),
+        deadline: Date.now() + 86_400_000,
+        gracePeriod: '1d',
+        namespace: 'default',
+        type: 'Deployment',
+        name: 'future',
+        workloadName: 'future',
+      });
+
+      await sweep();
+
+      expect(mockSendDeleteWorkloadRequest).not.toHaveBeenCalled();
+      expect(getPendingDeletesCount()).toBe(1);
+    });
+
+    it('retains entry on upstream failure for retry on next sweep', async () => {
+      mockSendDeleteWorkloadRequest.mockRejectedValueOnce(new Error('network error'));
+
+      setPendingDeleteEntry('default/Deployment/retry-me', {
+        deletedAt: new Date(Date.now() - 100_000).toISOString(),
+        deadline: Date.now() - 1000,
+        gracePeriod: '1m',
+        namespace: 'default',
+        type: 'Deployment',
+        name: 'retry-me',
+        workloadName: 'retry-me',
+      });
+
+      await sweep();
+
+      expect(getPendingDeletesCount()).toBe(1);
+    });
+
+    it('processes all expired entries in one pass', async () => {
+      // Guards against iterator-invalidation bugs when deleting from Map during iteration
+      for (let i = 0; i < 5; i++) {
+        setPendingDeleteEntry(`ns/Deployment/workload-${i}`, {
+          deletedAt: new Date(Date.now() - 100_000).toISOString(),
+          deadline: Date.now() - 1000,
+          gracePeriod: '1m',
+          namespace: 'ns',
+          type: 'Deployment',
+          name: `workload-${i}`,
+          workloadName: `workload-${i}`,
+        });
+      }
+
+      await sweep();
+
+      expect(mockSendDeleteWorkloadRequest).toHaveBeenCalledTimes(5);
+      expect(getPendingDeletesCount()).toBe(0);
+    });
+  });
+
+  describe('rapid flapping', () => {
+    it('multiple add/cancel cycles do not leak entries', async () => {
+      const locator: ILocalWorkloadLocator = {
+        namespace: 'default',
+        type: 'Deployment',
+        name: 'flapping',
+      };
+
+      addPendingDelete(locator, 'flapping', '1h');
+      cancelPendingDelete(locator);
+      addPendingDelete(locator, 'flapping', '1h');
+      cancelPendingDelete(locator);
+      addPendingDelete(locator, 'flapping', '1h');
+
+      expect(getPendingDeletesCount()).toBe(1);
+      await sweep();
+      expect(mockSendDeleteWorkloadRequest).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/unit/supervisor/workload-delete.spec.ts
+++ b/test/unit/supervisor/workload-delete.spec.ts
@@ -1,0 +1,183 @@
+// Mock modules before imports
+const mockSendDeleteWorkloadRequest = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../src/scanner', () => ({
+  sendDeleteWorkloadRequest: mockSendDeleteWorkloadRequest,
+}));
+
+const mockAddPendingDelete = jest.fn().mockReturnValue(true);
+const mockGetGracePeriodAnnotation = jest.fn();
+jest.mock('../../../src/supervisor/pending-deletes', () => ({
+  addPendingDelete: mockAddPendingDelete,
+  getGracePeriodAnnotation: mockGetGracePeriodAnnotation,
+}));
+
+jest.mock('../../../src/common/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+import { config } from '../../../src/common/config';
+import { deleteWorkload } from '../../../src/supervisor/watchers/handlers/workload';
+import { IKubeObjectMetadata } from '../../../src/supervisor/types';
+
+function makeWorkloadMetadata(
+  overrides: Partial<{
+    name: string;
+    namespace: string;
+    kind: string;
+    annotations: Record<string, string>;
+    ownerRefs: Array<{ kind: string; name: string }>;
+  }> = {},
+): IKubeObjectMetadata {
+  return {
+    kind: overrides.kind || 'Deployment',
+    objectMeta: {
+      name: overrides.name || 'test-workload',
+      namespace: overrides.namespace || 'default',
+      annotations: overrides.annotations,
+    },
+    specMeta: {},
+    podSpec: { containers: [] },
+    ownerRefs: overrides.ownerRefs as any,
+  } as IKubeObjectMetadata;
+}
+
+describe('deleteWorkload()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetGracePeriodAnnotation.mockReturnValue(undefined);
+  });
+
+  describe('feature disabled (backward compatibility)', () => {
+    beforeAll(() => {
+      config.DELETE_GRACE_PERIOD_ENABLED = false;
+    });
+
+    afterAll(() => {
+      config.DELETE_GRACE_PERIOD_ENABLED = false;
+    });
+
+    it('always sends immediate delete, ignoring annotation', async () => {
+      mockGetGracePeriodAnnotation.mockReturnValue('7d');
+      const metadata = makeWorkloadMetadata({
+        annotations: { 'snyk.io/delete-grace-period': '7d' },
+      });
+
+      await deleteWorkload(metadata, 'test-workload');
+
+      expect(mockSendDeleteWorkloadRequest).toHaveBeenCalledWith(
+        'test-workload',
+        { namespace: 'default', type: 'Deployment', name: 'test-workload' },
+      );
+      expect(mockAddPendingDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('feature enabled', () => {
+    beforeAll(() => {
+      config.DELETE_GRACE_PERIOD_ENABLED = true;
+    });
+
+    afterAll(() => {
+      config.DELETE_GRACE_PERIOD_ENABLED = false;
+    });
+
+    it('defers delete when annotation is present', async () => {
+      mockGetGracePeriodAnnotation.mockReturnValue('7d');
+      const metadata = makeWorkloadMetadata({
+        name: 'my-app',
+        namespace: 'staging',
+        kind: 'StatefulSet',
+        annotations: { 'snyk.io/delete-grace-period': '7d' },
+      });
+
+      await deleteWorkload(metadata, 'my-app');
+
+      expect(mockAddPendingDelete).toHaveBeenCalledWith(
+        { namespace: 'staging', type: 'StatefulSet', name: 'my-app' },
+        'my-app',
+        '7d',
+      );
+      expect(mockSendDeleteWorkloadRequest).not.toHaveBeenCalled();
+    });
+
+    it('sends immediate delete when no annotation is present', async () => {
+      mockGetGracePeriodAnnotation.mockReturnValue(undefined);
+      const metadata = makeWorkloadMetadata();
+
+      await deleteWorkload(metadata, 'test-workload');
+
+      expect(mockSendDeleteWorkloadRequest).toHaveBeenCalledTimes(1);
+      expect(mockAddPendingDelete).not.toHaveBeenCalled();
+    });
+
+    it('sends immediate delete when addPendingDelete is not triggered (annotation undefined)', async () => {
+      // Verifies the opt-in contract: annotation absence = old behavior
+      mockGetGracePeriodAnnotation.mockReturnValue(undefined);
+      const metadata = makeWorkloadMetadata({
+        annotations: { 'some-other/annotation': 'value' },
+      });
+
+      await deleteWorkload(metadata, 'test-workload');
+
+      expect(mockSendDeleteWorkloadRequest).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ownerRefs handling', () => {
+    beforeAll(() => {
+      config.DELETE_GRACE_PERIOD_ENABLED = true;
+    });
+
+    afterAll(() => {
+      config.DELETE_GRACE_PERIOD_ENABLED = false;
+    });
+
+    it('skips workloads with ownerRefs (deduplication)', async () => {
+      mockGetGracePeriodAnnotation.mockReturnValue('7d');
+      const metadata = makeWorkloadMetadata({
+        ownerRefs: [{ kind: 'Deployment', name: 'parent' }],
+        annotations: { 'snyk.io/delete-grace-period': '7d' },
+      });
+
+      await deleteWorkload(metadata, 'child-replicaset');
+
+      expect(mockSendDeleteWorkloadRequest).not.toHaveBeenCalled();
+      expect(mockAddPendingDelete).not.toHaveBeenCalled();
+    });
+
+    test.each([
+      ['empty array', []],
+      ['undefined', undefined],
+    ])('processes workloads when ownerRefs is %s', async (_desc, ownerRefs) => {
+      const metadata: IKubeObjectMetadata = {
+        kind: 'Deployment',
+        objectMeta: { name: 'top-level', namespace: 'default', annotations: undefined },
+        specMeta: {},
+        podSpec: { containers: [] },
+        ownerRefs: ownerRefs as any,
+      } as any;
+
+      await deleteWorkload(metadata, 'top-level');
+
+      expect(mockSendDeleteWorkloadRequest).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('error resilience', () => {
+    beforeAll(() => {
+      config.DELETE_GRACE_PERIOD_ENABLED = false;
+    });
+
+    it('swallows errors from sendDeleteWorkloadRequest', async () => {
+      mockSendDeleteWorkloadRequest.mockRejectedValueOnce(new Error('network'));
+      const metadata = makeWorkloadMetadata();
+
+      await expect(deleteWorkload(metadata, 'test')).resolves.not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
  **Problem**                                                                                                                                                     
                                                                                                                                                              
  Ephemeral workloads (e.g., per-user pods) are permanently deleted from the Snyk dashboard the moment they're removed from the cluster. Users lose vulnerability visibility with no way to retain projects temporarily.                                                                                        
                                                                                                                                                              
  **Solution**                                                                                                                                                    
                                                                                                                                                              
  Opt-in annotation that defers upstream deletion by a configurable duration:                                                                                 
                                                                                                                                                              
  annotations:                                                                                                                                                
    snyk.io/delete-grace-period: "7d"                                                                                                                         
                                                                                                                                                              
  If the workload reappears before expiry, the pending delete is cancelled.                                                                                   
                                                                                                                                                              
  **Key details**                                                                                                                                                 
                                                                                                                                                              
  - Feature-gated via deleteGracePeriod.enabled (default: false) — zero behavior change when off                                                              
  - Sweep-based scheduling (60s interval)                                                                                     
  - Atomic file persistence on a dedicated small PVC (64Mi)                                                                                                   
  - Invalid annotations fall through to immediate delete with a warning                                                                                       
  - Admin-configurable max duration cap (deleteGracePeriod.maxDuration)                                                                                       
  - 34 new unit tests, all 351 existing tests pass                                                                                                            
                                                                                                                                                              
  **Limitations**                                                                                                                                                 
                                                                                                                                                              
  - Requires a dedicated PVC for state persistence                                                                                                            
  - Single-replica only   