### PR TITLE
feat: load custom registry certs from a Secret

### DIFF
--- a/snyk-monitor-deployment.yaml
+++ b/snyk-monitor-deployment.yaml
@@ -122,9 +122,14 @@ spec:
         emptyDir:
           sizeLimit: 50Gi
       - name: ssl-certs
-        configMap:
-          name: snyk-monitor-certs
-          optional: true
+        projected:
+          sources:
+          - configMap:
+              name: snyk-monitor-certs
+              optional: true
+          - secret:
+              name: snyk-monitor-certs
+              optional: true
       - name: registries-conf
         configMap:
           name: snyk-monitor-registries-conf

--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -105,9 +105,10 @@ Finally, create the secret in Kubernetes by running the following command:
 kubectl create secret generic snyk-monitor -n snyk-monitor --from-file=./dockercfg.json --from-literal=integrationId=abcd1234-abcd-1234-abcd-1234abcd1234 --from-literal=serviceAccountApiToken=aabb1212-abab-1212-dcba-4321abcd4321
 ```
 
-5. (Optional) If your private registry requires installing certificates (*.crt, *.cert, *.key only) please put them in a folder and create the following ConfigMap:
+5. (Optional) If your private registry requires installing certificates (_.crt,_.cert, *.key only) please put them in a folder and create the following Secret:
+
 ```shell
-kubectl create configmap snyk-monitor-certs -n snyk-monitor --from-file=<path_to_certs_folder>
+kubectl create secret tls snyk-monitor-certs -n snyk-monitor --cert=path/to/tls.crt --key=path/to/tls.key
 ```
 
 6. (Optional) If you are using an insecure registry or your registry is using unqualified images, you can provide a `registries.conf` file. See [the documentation](https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md) for information on the format and examples.

--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -105,10 +105,10 @@ Finally, create the secret in Kubernetes by running the following command:
 kubectl create secret generic snyk-monitor -n snyk-monitor --from-file=./dockercfg.json --from-literal=integrationId=abcd1234-abcd-1234-abcd-1234abcd1234 --from-literal=serviceAccountApiToken=aabb1212-abab-1212-dcba-4321abcd4321
 ```
 
-5. (Optional) If your private registry requires installing certificates (_.crt,_.cert, *.key only) please put them in a folder and create the following Secret:
+5. (Optional) If your private registry requires installing certificates (*.crt, *.cert, *.key only) please put them in a folder and create the following Secret:
 
 ```shell
-kubectl create secret tls snyk-monitor-certs -n snyk-monitor --cert=path/to/tls.crt --key=path/to/tls.key
+kubectl create secret generic snyk-monitor-certs -n snyk-monitor --from-file=<path_to_certs_folder>
 ```
 
 6. (Optional) If you are using an insecure registry or your registry is using unqualified images, you can provide a `registries.conf` file. See [the documentation](https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md) for information on the format and examples.

--- a/snyk-monitor/README.md
+++ b/snyk-monitor/README.md
@@ -111,6 +111,14 @@ kubectl create secret generic snyk-monitor -n snyk-monitor --from-file=./dockerc
 kubectl create secret generic snyk-monitor-certs -n snyk-monitor --from-file=<path_to_certs_folder>
 ```
 
+If you were already using a ConfigMap named `snyk-monitor-certs` for these certificates, delete it once the Secret exists:
+
+```shell
+kubectl delete configmap snyk-monitor-certs -n snyk-monitor
+```
+
+The monitor now mounts the certificates through a projected volume that merges the ConfigMap and the Secret into one directory, `/srv/app/certs`. A projected volume can't have two sources writing to the same file path. If the old ConfigMap and the new Secret both hold a file with the same name — likely, since you'd create both from the same cert folder — the kubelet refuses to mount the volume and the pod is stuck in `ContainerCreating`. Keep one or the other, not both.
+
 6. (Optional) If you are using an insecure registry or your registry is using unqualified images, you can provide a `registries.conf` file. See [the documentation](https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md) for information on the format and examples.
 
 Create a file named `registries.conf`, see example adding an insecure registry: 

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -283,8 +283,8 @@ spec:
             sizeLimit: {{ .Values.temporaryStorageSize }}
           {{- end }}
         - name: ssl-certs
-          configMap:
-            name: {{ .Values.certsConfigMap }}
+          secret:
+            secretName: {{ .Values.certsSecret }}
             optional: true
         - name: workload-policies
           configMap:

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -283,9 +283,14 @@ spec:
             sizeLimit: {{ .Values.temporaryStorageSize }}
           {{- end }}
         - name: ssl-certs
-          secret:
-            secretName: {{ .Values.certsSecret }}
-            optional: true
+          projected:
+            sources:
+            - configMap:
+                name: {{.Values.certsConfigMap}}
+                optional: true
+            - secret:
+                name: {{ .Values.certsSecret }}
+                optional: true
         - name: workload-policies
           configMap:
             {{- if .Values.workloadPoliciesMap }}

--- a/snyk-monitor/templates/deployment.yaml
+++ b/snyk-monitor/templates/deployment.yaml
@@ -286,7 +286,7 @@ spec:
           projected:
             sources:
             - configMap:
-                name: {{.Values.certsConfigMap}}
+                name: {{ .Values.certsConfigMap }}
                 optional: true
             - secret:
                 name: {{ .Values.certsSecret }}

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -5,7 +5,7 @@
 # The secrets should be created externally, before applying this Helm chart.
 # The currently used keys within the secret are: "dockercfg.json", "integrationId".
 monitorSecrets: snyk-monitor
-certsConfigMap: snyk-monitor-certs
+certsSecret: snyk-monitor-certs
 registriesConfConfigMap: snyk-monitor-registries-conf
 
 # An external ConfigMap to use for loading policies into snyk-monitor.

--- a/snyk-monitor/values.yaml
+++ b/snyk-monitor/values.yaml
@@ -6,6 +6,10 @@
 # The currently used keys within the secret are: "dockercfg.json", "integrationId".
 monitorSecrets: snyk-monitor
 certsSecret: snyk-monitor-certs
+
+# Deprecated, use the certsSecret instead
+certsConfigMap: snyk-monitor-certs
+
 registriesConfConfigMap: snyk-monitor-registries-conf
 
 # An external ConfigMap to use for loading policies into snyk-monitor.


### PR DESCRIPTION
- [ ] Tests written and linted
- [x] Documentation written
- [x] Commit history is tidy

### What this does

This continues #1585. Custom CA certificates for the monitor could only be installed through a ConfigMap. This change also accepts them from a Secret, so cert-manager or external-secrets can manage them. The `ssl-certs` volume becomes a projected volume mounting both the ConfigMap and the new Secret, both optional, so existing ConfigMap-based installs keep working after an upgrade. I also added a README note about deleting the old ConfigMap when migrating, because a projected volume can't have two sources writing to the same file path.

I opened this on the main repo because the required `PR_TO_STAGING` check runs on CircleCI, and CircleCI doesn't build pull requests from forks. The commits are the same ones from #1585, rebased onto current staging and signed to satisfy the branch's signed-commits rule. 

### Notes for the reviewer

The original review and discussion are on #1585. The main thing to confirm is backward compatibility: an existing install that mounts certs from the `snyk-monitor-certs` ConfigMap keeps working after this upgrade, because the projected volume still mounts that ConfigMap (optional) next to the new Secret. No application code changed. It's the Helm chart and docs only.

### Screenshots

N/A