### PR TITLE
chore: parallelize and cache the CI image builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,40 +94,69 @@ jobs:
           mode: auto
           release-branch: master
           open-source-additional-arguments: --exclude=test
-  build_image:
-    docker:
-      - image: cimg/base:current
+  # The alpine and ubi9 images share no build stages, so they build, scan and push
+  # as two independent jobs. Both run on a machine executor rather than a docker
+  # executor plus setup_remote_docker: that avoids shipping the build context to a
+  # separate VM, lets docker_layer_caching reuse the gcloud SDK, skopeo, Node and
+  # credential-helper layers between runs, and lets resource_class apply to the build
+  # itself. `system_tests` already uses this executor.
+  build_image_alpine:
+    machine:
+      docker_layer_caching: true
+      image: default
+    resource_class: large
+    environment:
+      DOCKER_BUILDKIT: 1
     steps:
       - checkout
-      - setup_remote_docker
       - run:
           command: |
             IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
             IMAGE_NAME_CANDIDATE=snyk/kubernetes-monitor:${IMAGE_TAG}-${CIRCLE_SHA1}
-            IMAGE_NAME_CANDIDATE_UBI9=snyk/kubernetes-monitor:${IMAGE_TAG}-ubi9-${CIRCLE_SHA1:0:8}
             echo "export IMAGE_NAME_CANDIDATE=$IMAGE_NAME_CANDIDATE" >> $BASH_ENV
-            echo "export IMAGE_NAME_CANDIDATE_UBI9=$IMAGE_NAME_CANDIDATE_UBI9" >> $BASH_ENV
           name: Export environment variables
       - run:
           command: |
             docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASS}
             ./scripts/docker/build-image.sh ${IMAGE_NAME_CANDIDATE}
-            ./scripts/docker/build-image-ubi9.sh ${IMAGE_NAME_CANDIDATE_UBI9}
           name: Build image
       - prodsec/container_scan:
           mode: gate
           docker-image-name: ${IMAGE_NAME_CANDIDATE}
           docker-file: Dockerfile
           project-name: alpine
+      - run:
+          command: docker push ${IMAGE_NAME_CANDIDATE}
+          name: Push image
+      - notify_slack_on_failure
+    working_directory: ~/kubernetes-monitor
+  build_image_ubi9:
+    machine:
+      docker_layer_caching: true
+      image: default
+    resource_class: large
+    environment:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - checkout
+      - run:
+          command: |
+            IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
+            IMAGE_NAME_CANDIDATE_UBI9=snyk/kubernetes-monitor:${IMAGE_TAG}-ubi9-${CIRCLE_SHA1:0:8}
+            echo "export IMAGE_NAME_CANDIDATE_UBI9=$IMAGE_NAME_CANDIDATE_UBI9" >> $BASH_ENV
+          name: Export environment variables
+      - run:
+          command: |
+            docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASS}
+            ./scripts/docker/build-image-ubi9.sh ${IMAGE_NAME_CANDIDATE_UBI9}
+          name: Build image
       - prodsec/container_scan:
           mode: gate
           docker-image-name: ${IMAGE_NAME_CANDIDATE_UBI9}
           docker-file: Dockerfile.ubi9
           project-name: ubi9
       - run:
-          command: |
-            docker push ${IMAGE_NAME_CANDIDATE}
-            docker push ${IMAGE_NAME_CANDIDATE_UBI9}
+          command: docker push ${IMAGE_NAME_CANDIDATE_UBI9}
           name: Push image
       - notify_slack_on_failure
     working_directory: ~/kubernetes-monitor
@@ -344,7 +373,18 @@ workflows:
             - publish
   MERGE_TO_STAGING:
     jobs:
-      - build_image:
+      - build_image_alpine:
+          context:
+            - infrasec_container
+            - go-private-modules
+            - snyk-bot-slack
+            - team-container-integration-docker-hub
+            - prodsec-orb-runtime
+          filters:
+            branches:
+              only:
+                - staging
+      - build_image_ubi9:
           context:
             - infrasec_container
             - go-private-modules
@@ -381,7 +421,8 @@ workflows:
               only:
                 - staging
           requires:
