### PR TITLE
fix(deps): upgrade @kubernetes/client-node to 1.4.0 [CN-1539]

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,11 @@ module.exports = {
   clearMocks: true,
   errorOnDeprecated: true,
 
+  moduleNameMapper: {
+    '^@kubernetes/client-node$':
+      '<rootDir>/test/helpers/kubernetes-client-node-bridge.js',
+  },
+
   // This is here until a bug in Jest (which in turn affects ts-jest) is resolved.
   // It affects our CI/CD runs and makes the machine run out of memory.
   // https://github.com/facebook/jest/issues/10550

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "private",
       "dependencies": {
         "@aws-sdk/client-ecr": "^3.1077.0",
-        "@kubernetes/client-node": "^0.22.3",
+        "@kubernetes/client-node": "^1.4.0",
         "@snyk/dep-graph": "^2.16.9",
         "async": "^3.2.6",
         "bunyan": "^1.8.15",
@@ -1943,25 +1943,43 @@
       }
     },
     "node_modules/@kubernetes/client-node": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.22.3.tgz",
-      "integrity": "sha512-dG8uah3+HDJLpJEESshLRZlAZ4PgDeV9mZXT0u1g7oy4KMRzdZ7n5g0JEIlL6QhK51/2ztcIqURAnjfjJt6Z+g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.4.0.tgz",
+      "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "byline": "^5.0.0",
+        "@types/js-yaml": "^4.0.1",
+        "@types/node": "^24.0.0",
+        "@types/node-fetch": "^2.6.13",
+        "@types/stream-buffers": "^3.0.3",
+        "form-data": "^4.0.0",
+        "hpagent": "^1.2.0",
         "isomorphic-ws": "^5.0.0",
         "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^10.2.0",
-        "request": "^2.88.0",
+        "jsonpath-plus": "^10.3.0",
+        "node-fetch": "^2.7.0",
+        "openid-client": "^6.1.3",
         "rfc4648": "^1.3.0",
+        "socks-proxy-agent": "^8.0.4",
         "stream-buffers": "^3.0.2",
-        "tar": "^7.0.0",
-        "tslib": "^2.4.1",
-        "ws": "^8.18.0"
-      },
-      "optionalDependencies": {
-        "openid-client": "^6.1.3"
+        "tar-fs": "^3.0.9",
+        "ws": "^8.18.2"
       }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2511,6 +2529,12 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2558,6 +2582,16 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
@@ -2587,6 +2621,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "node_modules/@types/stream-buffers": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/stream-buffers/-/stream-buffers-3.0.8.tgz",
+      "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/treeify": {
       "version": "1.0.3",
@@ -3029,6 +3072,15 @@
         "node": ">=12.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -3179,15 +3231,6 @@
         "safer-buffer": "~2.1.0"
       }
     },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -3206,21 +3249,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "license": "MIT"
     },
     "node_modules/b4a": {
@@ -3656,15 +3684,6 @@
         "safe-json-stringify": "~1"
       }
     },
-    "node_modules/byline": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
@@ -3730,22 +3749,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3782,12 +3785,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
     },
     "node_modules/chalk": {
       "version": "5.4.1",
@@ -4109,18 +4106,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4402,16 +4387,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/ejs": {
@@ -4995,21 +4970,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fadge": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/fadge/-/fadge-0.0.1.tgz",
@@ -5067,7 +5027,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -5099,7 +5060,8 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -5211,30 +5173,20 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/form-data": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
-      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
         "hasown": "^2.0.4",
-        "mime-types": "^2.1.35",
-        "safe-buffer": "^5.2.1"
+        "mime-types": "^2.1.35"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
       }
     },
     "node_modules/from": {
@@ -5376,15 +5328,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
       }
     },
     "node_modules/git-raw-commits": {
@@ -5550,51 +5493,6 @@
         "gunzip-maybe": "bin.js"
       }
     },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/har-validator/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/har-validator/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5673,21 +5571,6 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
@@ -5848,6 +5731,15 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -5969,12 +5861,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -5992,12 +5878,6 @@
       "peerDependencies": {
         "ws": "*"
       }
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -7237,7 +7117,6 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
       "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -7259,12 +7138,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
     },
     "node_modules/jsep": {
       "version": "1.4.0",
@@ -7297,12 +7170,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -7318,7 +7185,8 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7383,21 +7251,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/keyv": {
@@ -7999,6 +7852,26 @@
       "integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -8052,20 +7925,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/oauth4webapi": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.5.1.tgz",
       "integrity": "sha512-txg/jZQwcbaF7PMJgY7aoxc9QuCxHVFMiEkDIJ60DwDz3PbtXPQnrzo+3X4IRYGChIwWLabRBRpf1k9hO9+xrQ==",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -8076,18 +7939,6 @@
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/once": {
@@ -8117,7 +7968,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.5.0.tgz",
       "integrity": "sha512-fAfYaTnOYE2kQCqEJGX9KDObW2aw7IQy4jWpU/+3D3WoCFLbix5Hg6qIPQ6Js9r7f8jDUmsnnguRNCSw4wU/IQ==",
-      "optional": true,
       "dependencies": {
         "jose": "^6.0.10",
         "oauth4webapi": "^3.5.1"
@@ -8349,12 +8199,6 @@
         "duplexify": "^3.5.0",
         "through2": "^2.0.3"
       }
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8674,28 +8518,6 @@
         }
       ]
     },
-    "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "license": "MIT"
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -8758,48 +8580,6 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8817,12 +8597,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -9047,78 +8821,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/side-channel": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
-      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4",
-        "side-channel-list": "^1.0.1",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -9160,6 +8862,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/snyk-config": {
@@ -9425,6 +9137,34 @@
         "npm-tree": "lib/index.js"
       }
     },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -9494,31 +9234,6 @@
       "optionalDependencies": {
         "cpu-features": "~0.0.10",
         "nan": "^2.20.0"
-      }
-    },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stack-utils": {
@@ -9913,29 +9628,11 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/treeify": {
       "version": "1.1.0",
@@ -10118,18 +9815,6 @@
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -10248,19 +9933,10 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -10312,20 +9988,6 @@
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
@@ -10345,6 +10007,22 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-ecr": "^3.1077.0",
-    "@kubernetes/client-node": "^0.22.3",
+    "@kubernetes/client-node": "^1.4.0",
     "@snyk/dep-graph": "^2.16.9",
     "async": "^3.2.6",
     "bunyan": "^1.8.15",
