### PR TITLE
fix(deps): tighten fast-xml-parser override to >=5.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6024,9 +6024,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "funding": [
         {
           "type": "github",
@@ -6036,9 +6036,10 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.2.0",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -10574,9 +10575,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "cross-spawn": "^7.0.5",
     "jsonpath-plus": "10.3.0",
     "qs": "^6.15.2",
-    "fast-xml-parser": "^5.3.6",
+    "fast-xml-parser": ">=5.7.2",
     "fast-xml-builder": "^1.1.7",
     "minimatch": "^10.2.3",
     "brace-expansion": "^5.0.6",


### PR DESCRIPTION
When we migrated `credentials.ts` from AWS SDK v2 to v3 in v2.22.20, we swapped out `xml2js`+`sax` for `fast-xml-parser` without really thinking about it — it's a transitive dep, not something anyone touched directly. The problem is that `fast-xml-parser` 5.7.0 and 5.7.1 shipped a security hardening change that broke handling of hex numeric character references (`&#x...;`) in XML. Instead of recognizing `#x` as the prefix for a numeric reference, `EntityDecoderImpl` now throws "Invalid character '#' in entity name". That matters here because STS — which the AWS SDK v3 credential chain calls internally for IRSA — returns XML responses that contain those sequences. So ECR auth was silently failing at the deserialization step, even though the HTTP call returned 200.

The `^5.3.6` override we already had didn't protect us because it allows anything up to 6.0.0, which includes the broken range. `fast-xml-parser` 5.7.2 reverted the restriction. This PR tightens the override to `>=5.7.2` — resolves to 5.8.0 on the current lockfile.

---

## Why we're confident this is the right fix

### 1. The error string is hardcoded in fast-xml-parser's dependency

`[EntityReplacer] Invalid character '#' in entity name` is thrown verbatim from `@nodable/entities` — the library `fast-xml-parser` 5.7.0 pulled in. From `EntityDecoder.js` in [`nodable/val-parsers`](https://github.com/nodable/val-parsers):

```js
function validateEntityName(name) {
  if (name[0] === '#') {
    throw new Error(`[EntityReplacer] Invalid character '#' in entity name: "${name}"`);
  }
  // ...
}
```

There's no ambiguity about where the error comes from.

### 2. fast-xml-parser 5.7.0 explicitly broke numeric entity handling

From the [fast-xml-parser CHANGELOG](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CHANGELOG.md):

> **5.7.0 / 2026-04-17**
> - Use `@nodable/entities` v2.1.0
>   - breaking changes
>     - single entity scan. You're not allowed to use entity value to form another entity name.
>     - **you cant add numeric external entity**
>     - entity error message when expansion limit is crossed might change

Upgrading to `@nodable/entities` v2.1.0 introduced `validateEntityName()`, which explicitly blocks any entity name starting with `#`. XML hex numeric character references like `&#xD;` have `#xD` as their name — so they now throw. AWS STS XML responses legitimately contain these sequences (e.g. `&#xD;` = carriage return), which is why deserialization fails on a 200.

### 3. The identical error and stack trace has been confirmed in the wild

From [n8n issue #29350](https://github.com/n8n-io/n8n/issues/29350) — the same bug hit n8n's S3/IRSA integration:

> ```
> Error: [EntityReplacer] Invalid character '#' in entity name: "#xD"
>     at fast-xml-parser@5.7.0/lib/fxp.cjs
>     at de_AssumeRoleWithWebIdentityCommand (@aws-sdk/nested-clients/.../sts/index.js)
> ```

> "The HTTP status from AWS STS is **200** — STS replied successfully. The crash is purely on XML deserialization inside the AWS SDK."

Same library version, same error string, same STS/IRSA/HTTP-200 pattern we're seeing.

### 4. 5.7.2 explicitly reverses the breaking change

From the [fast-xml-parser CHANGELOG](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CHANGELOG.md):

> **5.7.2 / 2026-04-25**
> - **allow numerical external entity for backward compatibility**

Confirmed working in n8n:

> "version 2.19.5 has fast-xml-parser upgraded to 5.7.2, which also works. i've tested it and I don't see the error anymore"

---

## References

- [fast-xml-parser CHANGELOG](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CHANGELOG.md)
- [fast-xml-parser v5.7.2 release](https://github.com/NaturalIntelligence/fast-xml-parser/releases/tag/v5.7.2)
- [n8n issue #29350 — identical error, same IRSA/STS context](https://github.com/n8n-io/n8n/issues/29350)
- [AWS SDK JS v3 fast-xml-parser tracking issue](https://github.com/aws/aws-sdk-js-v3/issues/7366)
- [nodable/val-parsers — EntityDecoder.js source](https://github.com/nodable/val-parsers)

Fixes CN-1359