-            - build_image
+            - build_image_alpine
+            - build_image_ubi9
             - unit_tests
             - system_tests
       - prepare_to_deploy:
@@ -421,7 +462,22 @@ workflows:
               ignore:
                 - staging
                 - master
-      - build_image:
+      - build_image_alpine:
+          context:
+            - infrasec_container
+            - go-private-modules
+            - snyk-bot-slack
+            - team-container-integration-docker-hub
+            - prodsec-orb-runtime
+          requires:
+            - Scan repository for secrets
+            - Security Scans
+          filters:
+            branches:
+              ignore:
+                - staging
+                - master
+      - build_image_ubi9:
           context:
             - infrasec_container
             - go-private-modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,9 +82,14 @@ RUN mkdir -p .config
 
 # --include=dev is required despite NODE_ENV=production above: tsc and @types/* are
 # devDependencies and `npm run build` below needs them. They are pruned again after the build.
+# The cache mount keeps the npm tarball cache across builds so a package-lock.json change
+# re-resolves from local disk instead of re-downloading the whole tree. It is a BuildKit cache
+# mount, so it is never part of the resulting image. uid/gid match the snyk user, which is who
+# runs npm here.
 RUN --mount=type=secret,id=npm_token,uid=10001 \
+    --mount=type=cache,target=/tmp/npm-cache,uid=10001,gid=10001 \
     echo "//registry.npmjs.org/:_authToken=$(cat /run/secrets/npm_token)" > ~/.npmrc && \
-    npm ci --include=dev && \
+    npm ci --include=dev --cache /tmp/npm-cache && \
     rm -f ~/.npmrc
 
 # add the rest of the app files

--- a/Dockerfile.ubi9
+++ b/Dockerfile.ubi9
@@ -24,9 +24,14 @@ COPY --chown=1001:1001 package.json package-lock.json ./
 
 # --include=dev is required despite NODE_ENV=production above: tsc and @types/* are
 # devDependencies and `npm run build` below needs them. They are pruned again after the build.
+# The cache mount keeps the npm tarball cache across builds so a package-lock.json change
+# re-resolves from local disk instead of re-downloading the whole tree. It is a BuildKit cache
+# mount, so it is never part of the resulting image. uid/gid match the default user of the
+# ubi9/nodejs-22 image, which is who runs npm here.
 RUN --mount=type=secret,id=npm_token,uid=1001 \
+    --mount=type=cache,target=/tmp/npm-cache,uid=1001,gid=0 \
     echo "//registry.npmjs.org/:_authToken=$(cat /run/secrets/npm_token)" > ~/.npmrc && \
-    npm ci --include=dev && \
+    npm ci --include=dev --cache /tmp/npm-cache && \
     rm -f ~/.npmrc
 
 # add the rest of the app files

--- a/scripts/docker/build-image-ubi9.sh
+++ b/scripts/docker/build-image-ubi9.sh
@@ -14,9 +14,10 @@ NAME_AND_TAG=${1:-$LOCAL_DISCARDABLE_IMAGE}
 # This step gets the latest version of node 22 from node.js. It removes the .tar.gz extension and then returns the result.
 # It is used when buidling the ubi image in order to download the latest node 22 version and copy its binary.
 NODE_MAJOR_VERSION=22
