### PR TITLE
chore(deps): bump snyk-docker-plugin to ^9.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "packageurl-js": "^1.2.1",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.3.0",
-        "snyk-docker-plugin": "^9.19.0",
+        "snyk-docker-plugin": "^9.20.0",
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "4.9.5",
@@ -8646,9 +8646,9 @@
       }
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.19.0.tgz",
-      "integrity": "sha512-XVOEneK1YKfFxOqyUR8PRBHzxosRNnfEuejNZHIKUqRdFrJjfVzxPRNo5a2ypis8z26C0/Hgha18nCwitvejRA==",
+      "version": "9.20.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.20.0.tgz",
+      "integrity": "sha512-wzvEK7aO7od4/bp1ZXivQzzMJNRYSX9s3DY+sCB5wCw/MVx93R2fNcTqXt3HtObJYPSUtEm5pA8nYVSG77NqYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "packageurl-js": "^1.2.1",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.3.0",
-    "snyk-docker-plugin": "^9.19.0",
+    "snyk-docker-plugin": "^9.20.0",
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "4.9.5",


### PR DESCRIPTION
Bumps `snyk-docker-plugin` from `^9.19.0` to `^9.20.0`.

Picks up the released provenance-attestation support (registry attestation fetch + validation and the provenance-attestation types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)