@@ -97,14 +97,6 @@
   "overrides": {
     "@yarnpkg/parsers": {
       "js-yaml": "^3.15.0"
-    },
-    "@kubernetes/client-node": {
-      "ws": "^8.21.0",
-      "tough-cookie": "4.1.3",
-      "form-data": "2.5.6",
-      "qs": "^6.15.2",
-      "ajv": "8.18.0",
-      "fast-uri": "^3.1.4"
     },
     "cross-spawn": "^7.0.5",
     "jsonpath-plus": "10.3.0",

--- a/src/supervisor/agent.ts
+++ b/src/supervisor/agent.ts
@@ -21,10 +21,10 @@ async function getSnykMonitorDeploymentUid(
 ): Promise<string | undefined> {
   try {
     const attemptedApiCall = await retryKubernetesApiRequestIndefinitely(
-      () => k8sApi.appsClient.readNamespacedDeployment(name, namespace),
+      () => k8sApi.appsClient.readNamespacedDeployment({ name, namespace }),
       config.MAX_RETRY_BACKOFF_DURATION_SECONDS,
     );
-    return attemptedApiCall.body.metadata?.uid;
+    return attemptedApiCall.metadata?.uid;
   } catch (error) {
     logger.error(
       { error, namespace, deploymentName: name },

--- a/src/supervisor/kuberenetes-api-wrappers.ts
+++ b/src/supervisor/kuberenetes-api-wrappers.ts
@@ -1,5 +1,4 @@
 import * as fastq from 'fastq';
-import * as http from 'http';
 import sleep from 'sleep-promise';
 import { config } from '../common/config';
 
@@ -35,7 +34,7 @@ export async function retryKubernetesApiRequest<ResponseType>(
         throw err;
       }
 
-      const sleepSeconds = calculateSleepSeconds(err.response);
+      const sleepSeconds = calculateSleepSeconds(err);
       await sleep(sleepSeconds * 1000);
     }
   }
@@ -79,17 +78,13 @@ export async function retryKubernetesApiRequestIndefinitely<ResponseType>(
   }
 }
 
-export function calculateSleepSeconds(
-  httpResponse?: http.IncomingMessage,
-): number {
+export function calculateSleepSeconds(err?: IRequestError): number {
   let sleepSeconds = DEFAULT_SLEEP_SEC;
-  if (
-    httpResponse &&
-    httpResponse.headers &&
-    httpResponse.headers['Retry-After']
-  ) {
+  const retryAfter =
+    err?.headers?.['retry-after'] ?? err?.headers?.['Retry-After'];
+  if (retryAfter) {
     try {
-      sleepSeconds = Number(httpResponse.headers['Retry-After']);
+      sleepSeconds = Number(retryAfter);
       if (isNaN(sleepSeconds) || sleepSeconds <= 0) {
         sleepSeconds = DEFAULT_SLEEP_SEC;
       }
@@ -105,7 +100,10 @@ function shouldRetryRequest(err: IRequestError, attempt: number): boolean {
     return false;
   }
 
-  if (err.code && RETRYABLE_NETWORK_ERROR_CODES.includes(err.code)) {
+  if (
+    typeof err.code === 'string' &&
+    RETRYABLE_NETWORK_ERROR_CODES.includes(err.code)
+  ) {
     return true;
   }
 
@@ -113,13 +111,5 @@ function shouldRetryRequest(err: IRequestError, attempt: number): boolean {
     return true;
   }
 
-  if (!err.response) {
-    return false;
-  }
-
-  if (err.response.statusCode === 429) {
-    return true;
-  }
-
-  return false;
+  return err.code === 429;
 }

--- a/src/supervisor/metadata-extractor.ts
+++ b/src/supervisor/metadata-extractor.ts
@@ -11,7 +11,7 @@ import { getSupportedWorkload, getWorkloadReader } from './workload-reader';
 import { logger } from '../common/logger';
 import { config } from '../common/config';
 
-import type { IKubeObjectMetadata } from './types';
+import type { IKubeObjectMetadata, IRequestError } from './types';
 import type { IWorkload, ILocalWorkloadLocator } from '../transmitter/types';
 
 const loopingThreshold = 20;
@@ -108,7 +108,7 @@ async function findParentWorkload(
       parentMetadata = { ...workloadMetadata, podSpec };
       ownerReferences = parentMetadata.ownerRefs;
     } catch (err: any) {
-      if (err?.response?.body?.code === 404) {
+      if ((err as IRequestError)?.code === 404) {
         logger.info(
           {
             supportedWorkloadName: supportedWorkload.name,

--- a/src/supervisor/types.ts
+++ b/src/supervisor/types.ts
@@ -1,11 +1,9 @@
-import { IncomingMessage } from 'http';
 import {
   AppsV1Api,
   BatchV1Api,
   CoreV1Api,
   CustomObjectsApi,
   KubeConfig,
-  V1Namespace,
   V1ObjectMeta,
   V1OwnerReference,
   V1PodSpec,
@@ -26,8 +24,9 @@ export enum WorkloadKind {
 
 export interface IRequestError {
   message?: string;
-  code?: string;
-  response?: IncomingMessage;
+  code?: string | number;
+  body?: unknown;
+  headers?: { [key: string]: string };
 }
 
 export interface IKubeObjectMetadata {
@@ -64,9 +63,4 @@ export class K8sClients implements IK8sClients {
     this.batchClient = config.makeApiClient(BatchV1Api);
     this.customObjectsClient = config.makeApiClient(CustomObjectsApi);
   }
-}
-
-export interface NamespaceResponse {
-  response: IncomingMessage;
-  body: V1Namespace;
 }

--- a/src/supervisor/watchers/handlers/argo-rollout.ts
+++ b/src/supervisor/watchers/handlers/argo-rollout.ts
@@ -1,4 +1,3 @@
-import { IncomingMessage } from 'http';
 import { deleteWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import {
@@ -20,10 +19,7 @@ import { trimWorkload } from '../../workload-sanitization';
 
 export async function paginatedNamespacedArgoRolloutList(
   namespace: string,
-): Promise<{
-  response: IncomingMessage;
-  body: V1alpha1RolloutList;
-}> {
+): Promise<V1alpha1RolloutList> {
   const rolloutList = new V1alpha1RolloutList();
   rolloutList.apiVersion = 'argoproj.io/v1alpha1';
   rolloutList.kind = 'RolloutList';
@@ -32,43 +28,19 @@ export async function paginatedNamespacedArgoRolloutList(
   return await paginatedNamespacedList(
     namespace,
     rolloutList,
-    async (
-      namespace: string,
-      pretty?: string,
-      _allowWatchBookmarks?: boolean,
-      _continue?: string,
-      fieldSelector?: string,
-      labelSelector?: string,
-      limit?: number,
-    ) =>
-      k8sApi.customObjectsClient.listNamespacedCustomObject(
-        'argoproj.io',
-        'v1alpha1',
-        namespace,
-        'rollouts',
-        pretty,
-        false,
-        _continue,
-        fieldSelector,
-        labelSelector,
-        limit,
-        /**
-         * The K8s client's listNamespacedCustomObject() doesn't allow to specify
-         * the type of the response body and returns the generic "object" type,
-         * but with how we declared our types we expect it to return a "KubernetesListObject" type.
-         *
-         * Not using "any" results in a similar error (highlighting the "body" property):
-         * Type 'Promise<{ response: IncomingMessage; ***body: object;*** }>' is not assignable to type
-         * 'Promise<{ response: IncomingMessage; ***body: KubernetesListObject<...>;*** }>'
-         */
-      ) as any,
+    (args) =>
+      k8sApi.customObjectsClient.listNamespacedCustomObject({
+        group: 'argoproj.io',
+        version: 'v1alpha1',
+        plural: 'rollouts',
+        namespace: args.namespace,
+        _continue: args._continue,
+        limit: args.limit,
+      }) as unknown as Promise<V1alpha1RolloutList>,
   );
 }
 
-export async function paginatedClusterArgoRolloutList(): Promise<{
-  response: IncomingMessage;
-  body: V1alpha1RolloutList;
-}> {
+export async function paginatedClusterArgoRolloutList(): Promise<V1alpha1RolloutList> {
   const rolloutList = new V1alpha1RolloutList();
   rolloutList.apiVersion = 'argoproj.io/v1';
   rolloutList.kind = 'RolloutList';
@@ -76,25 +48,14 @@ export async function paginatedClusterArgoRolloutList(): Promise<{
 
   return await paginatedClusterList(
     rolloutList,
-    async (
-      _allowWatchBookmarks?: boolean,
-      _continue?: string,
-      fieldSelector?: string,
-      labelSelector?: string,
-      limit?: number,
-      pretty?: string,
-    ) =>
-      k8sApi.customObjectsClient.listClusterCustomObject(
-        'argoproj.io',
-        'v1alpha1',
-        'rollouts',
-        pretty,
-        false,
-        _continue,
-        fieldSelector,
-        labelSelector,
-        limit,
-      ) as any,
+    (args) =>
+      k8sApi.customObjectsClient.listClusterCustomObject({
+        group: 'argoproj.io',
+        version: 'v1alpha1',
+        plural: 'rollouts',
+        _continue: args._continue,
+        limit: args.limit,
+      }) as unknown as Promise<V1alpha1RolloutList>,
   );
 }
 
@@ -109,23 +70,32 @@ export async function argoRolloutWatchHandler(
       // Perform lookup for known supported kinds: https://github.com/argoproj/argo-rollouts/blob/master/rollout/templateref.go#L40-L52
       case 'Deployment': {
         const deployResult = await retryKubernetesApiRequest(() =>
-          k8sApi.appsClient.readNamespacedDeployment(workloadName, namespace),
+          k8sApi.appsClient.readNamespacedDeployment({
+            name: workloadName,
+            namespace,
+          }),
         );
-        rollout.spec.template = deployResult.body.spec?.template;
+        rollout.spec.template = deployResult.spec?.template;
         break;
       }
       case 'ReplicaSet': {
         const replicaSetResult = await retryKubernetesApiRequest(() =>
-          k8sApi.appsClient.readNamespacedReplicaSet(workloadName, namespace),
+          k8sApi.appsClient.readNamespacedReplicaSet({
+            name: workloadName,
+            namespace,
+          }),
         );
-        rollout.spec.template = replicaSetResult.body.spec?.template;
+        rollout.spec.template = replicaSetResult.spec?.template;
         break;
       }
       case 'PodTemplate': {
         const podTemplateResult = await retryKubernetesApiRequest(() =>
-          k8sApi.coreClient.readNamespacedPodTemplate(workloadName, namespace),
+          k8sApi.coreClient.readNamespacedPodTemplate({
+            name: workloadName,
+            namespace,
+          }),
         );
-        rollout.spec.template = podTemplateResult.body.template;
+        rollout.spec.template = podTemplateResult.template;
         break;
       }
       default:
@@ -178,37 +148,17 @@ export async function isNamespacedArgoRolloutSupported(
   namespace: string,
 ): Promise<boolean> {
   try {
-    const pretty = undefined;
-    const continueToken = undefined;
-    const fieldSelector = undefined;
-    const labelSelector = undefined;
-    const limit = 1; // Try to grab only a single object
-    const resourceVersion = undefined; // List anything in the cluster
-    const timeoutSeconds = 10; // Don't block the snyk-monitor indefinitely
-    const attemptedApiCall = await retryKubernetesApiRequest(() =>
-      k8sApi.customObjectsClient.listNamespacedCustomObject(
-        'argoproj.io',
-        'v1alpha1',
+    await retryKubernetesApiRequest(() =>
+      k8sApi.customObjectsClient.listNamespacedCustomObject({
+        group: 'argoproj.io',
+        version: 'v1alpha1',
         namespace,
-        'rollouts',
-        pretty,
-        false,
-        continueToken,
-        fieldSelector,
-        labelSelector,
-        limit,
-        resourceVersion,
-        undefined,
-        timeoutSeconds,
-      ),
+        plural: 'rollouts',
+        limit: 1, // Try to grab only a single object
+        timeoutSeconds: 10, // Don't block the snyk-monitor indefinitely
+      }),
     );
-    return (
-      attemptedApiCall !== undefined &&
-      attemptedApiCall.response !== undefined &&
-      attemptedApiCall.response.statusCode !== undefined &&
-      attemptedApiCall.response.statusCode >= 200 &&
-      attemptedApiCall.response.statusCode < 300
-    );
+    return true;
   } catch (error) {
     logger.debug(
       { error, workloadKind: WorkloadKind.ArgoRollout },
@@ -220,36 +170,16 @@ export async function isNamespacedArgoRolloutSupported(
 
 export async function isClusterArgoRolloutSupported(): Promise<boolean> {
   try {
-    const pretty = undefined;
-    const continueToken = undefined;
-    const fieldSelector = undefined;
-    const labelSelector = undefined;
-    const limit = 1; // Try to grab only a single object
-    const resourceVersion = undefined; // List anything in the cluster
-    const timeoutSeconds = 10; // Don't block the snyk-monitor indefinitely
-    const attemptedApiCall = await retryKubernetesApiRequest(() =>
-      k8sApi.customObjectsClient.listClusterCustomObject(
-        'argoproj.io',
-        'v1alpha1',
-        'rollouts',
-        pretty,
-        false,
-        continueToken,
-        fieldSelector,
-        labelSelector,
-        limit,
-        resourceVersion,
-        undefined,
-        timeoutSeconds,
-      ),
+    await retryKubernetesApiRequest(() =>
+      k8sApi.customObjectsClient.listClusterCustomObject({
+        group: 'argoproj.io',
+        version: 'v1alpha1',
+        plural: 'rollouts',
+        limit: 1, // Try to grab only a single object
+        timeoutSeconds: 10, // Don't block the snyk-monitor indefinitely
+      }),
     );
-    return (
-      attemptedApiCall !== undefined &&
-      attemptedApiCall.response !== undefined &&
-      attemptedApiCall.response.statusCode !== undefined &&
-      attemptedApiCall.response.statusCode >= 200 &&
-      attemptedApiCall.response.statusCode < 300
-    );
+    return true;
   } catch (error) {
     logger.debug(
       { error, workloadKind: WorkloadKind.ArgoRollout },

--- a/src/supervisor/watchers/handlers/cron-job.ts
+++ b/src/supervisor/watchers/handlers/cron-job.ts
@@ -2,7 +2,6 @@ import { V1CronJob, V1CronJobList } from '@kubernetes/client-node';
 import { deleteWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
-import { IncomingMessage } from 'http';
 import { k8sApi } from '../../cluster';
 import { paginatedClusterList, paginatedNamespacedList } from './pagination';
 import {
@@ -15,10 +14,7 @@ import { deleteWorkloadFromScanQueue } from './queue';
 
 export async function paginatedNamespacedCronJobList(
   namespace: string,
-): Promise<{
-  response: IncomingMessage;
-  body: V1CronJobList;
-}> {
+): Promise<V1CronJobList> {
   const v1CronJobList = new V1CronJobList();
   v1CronJobList.apiVersion = 'batch/v1';
   v1CronJobList.kind = 'CronJobList';
@@ -31,10 +27,7 @@ export async function paginatedNamespacedCronJobList(
   );
 }
 
-export async function paginatedClusterCronJobList(): Promise<{
-  response: IncomingMessage;
-  body: V1CronJobList;
-}> {
+export async function paginatedClusterCronJobList(): Promise<V1CronJobList> {
   const v1CronJobList = new V1CronJobList();
   v1CronJobList.apiVersion = 'batch/v1';
   v1CronJobList.kind = 'CronJobList';

--- a/src/supervisor/watchers/handlers/daemon-set.ts
+++ b/src/supervisor/watchers/handlers/daemon-set.ts
@@ -2,7 +2,6 @@ import { V1DaemonSet, V1DaemonSetList } from '@kubernetes/client-node';
 import { deleteWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
-import { IncomingMessage } from 'http';
 import { k8sApi } from '../../cluster';
 import { paginatedClusterList, paginatedNamespacedList } from './pagination';
 import {
@@ -15,10 +14,7 @@ import { deleteWorkloadFromScanQueue } from './queue';
 
 export async function paginatedNamespacedDaemonSetList(
   namespace: string,
-): Promise<{
-  response: IncomingMessage;
-  body: V1DaemonSetList;
-}> {
+): Promise<V1DaemonSetList> {
   const v1DaemonSetList = new V1DaemonSetList();
   v1DaemonSetList.apiVersion = 'apps/v1';
   v1DaemonSetList.kind = 'DaemonSetList';
@@ -31,10 +27,7 @@ export async function paginatedNamespacedDaemonSetList(
   );
 }
 
-export async function paginatedClusterDaemonSetList(): Promise<{
-  response: IncomingMessage;
-  body: V1DaemonSetList;
-}> {
+export async function paginatedClusterDaemonSetList(): Promise<V1DaemonSetList> {
   const v1DaemonSetList = new V1DaemonSetList();
   v1DaemonSetList.apiVersion = 'apps/v1';
   v1DaemonSetList.kind = 'DaemonSetList';

--- a/src/supervisor/watchers/handlers/deployment-config.ts
+++ b/src/supervisor/watchers/handlers/deployment-config.ts
@@ -1,4 +1,3 @@
-import { IncomingMessage } from 'http';
 import { deleteWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import {
@@ -20,10 +19,7 @@ import { trimWorkload } from '../../workload-sanitization';
 
 export async function paginatedNamespacedDeploymentConfigList(
   namespace: string,
-): Promise<{
-  response: IncomingMessage;
-  body: V1DeploymentConfigList;
-}> {
+): Promise<V1DeploymentConfigList> {
   const v1DeploymentConfigList = new V1DeploymentConfigList();
   v1DeploymentConfigList.apiVersion = 'apps.openshift.io/v1';
   v1DeploymentConfigList.kind = 'DeploymentConfigList';
@@ -32,43 +28,19 @@ export async function paginatedNamespacedDeploymentConfigList(
   return await paginatedNamespacedList(
     namespace,
     v1DeploymentConfigList,
-    async (
-      namespace: string,
-      pretty?: string,
-      _allowWatchBookmarks?: boolean,
-      _continue?: string,
-      fieldSelector?: string,
-      labelSelector?: string,
-      limit?: number,
-    ) =>
-      k8sApi.customObjectsClient.listNamespacedCustomObject(
-        'apps.openshift.io',
-        'v1',
-        namespace,
-        'deploymentconfigs',
-        pretty,
-        false,
-        _continue,
-        fieldSelector,
-        labelSelector,
-        limit,
-        /**
-         * The K8s client's listNamespacedCustomObject() doesn't allow to specify
-         * the type of the response body and returns the generic "object" type,
-         * but with how we declared our types we expect it to return a "KubernetesListObject" type.
-         *
-         * Not using "any" results in a similar error (highlighting the "body" property):
-         * Type 'Promise<{ response: IncomingMessage; ***body: object;*** }>' is not assignable to type
-         * 'Promise<{ response: IncomingMessage; ***body: KubernetesListObject<...>;*** }>'
-         */
-      ) as any,
+    (args) =>
+      k8sApi.customObjectsClient.listNamespacedCustomObject({
+        group: 'apps.openshift.io',
+        version: 'v1',
+        plural: 'deploymentconfigs',
+        namespace: args.namespace,
+        _continue: args._continue,
+        limit: args.limit,
+      }) as unknown as Promise<V1DeploymentConfigList>,
   );
 }
 
-export async function paginatedClusterDeploymentConfigList(): Promise<{
-  response: IncomingMessage;
-  body: V1DeploymentConfigList;
-}> {
+export async function paginatedClusterDeploymentConfigList(): Promise<V1DeploymentConfigList> {
   const v1DeploymentConfigList = new V1DeploymentConfigList();
   v1DeploymentConfigList.apiVersion = 'apps.openshift.io/v1';
   v1DeploymentConfigList.kind = 'DeploymentConfigList';
@@ -76,25 +48,14 @@ export async function paginatedClusterDeploymentConfigList(): Promise<{
 
   return await paginatedClusterList(
     v1DeploymentConfigList,
-    async (
-      _allowWatchBookmarks?: boolean,
-      _continue?: string,
-      fieldSelector?: string,
-      labelSelector?: string,
-      limit?: number,
-      pretty?: string,
-    ) =>
-      k8sApi.customObjectsClient.listClusterCustomObject(
-        'apps.openshift.io',
-        'v1',
-        'deploymentconfigs',
-        pretty,
-        false,
-        _continue,
-        fieldSelector,
-        labelSelector,
-        limit,
-      ) as any,
+    (args) =>
+      k8sApi.customObjectsClient.listClusterCustomObject({
+        group: 'apps.openshift.io',
+        version: 'v1',
+        plural: 'deploymentconfigs',
+        _continue: args._continue,
+        limit: args.limit,
+      }) as unknown as Promise<V1DeploymentConfigList>,
   );
 }
 
@@ -146,37 +107,17 @@ export async function isNamespacedDeploymentConfigSupported(
   namespace: string,
 ): Promise<boolean> {
   try {
-    const pretty = undefined;
-    const continueToken = undefined;
-    const fieldSelector = undefined;
-    const labelSelector = undefined;
-    const limit = 1; // Try to grab only a single object
-    const resourceVersion = undefined; // List anything in the cluster
-    const timeoutSeconds = 10; // Don't block the snyk-monitor indefinitely
-    const attemptedApiCall = await retryKubernetesApiRequest(() =>
-      k8sApi.customObjectsClient.listNamespacedCustomObject(
-        'apps.openshift.io',
-        'v1',
+    await retryKubernetesApiRequest(() =>
+      k8sApi.customObjectsClient.listNamespacedCustomObject({
+        group: 'apps.openshift.io',
+        version: 'v1',
         namespace,
-        'deploymentconfigs',
-        pretty,
-        false,
-        continueToken,
-        fieldSelector,
-        labelSelector,
-        limit,
-        resourceVersion,
-        undefined,
-        timeoutSeconds,
-      ),
+        plural: 'deploymentconfigs',
+        limit: 1, // Try to grab only a single object
+        timeoutSeconds: 10, // Don't block the snyk-monitor indefinitely
+      }),
     );
-    return (
-      attemptedApiCall !== undefined &&
-      attemptedApiCall.response !== undefined &&
-      attemptedApiCall.response.statusCode !== undefined &&
-      attemptedApiCall.response.statusCode >= 200 &&
-      attemptedApiCall.response.statusCode < 300
-    );
+    return true;
   } catch (error) {
     logger.debug(
       { error, workloadKind: WorkloadKind.DeploymentConfig },
@@ -188,36 +129,16 @@ export async function isNamespacedDeploymentConfigSupported(
 
 export async function isClusterDeploymentConfigSupported(): Promise<boolean> {
   try {
-    const pretty = undefined;
-    const continueToken = undefined;
-    const fieldSelector = undefined;
-    const labelSelector = undefined;
-    const limit = 1; // Try to grab only a single object
-    const resourceVersion = undefined; // List anything in the cluster
-    const timeoutSeconds = 10; // Don't block the snyk-monitor indefinitely
-    const attemptedApiCall = await retryKubernetesApiRequest(() =>
-      k8sApi.customObjectsClient.listClusterCustomObject(
-        'apps.openshift.io',
-        'v1',
-        'deploymentconfigs',
-        pretty,
-        false,
-        continueToken,
-        fieldSelector,
-        labelSelector,
-        limit,
-        resourceVersion,
-        undefined,
-        timeoutSeconds,
-      ),
+    await retryKubernetesApiRequest(() =>
+      k8sApi.customObjectsClient.listClusterCustomObject({
+        group: 'apps.openshift.io',
+        version: 'v1',
+        plural: 'deploymentconfigs',
+        limit: 1, // Try to grab only a single object
+        timeoutSeconds: 10, // Don't block the snyk-monitor indefinitely
+      }),
     );
-    return (
-      attemptedApiCall !== undefined &&
-      attemptedApiCall.response !== undefined &&
-      attemptedApiCall.response.statusCode !== undefined &&
-      attemptedApiCall.response.statusCode >= 200 &&
-      attemptedApiCall.response.statusCode < 300
-    );
+    return true;
   } catch (error) {
     logger.debug(
       { error, workloadKind: WorkloadKind.DeploymentConfig },

--- a/src/supervisor/watchers/handlers/deployment.ts
+++ b/src/supervisor/watchers/handlers/deployment.ts
@@ -2,7 +2,6 @@ import { V1Deployment, V1DeploymentList } from '@kubernetes/client-node';
 import { deleteWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
-import { IncomingMessage } from 'http';
 import { k8sApi } from '../../cluster';
 import { paginatedClusterList, paginatedNamespacedList } from './pagination';
 import {
@@ -15,10 +14,7 @@ import { deleteWorkloadFromScanQueue } from './queue';
 
 export async function paginatedNamespacedDeploymentList(
   namespace: string,
-): Promise<{
-  response: IncomingMessage;
-  body: V1DeploymentList;
-}> {
+): Promise<V1DeploymentList> {
   const v1DeploymentList = new V1DeploymentList();
   v1DeploymentList.apiVersion = 'apps/v1';
   v1DeploymentList.kind = 'DeploymentList';
@@ -31,10 +27,7 @@ export async function paginatedNamespacedDeploymentList(
   );
 }
 
-export async function paginatedClusterDeploymentList(): Promise<{
-  response: IncomingMessage;
-  body: V1DeploymentList;
-}> {
+export async function paginatedClusterDeploymentList(): Promise<V1DeploymentList> {
   const v1DeploymentList = new V1DeploymentList();
   v1DeploymentList.apiVersion = 'apps/v1';
   v1DeploymentList.kind = 'DeploymentList';

--- a/src/supervisor/watchers/handlers/error.ts
+++ b/src/supervisor/watchers/handlers/error.ts
@@ -7,6 +7,16 @@ import {
 
 type InformerError = Partial<{ code: string | number; message: string }>;
 
+// The 1.x client refuses plain-HTTP API servers at request-creation time,
+// e.g. KubeConfig.loadFromDefault()'s http://localhost:8080 fallback when no
+// kubeconfig exists. The 0.x client sent the request and failed with the
+// retryable ECONNREFUSED, so the informer kept restarting and its retry timer
+// kept the process alive (everything else on the event loop is unref'd).
+// Restart on this error too to preserve that liveness behavior.
+const RESTARTABLE_CLIENT_CONFIG_ERROR_MESSAGES: readonly string[] = [
+  'HTTP protocol is not allowed when skipTLSVerify is not set or false',
+];
+
 export function restartableErrorHandler(
   informer: Informer<KubernetesObject>,
   logContext: Record<string, unknown>,
@@ -17,7 +27,8 @@ export function restartableErrorHandler(
     logContext.code = error.code ?? '';
     if (
       RETRYABLE_NETWORK_ERROR_CODES.includes(code) ||
-      RETRYABLE_NETWORK_ERROR_MESSAGES.includes(message)
+      RETRYABLE_NETWORK_ERROR_MESSAGES.includes(message) ||
+      RESTARTABLE_CLIENT_CONFIG_ERROR_MESSAGES.includes(message)
     ) {
       logger.debug(logContext, 'informer error occurred, restarting informer');
 

--- a/src/supervisor/watchers/handlers/error.ts
+++ b/src/supervisor/watchers/handlers/error.ts
@@ -5,16 +5,16 @@ import {
   RETRYABLE_NETWORK_ERROR_MESSAGES,
 } from '../types';
 
-type InformerError = Partial<{ code: string; message: string }>;
+type InformerError = Partial<{ code: string | number; message: string }>;
 
 export function restartableErrorHandler(
   informer: Informer<KubernetesObject>,
   logContext: Record<string, unknown>,
 ) {
   return function handler(error: InformerError): void {
-    const code = error.code || '';
+    const code = typeof error.code === 'string' ? error.code : '';
     const message = error.message || '';
-    logContext.code = code;
+    logContext.code = error.code ?? '';
     if (
       RETRYABLE_NETWORK_ERROR_CODES.includes(code) ||
       RETRYABLE_NETWORK_ERROR_MESSAGES.includes(message)

--- a/src/supervisor/watchers/handlers/job.ts
+++ b/src/supervisor/watchers/handlers/job.ts
@@ -2,7 +2,6 @@ import { V1Job, V1JobList } from '@kubernetes/client-node';
 import { deleteWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
-import { IncomingMessage } from 'http';
 import { k8sApi } from '../../cluster';
 import { paginatedClusterList, paginatedNamespacedList } from './pagination';
 import {
@@ -13,10 +12,9 @@ import {
 import { trimWorkload } from '../../workload-sanitization';
 import { deleteWorkloadFromScanQueue } from './queue';
 
-export async function paginatedNamespacedJobList(namespace: string): Promise<{
-  response: IncomingMessage;
-  body: V1JobList;
-}> {
+export async function paginatedNamespacedJobList(
+  namespace: string,
+): Promise<V1JobList> {
   const v1JobList = new V1JobList();
   v1JobList.apiVersion = 'batch/v1';
   v1JobList.kind = 'JobList';
@@ -29,10 +27,7 @@ export async function paginatedNamespacedJobList(namespace: string): Promise<{
   );
 }
 
-export async function paginatedClusterJobList(): Promise<{
-  response: IncomingMessage;
-  body: V1JobList;
-}> {
+export async function paginatedClusterJobList(): Promise<V1JobList> {
   const v1JobList = new V1JobList();
   v1JobList.apiVersion = 'batch/v1';
   v1JobList.kind = 'JobList';

--- a/src/supervisor/watchers/handlers/namespace.ts
+++ b/src/supervisor/watchers/handlers/namespace.ts
@@ -9,7 +9,6 @@ import {
   V1NamespaceList,
   V1ListMeta,
 } from '@kubernetes/client-node';
-import { IncomingMessage } from 'http';
 import sleep from 'sleep-promise';
 import { logger } from '../../../common/logger';
 import { storeNamespace, deleteNamespace } from '../../../state';
@@ -86,16 +85,15 @@ export async function trackNamespace(namespace: string): Promise<void> {
     try {
       return await retryKubernetesApiRequest(async () => {
         logger.info({}, 'retrying k8s api request');
-        const reply = await k8sApi.coreClient.readNamespace(namespace);
+        const reply = await k8sApi.coreClient.readNamespace({
+          name: namespace,
+        });
         const list = new V1NamespaceList();
         list.apiVersion = 'v1';
         list.kind = 'NamespaceList';
-        list.items = new Array<V1Namespace>(reply.body);
+        list.items = [reply];
         list.metadata = new V1ListMeta();
-        return {
-          response: reply.response,
-          body: list,
-        };
+        return list;
       });
     } catch (error) {
       logger.error({ ...logContext, error }, 'error while listing namespace');
@@ -117,10 +115,7 @@ export async function trackNamespace(namespace: string): Promise<void> {
   await informer.start();
 }
 
-async function paginatedNamespaceList(): Promise<{
-  response: IncomingMessage;
-  body: V1NamespaceList;
-}> {
+async function paginatedNamespaceList(): Promise<V1NamespaceList> {
   const v1NamespaceList = new V1NamespaceList();
   v1NamespaceList.apiVersion = 'v1';
   v1NamespaceList.kind = 'NamespaceList';
@@ -134,38 +129,28 @@ async function paginatedNamespaceList(): Promise<{
  * The workloads collected are additionally trimmed to contain only the relevant data for vulnerability analysis.
  * The combination of both listing and trimming ensures we reduce our memory footprint and prevent overloading the API server.
  */
-async function listPaginatedNamespaces(list: V1NamespaceList): Promise<{
-  response: IncomingMessage;
-  body: V1NamespaceList;
-}> {
+async function listPaginatedNamespaces(
+  list: V1NamespaceList,
+): Promise<V1NamespaceList> {
   let continueToken: string | undefined = undefined;
 
-  const pretty = undefined;
-  const allowWatchBookmarks = undefined;
-  const fieldSelector = undefined;
-  const labelSelector = undefined;
-
-  let incomingMessage: IncomingMessage | undefined = undefined;
+  let receivedAnyPage = false;
 
   loop: while (true) {
     try {
-      const listCall = await k8sApi.coreClient.listNamespace(
-        pretty,
-        allowWatchBookmarks,
-        continueToken,
-        fieldSelector,
-        labelSelector,
-        PAGE_SIZE,
-      );
-      incomingMessage = listCall.response;
-      list.metadata = listCall.body.metadata;
+      const listCall = await k8sApi.coreClient.listNamespace({
+        _continue: continueToken,
+        limit: PAGE_SIZE,
+      });
+      receivedAnyPage = true;
+      list.metadata = listCall.metadata;
 
-      if (Array.isArray(listCall.body.items)) {
-        const trimmedItems = trimWorkloads(listCall.body.items);
+      if (Array.isArray(listCall.items)) {
+        const trimmedItems = trimWorkloads(listCall.items);
         list.items.push(...trimmedItems);
       }
 
-      continueToken = listCall.body.metadata?._continue;
+      continueToken = listCall.metadata?._continue;
       if (!continueToken) {
         break;
       }
@@ -173,7 +158,9 @@ async function listPaginatedNamespaces(list: V1NamespaceList): Promise<{
       const error = err as IRequestError;
 
       if (
-        RETRYABLE_NETWORK_ERROR_CODES.includes(error.code || '') ||
+        RETRYABLE_NETWORK_ERROR_CODES.includes(
+          typeof error.code === 'string' ? error.code : '',
+        ) ||
         RETRYABLE_NETWORK_ERROR_MESSAGES.includes(error.message || '')
       ) {
         const seconds = calculateSleepSeconds();
@@ -181,14 +168,14 @@ async function listPaginatedNamespaces(list: V1NamespaceList): Promise<{
         continue;
       }
 
-      switch (error.response?.statusCode) {
+      switch (typeof error.code === 'number' ? error.code : undefined) {
         case 410: // Gone
           break loop;
         case 429: // Too Many Requests
         case 502: // Bad Gateway
         case 503: // Service Unavailable
         case 504: // Gateway Timeout
-          const seconds = calculateSleepSeconds(error.response);
+          const seconds = calculateSleepSeconds(error);
           await sleep(seconds);
           continue;
         default:
@@ -197,12 +184,9 @@ async function listPaginatedNamespaces(list: V1NamespaceList): Promise<{
     }
   }
 
-  if (!incomingMessage) {
+  if (!receivedAnyPage) {
     throw new Error('could not list workload');
   }
 
-  return {
-    response: incomingMessage,
-    body: list,
-  };
+  return list;
 }

--- a/src/supervisor/watchers/handlers/pagination.ts
+++ b/src/supervisor/watchers/handlers/pagination.ts
@@ -1,4 +1,3 @@
-import { IncomingMessage } from 'http';
 import sleep from 'sleep-promise';
 import type {
   KubernetesListObject,
@@ -27,42 +26,27 @@ export async function paginatedNamespacedList<
   namespace: string,
   list: KubernetesListObject<KubernetesObject>,
   listPromise: V1NamespacedList<KubernetesListObject<T>>,
-): Promise<{
-  response: IncomingMessage;
-  body: KubernetesListObject<KubernetesObject>;
-}> {
+): Promise<KubernetesListObject<KubernetesObject>> {
   let continueToken: string | undefined = undefined;
 
-  const pretty = undefined;
-  const allowWatchBookmarks = undefined;
-  const fieldSelector = undefined;
-  const labelSelector = undefined;
-
-  let incomingMessage: IncomingMessage | undefined = undefined;
+  let receivedAnyPage = false;
 
   loop: while (true) {
     try {
-      const listCall: {
-        response: IncomingMessage;
-        body: KubernetesListObject<T>;
-      } = await listPromise(
+      const listCall: KubernetesListObject<T> = await listPromise({
         namespace,
-        pretty,
-        allowWatchBookmarks,
-        continueToken,
-        fieldSelector,
-        labelSelector,
-        PAGE_SIZE,
-      );
-      incomingMessage = listCall.response;
-      list.metadata = listCall.body.metadata;
+        _continue: continueToken,
+        limit: PAGE_SIZE,
+      });
+      receivedAnyPage = true;
+      list.metadata = listCall.metadata;
 
-      if (Array.isArray(listCall.body.items)) {
-        const trimmedItems = trimWorkloads(listCall.body.items);
+      if (Array.isArray(listCall.items)) {
+        const trimmedItems = trimWorkloads(listCall.items);
         list.items.push(...trimmedItems);
       }
 
-      continueToken = listCall.body.metadata?._continue;
+      continueToken = listCall.metadata?._continue;
       if (!continueToken) {
         break;
       }
@@ -70,7 +54,9 @@ export async function paginatedNamespacedList<
       const error = err as IRequestError;
 
       if (
-        RETRYABLE_NETWORK_ERROR_CODES.includes(error.code || '') ||
+        RETRYABLE_NETWORK_ERROR_CODES.includes(
+          typeof error.code === 'string' ? error.code : '',
+        ) ||
         RETRYABLE_NETWORK_ERROR_MESSAGES.includes(error.message || '')
       ) {
         const seconds = calculateSleepSeconds();
@@ -78,14 +64,14 @@ export async function paginatedNamespacedList<
         continue;
       }
 
-      switch (error.response?.statusCode) {
+      switch (typeof error.code === 'number' ? error.code : undefined) {
         case 410: // Gone
           break loop;
         case 429: // Too Many Requests
         case 502: // Bad Gateway
         case 503: // Service Unavailable
         case 504: // Gateway Timeout
-          const seconds = calculateSleepSeconds(error.response);
+          const seconds = calculateSleepSeconds(error);
           await sleep(seconds);
           continue;
         default:
@@ -94,14 +80,11 @@ export async function paginatedNamespacedList<
     }
   }
 
-  if (!incomingMessage) {
+  if (!receivedAnyPage) {
     throw new Error('could not list workload');
   }
 
-  return {
-    response: incomingMessage,
-    body: list,
-  };
+  return list;
 }
 
 /**
@@ -114,39 +97,26 @@ export async function paginatedClusterList<
 >(
   list: KubernetesListObject<KubernetesObject>,
   listPromise: V1ClusterList<KubernetesListObject<T>>,
-): Promise<{
-  response: IncomingMessage;
-  body: KubernetesListObject<KubernetesObject>;
-}> {
+): Promise<KubernetesListObject<KubernetesObject>> {
   let continueToken: string | undefined = undefined;
 
-  const allowWatchBookmarks = undefined;
-  const fieldSelector = undefined;
-  const labelSelector = undefined;
-
-  let incomingMessage: IncomingMessage | undefined = undefined;
+  let receivedAnyPage = false;
 
   loop: while (true) {
     try {
-      const listCall: {
-        response: IncomingMessage;
-        body: KubernetesListObject<T>;
-      } = await listPromise(
-        allowWatchBookmarks,
-        continueToken,
-        fieldSelector,
-        labelSelector,
-        PAGE_SIZE,
-      );
-      incomingMessage = listCall.response;
-      list.metadata = listCall.body.metadata;
+      const listCall: KubernetesListObject<T> = await listPromise({
+        _continue: continueToken,
+        limit: PAGE_SIZE,
+      });
+      receivedAnyPage = true;
+      list.metadata = listCall.metadata;
 
-      if (Array.isArray(listCall.body.items)) {
-        const trimmedItems = trimWorkloads(listCall.body.items);
+      if (Array.isArray(listCall.items)) {
+        const trimmedItems = trimWorkloads(listCall.items);
         list.items.push(...trimmedItems);
       }
 
-      continueToken = listCall.body.metadata?._continue;
+      continueToken = listCall.metadata?._continue;
       if (!continueToken) {
         break;
       }
@@ -154,7 +124,9 @@ export async function paginatedClusterList<
       const error = err as IRequestError;
 
       if (
-        RETRYABLE_NETWORK_ERROR_CODES.includes(error.code || '') ||
+        RETRYABLE_NETWORK_ERROR_CODES.includes(
+          typeof error.code === 'string' ? error.code : '',
+        ) ||
         RETRYABLE_NETWORK_ERROR_MESSAGES.includes(error.message || '')
       ) {
         const seconds = calculateSleepSeconds();
@@ -162,14 +134,14 @@ export async function paginatedClusterList<
         continue;
       }
 
-      switch (error.response?.statusCode) {
+      switch (typeof error.code === 'number' ? error.code : undefined) {
         case 410: // Gone
           break loop;
         case 429: // Too Many Requests
         case 502: // Bad Gateway
         case 503: // Service Unavailable
         case 504: // Gateway Timeout
-          const seconds = calculateSleepSeconds(error.response);
+          const seconds = calculateSleepSeconds(error);
           await sleep(seconds);
           continue;
         default:
@@ -178,12 +150,9 @@ export async function paginatedClusterList<
     }
   }
 
-  if (!incomingMessage) {
+  if (!receivedAnyPage) {
     throw new Error('could not list workload');
   }
 
-  return {
-    response: incomingMessage,
-    body: list,
-  };
+  return list;
 }

--- a/src/supervisor/watchers/handlers/pod.ts
+++ b/src/supervisor/watchers/handlers/pod.ts
@@ -1,5 +1,4 @@
 import { V1Pod, V1PodList } from '@kubernetes/client-node';
-import { IncomingMessage } from 'http';
 
 import { logger } from '../../../common/logger';
 import { sendWorkloadMetadata } from '../../../transmitter';
@@ -85,10 +84,9 @@ export function isPodReady(pod: V1Pod): boolean {
   return !isTerminating && podStatusPhase && containerReadyStatuses;
 }
 
-export async function paginatedNamespacedPodList(namespace: string): Promise<{
-  response: IncomingMessage;
-  body: V1PodList;
-}> {
+export async function paginatedNamespacedPodList(
+  namespace: string,
+): Promise<V1PodList> {
   const v1PodList = new V1PodList();
   v1PodList.apiVersion = 'v1';
   v1PodList.kind = 'PodList';
@@ -101,10 +99,7 @@ export async function paginatedNamespacedPodList(namespace: string): Promise<{
   );
 }
 
-export async function paginatedClusterPodList(): Promise<{
-  response: IncomingMessage;
-  body: V1PodList;
-}> {
+export async function paginatedClusterPodList(): Promise<V1PodList> {
   const v1PodList = new V1PodList();
   v1PodList.apiVersion = 'v1';
   v1PodList.kind = 'PodList';

--- a/src/supervisor/watchers/handlers/replica-set.ts
+++ b/src/supervisor/watchers/handlers/replica-set.ts
@@ -2,7 +2,6 @@ import { V1ReplicaSet, V1ReplicaSetList } from '@kubernetes/client-node';
 import { deleteWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
-import { IncomingMessage } from 'http';
 import { k8sApi } from '../../cluster';
 import { paginatedClusterList, paginatedNamespacedList } from './pagination';
 import {
@@ -15,10 +14,7 @@ import { deleteWorkloadFromScanQueue } from './queue';
 
 export async function paginatedNamespacedReplicaSetList(
   namespace: string,
-): Promise<{
-  response: IncomingMessage;
-  body: V1ReplicaSetList;
-}> {
+): Promise<V1ReplicaSetList> {
   const v1ReplicaSetList = new V1ReplicaSetList();
   v1ReplicaSetList.apiVersion = 'apps/v1';
   v1ReplicaSetList.kind = 'ReplicaSetList';
@@ -31,10 +27,7 @@ export async function paginatedNamespacedReplicaSetList(
   );
 }
 
-export async function paginatedClusterReplicaSetList(): Promise<{
-  response: IncomingMessage;
-  body: V1ReplicaSetList;
-}> {
+export async function paginatedClusterReplicaSetList(): Promise<V1ReplicaSetList> {
   const v1ReplicaSetList = new V1ReplicaSetList();
   v1ReplicaSetList.apiVersion = 'apps/v1';
   v1ReplicaSetList.kind = 'ReplicaSetList';

--- a/src/supervisor/watchers/handlers/replication-controller.ts
+++ b/src/supervisor/watchers/handlers/replication-controller.ts
@@ -5,7 +5,6 @@ import {
 import { deleteWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
-import { IncomingMessage } from 'http';
 import { k8sApi } from '../../cluster';
 import { paginatedClusterList, paginatedNamespacedList } from './pagination';
 import {
@@ -18,10 +17,7 @@ import { deleteWorkloadFromScanQueue } from './queue';
 
 export async function paginatedNamespacedReplicationControllerList(
   namespace: string,
-): Promise<{
-  response: IncomingMessage;
-  body: V1ReplicationControllerList;
-}> {
+): Promise<V1ReplicationControllerList> {
   const v1ReplicationControllerList = new V1ReplicationControllerList();
   v1ReplicationControllerList.apiVersion = 'v1';
   v1ReplicationControllerList.kind = 'ReplicationControllerList';
@@ -36,10 +32,7 @@ export async function paginatedNamespacedReplicationControllerList(
   );
 }
 
-export async function paginatedClusterReplicationControllerList(): Promise<{
-  response: IncomingMessage;
-  body: V1ReplicationControllerList;
-}> {
+export async function paginatedClusterReplicationControllerList(): Promise<V1ReplicationControllerList> {
   const v1ReplicationControllerList = new V1ReplicationControllerList();
   v1ReplicationControllerList.apiVersion = 'v1';
   v1ReplicationControllerList.kind = 'ReplicationControllerList';

--- a/src/supervisor/watchers/handlers/stateful-set.ts
+++ b/src/supervisor/watchers/handlers/stateful-set.ts
@@ -2,7 +2,6 @@ import { V1StatefulSet, V1StatefulSetList } from '@kubernetes/client-node';
 import { deleteWorkload } from './workload';
 import { WorkloadKind } from '../../types';
 import { FALSY_WORKLOAD_NAME_MARKER } from './types';
-import { IncomingMessage } from 'http';
 import { k8sApi } from '../../cluster';
 import { paginatedClusterList, paginatedNamespacedList } from './pagination';
 import {
@@ -15,10 +14,7 @@ import { deleteWorkloadFromScanQueue } from './queue';
 
 export async function paginatedNamespacedStatefulSetList(
   namespace: string,
-): Promise<{
-  response: IncomingMessage;
-  body: V1StatefulSetList;
-}> {
+): Promise<V1StatefulSetList> {
   const v1StatefulSetList = new V1StatefulSetList();
   v1StatefulSetList.apiVersion = 'apps/v1';
   v1StatefulSetList.kind = 'StatefulSetList';
@@ -31,10 +27,7 @@ export async function paginatedNamespacedStatefulSetList(
   );
 }
 
-export async function paginatedClusterStatefulSetList(): Promise<{
-  response: IncomingMessage;
-  body: V1StatefulSetList;
-}> {
+export async function paginatedClusterStatefulSetList(): Promise<V1StatefulSetList> {
   const v1StatefulSetList = new V1StatefulSetList();
   v1StatefulSetList.apiVersion = 'apps/v1';
   v1StatefulSetList.kind = 'StatefulSetList';

--- a/src/supervisor/watchers/handlers/types.ts
+++ b/src/supervisor/watchers/handlers/types.ts
@@ -8,7 +8,6 @@ import {
   DELETE,
   UPDATE,
 } from '@kubernetes/client-node';
-import { IncomingMessage } from 'http';
 
 export const FALSY_WORKLOAD_NAME_MARKER = 'falsy workload name';
 
@@ -22,15 +21,11 @@ type WorkloadHandlerFunc = (workload: any) => Promise<void>;
 
 type ListNamespacedWorkloadFunctionFactory = (
   namespace: string,
-) => () => Promise<{
-  response: any;
-  body: any;
-}>;
+) => () => Promise<KubernetesListObject<KubernetesObject>>;
 
-type ListClusterWorkloadFunctionFactory = () => () => Promise<{
-  response: any;
-  body: any;
-}>;
+type ListClusterWorkloadFunctionFactory = () => () => Promise<
+  KubernetesListObject<KubernetesObject>
+>;
 
 export interface IWorkloadWatchMetadata {
   [workloadKind: string]: {
@@ -99,47 +94,17 @@ export interface V1alpha1RolloutWorkloadRef {
   name: string;
 }
 
-export type V1ClusterList<T> = (
-  allowWatchBookmarks?: boolean,
-  _continue?: string,
-  fieldSelector?: string,
-  labelSelector?: string,
-  limit?: number,
-  pretty?: string,
-  resourceVersion?: string,
-  resourceVersionMatch?: string,
-  sendInitialEvents?: boolean,
-  timeoutSeconds?: number,
-  watch?: boolean,
-  options?: {
-    headers: {
-      [name: string]: string;
-    };
-  },
-) => Promise<{
-  response: IncomingMessage;
-  body: T;
-}>;
+export interface V1NamespacedListArgs {
+  namespace: string;
+  _continue?: string;
+  limit?: number;
+}
 
-export type V1NamespacedList<T> = (
-  namespace: string,
-  pretty?: string,
-  allowWatchBookmarks?: boolean,
-  _continue?: string,
-  fieldSelector?: string,
-  labelSelector?: string,
-  limit?: number,
-  resourceVersion?: string,
-  resourceVersionMatch?: string,
-  sendInitialEvents?: boolean,
-  timeoutSeconds?: number,
-  watch?: boolean,
-  options?: {
-    headers: {
-      [name: string]: string;
-    };
-  },
-) => Promise<{
-  response: IncomingMessage;
-  body: T;
-}>;
+export interface V1ClusterListArgs {
+  _continue?: string;
+  limit?: number;
+}
+
+export type V1NamespacedList<T> = (args: V1NamespacedListArgs) => Promise<T>;
+
+export type V1ClusterList<T> = (args: V1ClusterListArgs) => Promise<T>;

--- a/src/supervisor/watchers/index.ts
+++ b/src/supervisor/watchers/index.ts
@@ -2,7 +2,7 @@ import { V1Namespace } from '@kubernetes/client-node';
 
 import { logger } from '../../common/logger';
 import { config } from '../../common/config';
-import { NamespaceResponse, WorkloadKind } from '../types';
+import { WorkloadKind } from '../types';
 import { setupNamespacedInformer, setupClusterInformer } from './handlers';
 import { k8sApi } from '../cluster';
 import { extractNamespaceName } from './internal-namespaces';
@@ -60,11 +60,11 @@ export async function beginWatchingWorkloads(): Promise<void> {
       { namespace: config.WATCH_NAMESPACE },
       'kubernetes-monitor restricted to specific namespace',
     );
-    let namespaceResponse: NamespaceResponse | undefined;
+    let namespace: V1Namespace | undefined;
     try {
-      namespaceResponse = await k8sApi.coreClient.readNamespace(
-        config.WATCH_NAMESPACE,
-      );
+      namespace = await k8sApi.coreClient.readNamespace({
+        name: config.WATCH_NAMESPACE,
+      });
     } catch (err) {
       logger.error(
         { watchedNamespace: config.WATCH_NAMESPACE, err },
@@ -72,7 +72,6 @@ export async function beginWatchingWorkloads(): Promise<void> {
       );
       return;
     }
-    const namespace = namespaceResponse.body;
     await setupWatchesForNamespace(namespace);
     return;
   }

--- a/src/supervisor/workload-reader.ts
+++ b/src/supervisor/workload-reader.ts
@@ -24,9 +24,12 @@ const deploymentReader: IWorkloadReaderFunc = async (
 
   const deploymentResult =
     await kubernetesApiWrappers.retryKubernetesApiRequest(() =>
-      k8sApi.appsClient.readNamespacedDeployment(workloadName, namespace),
+      k8sApi.appsClient.readNamespacedDeployment({
+        name: workloadName,
+        namespace,
+      }),
     );
-  const deployment = trimWorkload(deploymentResult.body);
+  const deployment = trimWorkload(deploymentResult);
 
   if (
     !deployment.metadata ||
@@ -63,15 +66,17 @@ const deploymentConfigReader: IWorkloadReaderFunc = async (
 
   const deploymentResult =
     await kubernetesApiWrappers.retryKubernetesApiRequest(() =>
-      k8sApi.customObjectsClient.getNamespacedCustomObject(
-        'apps.openshift.io',
-        'v1',
+      k8sApi.customObjectsClient.getNamespacedCustomObject({
+        group: 'apps.openshift.io',
+        version: 'v1',
         namespace,
-        'deploymentconfigs',
-        workloadName,
-      ),
+        plural: 'deploymentconfigs',
+        name: workloadName,
+      }),
     );
-  const deployment: V1DeploymentConfig = trimWorkload(deploymentResult.body);
+  const deployment: V1DeploymentConfig = trimWorkload(
+    deploymentResult as V1DeploymentConfig,
+  );
 
   if (
     !deployment.metadata ||
@@ -107,9 +112,12 @@ const replicaSetReader: IWorkloadReaderFunc = async (
 
   const replicaSetResult =
     await kubernetesApiWrappers.retryKubernetesApiRequest(() =>
-      k8sApi.appsClient.readNamespacedReplicaSet(workloadName, namespace),
+      k8sApi.appsClient.readNamespacedReplicaSet({
+        name: workloadName,
+        namespace,
+      }),
     );
-  const replicaSet = trimWorkload(replicaSetResult.body);
+  const replicaSet = trimWorkload(replicaSetResult);
 
   if (
     !replicaSet.metadata ||
@@ -146,9 +154,12 @@ const statefulSetReader: IWorkloadReaderFunc = async (
 
   const statefulSetResult =
     await kubernetesApiWrappers.retryKubernetesApiRequest(() =>
-      k8sApi.appsClient.readNamespacedStatefulSet(workloadName, namespace),
+      k8sApi.appsClient.readNamespacedStatefulSet({
+        name: workloadName,
+        namespace,
+      }),
     );
-  const statefulSet = trimWorkload(statefulSetResult.body);
+  const statefulSet = trimWorkload(statefulSetResult);
 
   if (
     !statefulSet.metadata ||
@@ -183,9 +194,13 @@ const daemonSetReader: IWorkloadReaderFunc = async (
   }
 
   const daemonSetResult = await kubernetesApiWrappers.retryKubernetesApiRequest(
-    () => k8sApi.appsClient.readNamespacedDaemonSet(workloadName, namespace),
+    () =>
+      k8sApi.appsClient.readNamespacedDaemonSet({
+        name: workloadName,
+        namespace,
+      }),
   );
-  const daemonSet = trimWorkload(daemonSetResult.body);
+  const daemonSet = trimWorkload(daemonSetResult);
 
   if (
     !daemonSet.metadata ||
@@ -217,9 +232,9 @@ const jobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
   }
 
   const jobResult = await kubernetesApiWrappers.retryKubernetesApiRequest(() =>
-    k8sApi.batchClient.readNamespacedJob(workloadName, namespace),
+    k8sApi.batchClient.readNamespacedJob({ name: workloadName, namespace }),
   );
-  const job = trimWorkload(jobResult.body);
+  const job = trimWorkload(jobResult);
 
   if (
     !job.metadata ||
@@ -249,9 +264,13 @@ const cronJobReader: IWorkloadReaderFunc = async (workloadName, namespace) => {
   }
 
   const cronJobResult = await kubernetesApiWrappers.retryKubernetesApiRequest(
-    () => k8sApi.batchClient.readNamespacedCronJob(workloadName, namespace),
+    () =>
+      k8sApi.batchClient.readNamespacedCronJob({
+        name: workloadName,
+        namespace,
+      }),
   );
-  const cronJob = trimWorkload(cronJobResult.body);
+  const cronJob = trimWorkload(cronJobResult);
 
   if (
     !cronJob.metadata ||
@@ -286,12 +305,12 @@ const replicationControllerReader: IWorkloadReaderFunc = async (
 
   const replicationControllerResult =
     await kubernetesApiWrappers.retryKubernetesApiRequest(() =>
-      k8sApi.coreClient.readNamespacedReplicationController(
-        workloadName,
+      k8sApi.coreClient.readNamespacedReplicationController({
+        name: workloadName,
         namespace,
-      ),
+      }),
     );
-  const replicationController = trimWorkload(replicationControllerResult.body);
+  const replicationController = trimWorkload(replicationControllerResult);
 
   if (
     !replicationController.metadata ||
@@ -328,15 +347,17 @@ const argoRolloutReader: IWorkloadReaderFunc = async (
 
   const rolloutResult = await kubernetesApiWrappers.retryKubernetesApiRequest(
     () =>
-      k8sApi.customObjectsClient.getNamespacedCustomObject(
-        'argoproj.io',
-        'v1alpha1',
+      k8sApi.customObjectsClient.getNamespacedCustomObject({
+        group: 'argoproj.io',
+        version: 'v1alpha1',
         namespace,
-        'rollouts',
-        workloadName,
-      ),
+        plural: 'rollouts',
+        name: workloadName,
+      }),
   );
-  const rollout: V1alpha1Rollout = trimWorkload(rolloutResult.body);
+  const rollout: V1alpha1Rollout = trimWorkload(
+    rolloutResult as V1alpha1Rollout,
+  );
 
   if (rollout.spec?.workloadRef && rollout.metadata?.namespace) {
     // Lookup child template metadata when a workloadRef is defined

--- a/test/helpers/kubernetes-client-node-bridge.js
+++ b/test/helpers/kubernetes-client-node-bridge.js
@@ -1,0 +1,6 @@
+// @kubernetes/client-node >=1.0 is ESM-only; jest-runtime's CJS loader can't load it,
+// but Node >=22.12's native require() can. Jest patches require('node:module') with its
+// own createRequire that still honors moduleNameMapper (which would circularly resolve
+// back to this file), so grab the real built-in via process.getBuiltinModule instead.
+const { createRequire } = process.getBuiltinModule('node:module');
+module.exports = createRequire(__filename)('@kubernetes/client-node');

--- a/test/system/kind.spec.ts
+++ b/test/system/kind.spec.ts
@@ -66,10 +66,8 @@ test('Kubernetes-Monitor with KinD', async () => {
   const retryKubernetesApiRequestMock = jest
     .spyOn(kubernetesApiWrappers, 'retryKubernetesApiRequestIndefinitely')
     .mockResolvedValueOnce({
-      body: {
-        metadata: {
-          uid: agentId,
-        },
+      metadata: {
+        uid: agentId,
       },
     });
 

--- a/test/unit/supervisor/kubernetes-api-wrappers.spec.ts
+++ b/test/unit/supervisor/kubernetes-api-wrappers.spec.ts
@@ -1,4 +1,4 @@
-import * as http from 'http';
+import { IRequestError } from '../../../src/supervisor/types';
 import * as kubernetesApiWrappers from '../../../src/supervisor/kuberenetes-api-wrappers';
 
 describe('kubernetes api wrappers', () => {
@@ -6,44 +6,55 @@ describe('kubernetes api wrappers', () => {
     const responseWithoutHeaders = {};
     expect(
       kubernetesApiWrappers.calculateSleepSeconds(
-        responseWithoutHeaders as http.IncomingMessage,
+        responseWithoutHeaders as IRequestError,
       ),
     ).toEqual(kubernetesApiWrappers.DEFAULT_SLEEP_SEC);
 
-    const responseWithNegativeSeconds = { headers: { 'Retry-After': -3 } };
+    const responseWithNegativeSeconds = {
+      headers: { 'retry-after': '-3' },
+    };
     expect(
       kubernetesApiWrappers.calculateSleepSeconds(
-        responseWithNegativeSeconds as unknown as http.IncomingMessage,
+        responseWithNegativeSeconds as unknown as IRequestError,
       ),
     ).toEqual(kubernetesApiWrappers.DEFAULT_SLEEP_SEC);
 
-    const responseWithZeroSeconds = { headers: { 'Retry-After': 0 } };
+    const responseWithZeroSeconds = { headers: { 'retry-after': '0' } };
     expect(
       kubernetesApiWrappers.calculateSleepSeconds(
-        responseWithZeroSeconds as unknown as http.IncomingMessage,
+        responseWithZeroSeconds as unknown as IRequestError,
       ),
     ).toEqual(kubernetesApiWrappers.DEFAULT_SLEEP_SEC);
 
     const responseWithDate = {
-      headers: { 'Retry-After': 'Fri, 31 Dec 1999 23:59:59 GMT' },
+      headers: { 'retry-after': 'Fri, 31 Dec 1999 23:59:59 GMT' },
     };
     expect(
       kubernetesApiWrappers.calculateSleepSeconds(
-        responseWithDate as unknown as http.IncomingMessage,
+        responseWithDate as unknown as IRequestError,
       ),
     ).toEqual(kubernetesApiWrappers.DEFAULT_SLEEP_SEC);
 
-    const responseWithHighSecondsMock = { headers: { 'Retry-After': 55 } };
+    const responseWithHighSecondsMock = { headers: { 'retry-after': '55' } };
     expect(
       kubernetesApiWrappers.calculateSleepSeconds(
-        responseWithHighSecondsMock as unknown as http.IncomingMessage,
+        responseWithHighSecondsMock as unknown as IRequestError,
       ),
     ).toEqual(kubernetesApiWrappers.MAX_SLEEP_SEC);
 
-    const responseWithSecondsMock = { headers: { 'Retry-After': 4 } };
+    const responseWithSecondsMock = { headers: { 'retry-after': '4' } };
     expect(
       kubernetesApiWrappers.calculateSleepSeconds(
-        responseWithSecondsMock as unknown as http.IncomingMessage,
+        responseWithSecondsMock as unknown as IRequestError,
+      ),
+    ).toEqual(4);
+
+    const responseWithCapitalizedHeader = {
+      headers: { 'Retry-After': '4' },
+    };
+    expect(
+      kubernetesApiWrappers.calculateSleepSeconds(
+        responseWithCapitalizedHeader as unknown as IRequestError,
       ),
     ).toEqual(4);
   });
@@ -134,13 +145,13 @@ describe('kubernetes api wrappers', () => {
   test.concurrent(
     'retryKubernetesApiRequest for retryable errors',
     async () => {
-      const retryableErrorResponse = { response: { statusCode: 429 } };
+      const retryableErrorResponse = { code: 429 };
 
       await expect(async () =>
         kubernetesApiWrappers.retryKubernetesApiRequest(() =>
           Promise.reject(retryableErrorResponse),
         ),
-      ).rejects.toEqual({ response: { statusCode: 429 } });
+      ).rejects.toEqual({ code: 429 });
 
       let failures = 0;
       const functionThatFailsJustEnoughTimes = () => {
@@ -170,14 +181,14 @@ describe('kubernetes api wrappers', () => {
         kubernetesApiWrappers.retryKubernetesApiRequest(
           functionThatFailsOneTooManyTimes,
         ),
-      ).rejects.toEqual({ response: { statusCode: 429 } });
+      ).rejects.toEqual({ code: 429 });
     },
   );
 
   test.concurrent(
     'retryKubernetesApiRequest for non-retryable errors',
     async () => {
-      const nonRetryableErrorResponse = { response: { statusCode: 500 } };
+      const nonRetryableErrorResponse = { code: 500 };
 
       let failures = 0;
       const functionThatFails = () => {
@@ -187,7 +198,7 @@ describe('kubernetes api wrappers', () => {
 
       await expect(async () =>
         kubernetesApiWrappers.retryKubernetesApiRequest(functionThatFails),
-      ).rejects.toEqual({ response: { statusCode: 500 } });
+      ).rejects.toEqual({ code: 500 });
       expect(failures).toEqual(1);
     },
   );

--- a/test/unit/supervisor/pagination.spec.ts
+++ b/test/unit/supervisor/pagination.spec.ts
@@ -79,7 +79,7 @@ describe('pagination', () => {
           .mockResolvedValueOnce(undefined)
           .mockRejectedValueOnce(sleepError);
 
-        const listError = { response: { statusCode: code } } as IRequestError;
+        const listError = { code } as IRequestError;
         const listMock = jest.fn().mockRejectedValue(listError);
         const pushMock = jest.fn();
         const workloads = { items: [] };
@@ -97,7 +97,7 @@ describe('pagination', () => {
     );
 
     it.each([[410]])('handles unrecoverable http error: %s', async (code) => {
-      const listError = { response: { statusCode: code } } as IRequestError;
+      const listError = { code } as IRequestError;
       const listMock = jest.fn().mockRejectedValue(listError);
       const pushMock = jest.fn();
       const workloads = { items: [] };
@@ -118,7 +118,7 @@ describe('pagination', () => {
       async (codes) => {
         const listMock = jest.fn();
         for (const code of codes) {
-          const listError = { response: { statusCode: code } } as IRequestError;
+          const listError = { code } as IRequestError;
           listMock.mockRejectedValueOnce(listError);
         }
 
@@ -138,17 +138,14 @@ describe('pagination', () => {
     );
 
     it('handles failure after success', async () => {
-      const listError = { response: { statusCode: 410 } } as IRequestError;
+      const listError = { code: 410 } as IRequestError;
       const items = [{ metadata: { name: 'pod ' } }];
       const listMock = jest
         .fn()
         .mockResolvedValueOnce({
-          response: {},
-          body: {
-            items,
-            metadata: {
-              _continue: 'token',
-            },
+          items,
+          metadata: {
+            _continue: 'token',
           },
         })
         .mockRejectedValueOnce(listError);
@@ -172,28 +169,22 @@ describe('pagination', () => {
     });
 
     it('retries after failure', async () => {
-      const listError = { response: { statusCode: 429 } } as IRequestError;
+      const listError = { code: 429 } as IRequestError;
       const firstItems = [{ metadata: { name: 'first ' } }];
       const secondItems = [{ metadata: { name: 'second ' } }];
       const listMock = jest
         .fn()
         .mockResolvedValueOnce({
-          response: {},
-          body: {
-            items: firstItems,
-            metadata: {
-              _continue: 'token',
-            },
+          items: firstItems,
+          metadata: {
+            _continue: 'token',
           },
         })
         .mockRejectedValueOnce(listError)
         .mockResolvedValueOnce({
-          response: {},
-          body: {
-            items: secondItems,
-            metadata: {
-              _continue: undefined,
-            },
+          items: secondItems,
+          metadata: {
+            _continue: undefined,
           },
         });
 


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This upgrades `@kubernetes/client-node` from 0.22.3 to 1.4.0, fixing high-severity [SNYK-JS-FASTURI-18021349](https://security.snyk.io/vuln/SNYK-JS-FASTURI-18021349). It supersedes #1716, which bumped only package.json: the 0.x to 1.x jump is a rewrite of the client (request replaced with fetch), so that PR couldn't compile. I targeted 1.4.0 rather than 1.0.0 because proxy support, watch keep-alive, informer error callbacks and serialization fixes all landed between 1.1.2 and 1.4.0. Jira: [CN-1539](https://snyksec.atlassian.net/browse/CN-1539).

The awkward part is module format. 1.x ships only an ESM build while this repo is CommonJS. Node 22.12 and later can require() a synchronous ESM graph natively, and we run Node 22 everywhere (.nvmrc, CI, the alpine base image), so the compiled output just works and the repo stays CJS. A full ESM migration is deliberately out of scope.

Jest is the one place that breaks, since jest-runtime's CJS loader can't load real ESM. A moduleNameMapper entry routes the package to `test/helpers/kubernetes-client-node-bridge.js`, which gets Node's real createRequire through `process.getBuiltinModule` and loads the module natively, outside Jest's registry. A plain `require('node:module').createRequire` doesn't work here because Jest patches it with a version that still honors moduleNameMapper, and the bridge would resolve circularly back to itself.

The API migration across `src/supervisor`:

- Positional arguments became a single request object (the continue token is named `_continue`).
- The `{ response, body }` wrapper is gone, so methods resolve to the resource directly.
- `HttpError` no longer exists. Non-2xx responses reject with `ApiException`, whose numeric `.code` is the HTTP status. `IRequestError` now covers both fetch network errors (string code such as `ECONNRESET`) and `ApiException`, and the retry and pagination logic discriminates on the code type. `Retry-After` is read case-insensitively because fetch lower-cases header names.
- CustomObjectsApi bodies are untyped in 1.x, so the OpenShift DeploymentConfig and Argo Rollout lists cast the result. The `is*Supported` probes treat a resolved call as supported and any rejection as unsupported, which replaces the old statusCode range check.

The `overrides` block for `@kubernetes/client-node` (tough-cookie 4.1.3, form-data 2.5.6, qs, ws, ajv, fast-uri) is deleted in the same commit as the bump. Those pins existed for transitives of the old request stack, and 1.4.0 needs form-data ^4, which the pin would have blocked. tough-cookie and qs are gone from the dependency tree entirely.

### Notes for the reviewer

- No tsconfig changes were needed. The new type declarations compile clean under TS 4.9.5 without skipLibCheck and without bumping @types/node.
- `npm ls @types/node` shows a second copy (24.x) nested under the client, because 1.4.0 declares it as a runtime dependency. It is type-only and tsc is clean, so I left it alone.
- I verified locally: `npm ci` from scratch, build, full lint, all 312 unit tests, a `require()` smoke test of `dist/supervisor/cluster.js` (module-scope `loadFromDefault` without a kubeconfig), and the Docker image build (the image runs Node 22.23.1).
- The KinD system test needs the DOCKER_HUB_RO_* credentials that only exist in CI. My local run got through informers, watch/read and workload posts, then stalled on image scanning against Docker Hub rate limits, so please treat the system_tests CI job as the gate for that path.
- The retry on the literal 'Too Many Requests' message match may be dead code under node-fetch, since a 429 is now caught by its numeric code. I left the message check in place.
- One pre-existing quirk is left untouched: pagination passes seconds to sleep-promise, which expects milliseconds.

[CN-1539]: https://snyksec.atlassian.net/browse/CN-1539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