-NODE_LATEST_VERSION_TAR_GZ_FILE=$(curl -L --fail --silent https://nodejs.org/dist/latest-v${NODE_MAJOR_VERSION}.x/SHASUMS256.txt | grep linux-x64.tar.gz | awk '{ print $2 }')
+NODE_SHASUMS_LINE=$(curl -L --fail --silent https://nodejs.org/dist/latest-v${NODE_MAJOR_VERSION}.x/SHASUMS256.txt | grep linux-x64.tar.gz)
+NODE_LATEST_VERSION_TAR_GZ_FILE=$(echo "${NODE_SHASUMS_LINE}" | awk '{ print $2 }')
 NODE_LATEST_VERSION="${NODE_LATEST_VERSION_TAR_GZ_FILE%%.tar.gz}"
-NODE_LATEST_VERSION_TAR_GZ_FILE_SHASUM256=$(curl -L --fail --silent https://nodejs.org/dist/latest-v${NODE_MAJOR_VERSION}.x/SHASUMS256.txt | grep linux-x64.tar.gz | awk '{ print $1 }')
+NODE_LATEST_VERSION_TAR_GZ_FILE_SHASUM256=$(echo "${NODE_SHASUMS_LINE}" | awk '{ print $1 }')
 
 docker build \
   --build-arg NODE_LATEST_VERSION="${NODE_LATEST_VERSION}" \


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

`build_image` builds the alpine and ubi9 images one after the other in a single job, on a docker executor with a bare `setup_remote_docker`. Nothing in the ubi9 path depends on the alpine path. And with no `docker_layer_caching`, every run re-downloads the gcloud SDK, re-runs `apk upgrade` and `dnf upgrade`, re-downloads the Node tarball and skopeo, and rebuilds the ECR and ACR credential helpers with `go install`. None of that changes between PRs.

This splits the job into `build_image_alpine` and `build_image_ubi9`, so the two builds and their `container_scan` gates run concurrently. `tag_and_push` requires both.

Both jobs also move to a `machine` executor with `docker_layer_caching: true` and `resource_class: large`. A docker executor plus remote docker ships the build context out to a separate VM, and it leaves the job's resource class with no effect on build speed at all. `system_tests` already uses this executor here. `DOCKER_BUILDKIT: 1` is now explicit, since the build scripts pass `--secret` and that needs BuildKit.

There's also a BuildKit npm cache mount in each Dockerfile at `/tmp/npm-cache`, so a `package-lock.json` change re-resolves from local disk instead of refetching the whole tree. `npm ci` runs as uid 10001 in alpine and uid 1001 in ubi9, so each mount carries a matching uid and gid. `build-image-ubi9.sh` fetches `SHASUMS256.txt` once instead of twice.

CN-1555

### How much faster

Full `PR_TO_STAGING` wall clock, from the first job starting to the last one finishing, alongside the image build inside each run:

| commit | config | `build_image` | total CI time |
| --- | --- | --- | --- |
| 473fed32 | old | 13m28s | 14m34s |
| 58ccf66f | old | 11m48s | 14m03s |
| 293bf5e4 | old | 12m23s | 13m28s |
| c7497c9d | old | 12m05s | 13m05s |
| 37109da (this PR) | new | 4m10s alpine, 3m56s ubi9 | **5m04s** |

`build_image` was the critical path in every one of those old runs, which is why the workflow total tracks it so closely. The two replacements run concurrently, so the new critical path is 4m10s and the workflow finishes in 5m04s. That's roughly 8.5 minutes back on every PR. `MERGE_TO_STAGING` gets the same benefit and currently sits at 15m36s on c5926e9e.

Splitting the job explains only about half the gain. Most of the rest is the executor swap, which drops the build-context transfer and lets `resource_class` reach the build. Layer caching earns almost none of it here, because these are new job names on a new executor type, so the DLC volume started empty. A warm run should be quicker still.

### Notes for the reviewer

Someone should confirm that DLC really covers the BuildKit cache, because the numbers above don't demonstrate it yet. `docker_layer_caching` snapshots `/var/lib/docker`, and BuildKit keeps its cache under `/var/lib/docker/buildkit` when it runs inside dockerd on the default driver, which is what happens here. That stops holding if these builds ever move to a `docker buildx` container driver.

Two related findings are deliberately not in here. In `PR_TO_STAGING`, both build jobs still wait on "Scan repository for secrets" and "Security Scans", which are independent of the build, but dropping that gate is a security policy call rather than a pipeline one. Both Dockerfiles also end with `RUN chown -R snyk:snyk .` even though everything already arrives via `--chown`, which walks roughly 330MB of node_modules into a duplicate layer. The inline comment says the Red Hat Build Service needs it, so that one wants a real RHBS build to settle rather than a guess.

This hasn't been through `circleci config validate`, since the CLI isn't installed locally. The config was checked with a YAML parse and a script that cross-references every workflow job and `requires` entry against the defined jobs.
