### PR TITLE
chore: bump snyk-docker-plugin to 9.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "packageurl-js": "^1.2.1",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.3.0",
-        "snyk-docker-plugin": "^9.6.5",
+        "snyk-docker-plugin": "^9.18.0",
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "4.9.5",
@@ -2309,14 +2309,18 @@
       "license": "MIT"
     },
     "node_modules/@snyk/docker-registry-v2-client": {
-      "version": "2.24.4",
-      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.24.4.tgz",
-      "integrity": "sha512-adh3YNMBOF5Iqi7Nc9D49pIQMB9zxX9Q995PJIhXUa/WgVmUMLTZSFgS6M72G89XXk7UYrJOyHDD3zgKaeqPRQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-4.0.5.tgz",
+      "integrity": "sha512-/2IKc4zpWPU3qc+5l5Pn52ayGST6ome1DxSPI/mBe0hISiGF3mGB5BWLomAsF7jw9gCaXElQb80nBX+7RhdUsg==",
       "license": "Apache-2.0",
       "dependencies": {
         "needle": "^3.5.0",
         "parse-link-header": "^2.0.0",
+        "psl": "^1.15.0",
         "tslib": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=16.20"
       }
     },
     "node_modules/@snyk/docker-registry-v2-client/node_modules/tslib": {
@@ -9236,16 +9240,16 @@
       }
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.7.0.tgz",
-      "integrity": "sha512-DsfbmfPJzWars4VyCI4WcMkwdn5nV6YkYW5W0aRO3xeBVvJnWsVQFuVE/e58W2Wo9igMXHO+4V8oWQRe0Q1D2g==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.18.0.tgz",
+      "integrity": "sha512-nc0IzCs82FEFV4y6FIF8aMk8RCbuWvNoqnaBbpZ8qFH3ntZzMsRDzUfsWiT7/pUp9rL/s7GVDJUYfy+0NiFPmg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.12.1",
-        "@snyk/docker-registry-v2-client": "^2.24.2",
+        "@snyk/docker-registry-v2-client": "^4.0.2",
         "@snyk/rpm-parser": "^3.4.1",
-        "@snyk/snyk-docker-pull": "^3.15.1",
+        "@snyk/snyk-docker-pull": "^3.16.0",
         "@swimlane/docker-reference": "^2.0.1",
         "adm-zip": "^0.5.17",
         "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "packageurl-js": "^1.2.1",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.3.0",
-    "snyk-docker-plugin": "^9.6.5",
+    "snyk-docker-plugin": "^9.18.0",
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "4.9.5",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests) — N/A (dependency + lockfile bump only, no source changes)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation) — N/A
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Bumps `snyk-docker-plugin` from `^9.6.5` to `9.18.0`. 9.18.0 adds container-image provenance-attestation extraction.

### Notes for the reviewer

- Dependency + lockfile bump only — no source/behavior changes in this repo.

### Screenshots

N/A — dependency bump only.