### PR TITLE
fix(deps): bump form-data override to 2.5.6 (SNYK-JS-FORMDATA-17337015)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6141,15 +6141,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -6548,9 +6548,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@kubernetes/client-node": {
       "ws": "^8.21.0",
       "tough-cookie": "4.1.3",
-      "form-data": "2.5.5",
+      "form-data": "2.5.6",
       "qs": "^6.15.2",
       "ajv": "8.18.0",
       "fast-uri": "^3.1.2"


### PR DESCRIPTION
## What

Bumps the scoped `form-data` override (under `@kubernetes/client-node`) from `2.5.5` → `2.5.6` to fix **SNYK-JS-FORMDATA-17337015** (CVE-2026-12143, CRLF injection). `@kubernetes/client-node` stays at `^0.22.3`.

## Why not the 1.0.0 upgrade?

The Snyk auto-fix PR proposed bumping `@kubernetes/client-node` to 1.0.0, but that's a major release with a completely redesigned API — it breaks kubernetes-monitor with 76 `tsc` errors across 16 files. That migration is a separate tracked effort.

The CVE is in the transitive `form-data` package. `staging` already had a scoped override pinning it to `2.5.5`, which is one patch release short of the fix.

## Verification

```
npm ls form-data
# └─┬ @kubernetes/client-node@0.22.3
#   └─┬ request@2.88.2
#     └── form-data@2.5.6 overridden
```

## Diff

- `package.json`: one line (`"form-data": "2.5.5"` → `"2.5.6"`)
- `package-lock.json`: lockfile update