### PR TITLE
fix(docker): stop shipping npm in the Alpine image [CN-1542]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apk update
 RUN apk upgrade
 RUN apk --no-cache add dumb-init curl bash python3
 
-RUN npm install -g npm@10.9.8
+RUN npm install -g npm@11.18.0
 
 RUN addgroup -S -g 10001 snyk
 RUN adduser -S -G snyk -h /srv/app -u 10001 snyk

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,6 @@ RUN chmod 755 /srv/app && chmod 755 /srv/app/bin && chmod +x /srv/app/bin/start
 
 # This must be in the end for Red Hat Build Service
 RUN chown -R snyk:snyk .
-USER 10001:10001
 
 # Build typescript
 RUN npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,6 @@ RUN apk update
 RUN apk upgrade
 RUN apk --no-cache add dumb-init curl bash python3
 
-RUN npm install -g npm@11.18.0
-
 RUN addgroup -S -g 10001 snyk
 RUN adduser -S -G snyk -h /srv/app -u 10001 snyk
 
@@ -99,5 +97,15 @@ USER 10001:10001
 
 # Build typescript
 RUN npm run build
+
+# Remove npm, npx, corepack and yarn from the final image: the runtime entrypoint is `node`
+# directly and nothing shells out to a package manager, so shipping them only adds vulnerable
+# surface (the bundled npm CLI is a recurring source of scanner findings). This mirrors
+# Dockerfile.ubi9, whose final stage installs only the node binary.
+USER root
+RUN rm -rf /usr/local/lib/node_modules \
+    /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+    /usr/local/bin/yarn /usr/local/bin/yarnpkg /opt/yarn-v*
+USER 10001:10001
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "bin/start"]


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

`snyk container test` on our shipped Alpine image flags a steady stream of High/Medium CVEs in the npm CLI's bundled dependencies (currently brace-expansion, pacote, sigstore, tar, picomatch). None of them are our dependencies. They ship because the final image carries a globally installed npm, plus npx, corepack, and yarn, even though the runtime entrypoint is `node` directly and nothing in `src/` shells out to any package manager.

This PR stops shipping all four. The build still uses the base image's npm for `npm ci` and `npm run build`, and a cleanup step removes `/usr/local/lib/node_modules` and the npm/npx/corepack/yarn binaries before the entrypoint. That eliminates the whole class of bundled-npm findings instead of chasing whichever npm release fixes them this quarter. Notably, pacote and picomatch have no fix in any released npm line today, so a version bump alone could not clear them.

`Dockerfile.ubi9` already works this way: its final stage extracts only the `node` binary from the tarball onto a bare ubi9 base, so it has never carried npm-CLI vulns. I confirmed that against the published `staging-candidate-ubi9-122972ac` image, which has no npm, npx, corepack, or yarn. This PR brings the Alpine image to parity.

The branch history shows the path here: the first commit bumped npm 10.9.8 to 11.18.0 ([CN-1541](https://snyksec.atlassian.net/browse/CN-1541)), which cleared 12 of 15 findings but left 3 unfixable ones. The second commit removes npm from the image entirely ([CN-1542](https://snyksec.atlassian.net/browse/CN-1542)). The net diff against staging is small: the global npm pin line is deleted and the removal block is added.

### Scan results

I built images from staging and from this branch on the same Alpine 3.24 base and ran `snyk container test` on both. The bundled npm CLI project (`/usr/local/lib/node_modules`) goes from 15 vulnerabilities to not existing at all:

| Severity | staging (ships npm 10.9.8) | this branch (ships no npm) |
|----------|:--:|:--:|
| Critical | 0 | 0 |
| High | 8 | 0 |
| Medium | 7 | 0 |
| Low | 0 | 0 |
| **Total** | **15** | **0** |

The scan of this branch's image reports only the app's own dependencies under `/srv/app` (4 Medium: request, uuid, inflight, js-yaml, all part of the known `@kubernetes/client-node` upgrade work). The OS and Go-binary layers are clean on both images. Image size drops from 1.35GB to 1.31GB.

### Notes for the reviewer

The removal runs as `USER root` because `/usr/local` is root-owned, then switches back to `10001:10001` for OpenShift.

One trade-off to be aware of: the `rm -rf` happens in a later layer, so the npm files from the base image still exist in lower layers under a whiteout. The merged filesystem that runs (and that scanners read) is genuinely npm-free, but pull size only shrinks by the layer we no longer add. Getting the bytes out of the layers entirely would mean restructuring to a bare `alpine` final stage the way ubi9 uses bare `ubi`, which I'd treat as a separate change.

I verified locally that the rebuilt image boots the app to its normal startup sequence (identical log output to the staging image outside a cluster) and that `npm`, `npx`, `corepack`, and `yarn` are all absent from the running filesystem.

Tracks: [CN-1542](https://snyksec.atlassian.net/browse/CN-1542), [CN-1541](https://snyksec.atlassian.net/browse/CN-1541)

[CN-1541]: https://snyksec.atlassian.net/browse/CN-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