### PR TITLE
chore: bump snyk-docker-plugin to 9.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "packageurl-js": "^1.2.1",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.3.0",
-        "snyk-docker-plugin": "^9.18.0",
+        "snyk-docker-plugin": "^9.19.0",
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "4.9.5",
@@ -1241,20 +1241,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@ericcornelissen/lregexp": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@ericcornelissen/lregexp/-/lregexp-1.0.8.tgz",
-      "integrity": "sha512-asaQOkMr8CzYVpmCnBvEe8zejcv8Q1+f3Q1qssOF85njH1VTJfSQUYwwClE41SRdvZmN26uL08GuQk04VN2myA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-supported-regexp-flag": "^2.0.0"
-      },
-      "engines": {
-        "bun": "^1.2.0",
-        "deno": "^2.0.0",
-        "node": "^12.20.0 || ^14.13.0 || ^15 || ^16 || ^17 || ^18 || ^19 || ^20 || ^21 || ^22 || ^23 || ^24 || ^25"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -5948,15 +5934,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-supported-regexp-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-2.0.0.tgz",
-      "integrity": "sha512-8i4+OYUjdUaJ88KAs1WojIThDFjIpeYNrSlYy1g/At2p9YjQ7HEmB1yn60un0jRFjM3TQbKPMAluTPEPncZfqA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
     "node_modules/is-text-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
@@ -9021,16 +8998,23 @@
       }
     },
     "node_modules/shescape": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/shescape/-/shescape-2.1.10.tgz",
-      "integrity": "sha512-CJvUj3QcmIUqxfSci5x6SjATMbcVPYWnHDPoS6dZeLrB/o0qwPGYyshtylAEKH7eH61WfUYineGz5RJaWXuTbw==",
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/shescape/-/shescape-2.1.14.tgz",
+      "integrity": "sha512-BA3/itw2jFZ8MybwHAWN5c78CQDOBn+joA/66ftwwwWr8GbzD6ZchE3hH1trkI8+xEBXnjjkdbzPqTURNojRfQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ericcornelissen/lregexp": "^1.0.3",
-        "which": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+        "which": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       },
       "engines": {
-        "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20 || ^22 || ^24 || ^25"
+        "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20 || ^22 || ^24 || ^25 || ^26"
+      },
+      "peerDependencies": {
+        "@ericcornelissen/lregexp": "^1.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@ericcornelissen/lregexp": {
+          "optional": true
+        }
       }
     },
     "node_modules/shescape/node_modules/isexe": {
@@ -9184,9 +9168,9 @@
       }
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.18.0.tgz",
-      "integrity": "sha512-nc0IzCs82FEFV4y6FIF8aMk8RCbuWvNoqnaBbpZ8qFH3ntZzMsRDzUfsWiT7/pUp9rL/s7GVDJUYfy+0NiFPmg==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.19.0.tgz",
+      "integrity": "sha512-XVOEneK1YKfFxOqyUR8PRBHzxosRNnfEuejNZHIKUqRdFrJjfVzxPRNo5a2ypis8z26C0/Hgha18nCwitvejRA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
@@ -9195,7 +9179,7 @@
         "@snyk/rpm-parser": "^3.4.1",
         "@snyk/snyk-docker-pull": "^3.16.0",
         "@swimlane/docker-reference": "^2.0.1",
-        "adm-zip": "^0.5.17",
+        "adm-zip": "^0.5.18",
         "chalk": "^2.4.2",
         "debug": "^4.4.3",
         "docker-modem": "^3.0.8",
@@ -9204,10 +9188,10 @@
         "event-loop-spinner": "^2.3.2",
         "fzstd": "^0.1.1",
         "gunzip-maybe": "^1.4.2",
-        "minimatch": "^9.0.0",
+        "minimatch": "^9.0.9",
         "packageurl-js": "1.2.0",
         "semver": "^7.7.3",
-        "shescape": "^2.1.7",
+        "shescape": "^2.1.14",
         "snyk-nodejs-lockfile-parser": "^2.7.0",
         "snyk-poetry-lockfile-parser": "1.9.1",
         "snyk-resolve-deps": "^4.9.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "packageurl-js": "^1.2.1",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.3.0",
-    "snyk-docker-plugin": "^9.18.0",
+    "snyk-docker-plugin": "^9.19.0",
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "4.9.5",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests) — N/A (dependency + lockfile bump only, no source changes)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation) — N/A
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Bumps `snyk-docker-plugin` from `^9.18.0` to `^9.19.0`.

9.19.0 ([snyk/snyk-docker-plugin#889](https://github.com/snyk/snyk-docker-plugin/pull/889)) falls back to BuildKit's `vcs.source` for `buildConfigSourceUri` when `configSource.uri` is absent, so **locally-built images still surface their source repository** in the `provenanceMetadata` fact. Previously `configSource.uri` was only populated for remote (git-context) builds, leaving local/CI builds without a repository URI.

Follow-up to #1717, which brought this repo to 9.18.0.

### Notes for the reviewer

- Dependency + lockfile bump only — no source/behavior changes in this repo.
- The lockfile diff is slightly larger than the plugin entry alone: 9.19.0 also carries the transitive security bumps released in 9.18.1 (`adm-zip` 0.5.17 → 0.5.18, `shescape` 2.1.10 → 2.1.14, `minimatch` → 9.0.9). `@ericcornelissen/lregexp` and `is-supported-regexp-flag` drop out because shescape 2.1.14 made `lregexp` an optional peer dependency.
- Verified locally: `npm ci` resolves `snyk-docker-plugin@9.19.0` and `npm run build` (tsc) passes.

### Screenshots

N/A — dependency bump only.