### PR TITLE
fix(security): remove vim-minimal from ubi9 image

### DIFF
--- a/Dockerfile.ubi9
+++ b/Dockerfile.ubi9
@@ -111,8 +111,11 @@ RUN curl -sSfLo /tmp/node_${NODE_MAJOR_VERSION}.tar.gz "https://nodejs.org/dist/
     mv /tmp/node_${NODE_MAJOR_VERSION}/${NODE_LATEST_VERSION}/bin/node /usr/local/bin && \
     rm -rf /tmp/node_${NODE_MAJOR_VERSION}.tar.gz /tmp/node_${NODE_MAJOR_VERSION}
 
+# vim-minimal ships in the ubi9 base image and carries high-severity advisories
+# with no fixed version available. Nothing in this image uses an editor, so drop it.
 RUN rpm -e --nodeps curl-minimal && \
-    rpm -e --nodeps libcurl-minimal
+    rpm -e --nodeps libcurl-minimal && \
+    rpm -e --nodeps vim-minimal
 
 # The `.config` directory is used by `snyk protect` and we also mount a K8s volume there at runtime.
 # This clashes with OpenShift 3 which mounts things differently and prevents access to the directory.


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests) — N/A (Dockerfile only)
- [x] Manually tested relevant flows which are not covered by automated tests
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation) — N/A
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Unblocks the container scan gate, which fails on [job 39878](https://app.circleci.com/pipelines/github/snyk/kubernetes-monitor/7262/workflows/86ee56ee-7862-4d03-b949-2bf43fbf2fb8/jobs/39878):

```
✖  SNYK-RHEL9-VIMMINIMAL-17712765
   Reason:     HIGH severity: 31 days since publication exceeds 30-day remediation SLA
   Package:    vim-minimal@2:8.2.2637-26.el9_8.13
   Fixed in:   none
GATE BLOCKED: 1 issue(s) exceed their remediation SLA.
```

**There is no fixed version** — Snyk reports `Fixed in: none` — so the package cannot be upgraded out of the finding. It arrives from the `ubi9/ubi:9.8` base image.

`vim-minimal` only provides an editor, and nothing in this image uses one: the entrypoint is `dumb-init` → `bin/start` → `node`, and there are no `vi` / `vim` / `EDITOR` / `VISUAL` references anywhere in the repo. So the fix is to drop the package rather than suppress the finding — following the pattern already used here for `curl-minimal` and `libcurl-minimal`.

```diff
 RUN rpm -e --nodeps curl-minimal && \
-    rpm -e --nodeps libcurl-minimal
+    rpm -e --nodeps libcurl-minimal && \
+    rpm -e --nodeps vim-minimal
```

### Verification

Run against the real base image, `registry.access.redhat.com/ubi9/ubi:9.8`:

| Check | Result |
|---|---|
| `rpm -q vim-minimal` | `vim-minimal-8.2.2637-26.el9_8.13.x86_64` — the exact flagged version |
| `rpm -q --whatrequires vim-minimal` | **no package requires vim-minimal** |
| `rpm -e --nodeps vim-minimal` | succeeds |
| `rpm -q vim-minimal` after | `package vim-minimal is not installed` |
| `/usr/bin/vi`, `/usr/bin/vim` | both absent |

Nothing depends on it, so `--nodeps` here is not masking a broken dependency — it matches the existing lines' style rather than suppressing a real edge.

### Also cleared

Two further `vim-minimal` advisories were reported in the same scan but were still inside their SLA window, so they weren't blocking yet. Removing the package clears them too, rather than leaving them to fail the gate later:

- [SNYK-RHEL9-VIMMINIMAL-17790082](https://security.snyk.io/vuln/SNYK-RHEL9-VIMMINIMAL-17790082) (Arbitrary Code Injection, High)
- [SNYK-RHEL9-VIMMINIMAL-17816811](https://security.snyk.io/vuln/SNYK-RHEL9-VIMMINIMAL-17816811) (Arbitrary Code Injection, High)

### Notes for the reviewer

- `Dockerfile.ubi9` only. The other `Dockerfile` is Alpine-based, so it has no RPM packages and is unaffected.
- No `.snyk` changes — the file currently has `ignore: {}` and this needs no ignore.
- Based off `master` as requested. Note the failing pipeline (7262) did **not** run on `master` (the most recent `master` pipeline is 7258), so if that gate needs to go green on `staging` as well, this will need to land there too.
- I could not build the full image locally — it requires the `gh_token` and `npm_token` build secrets — so the removal was verified directly against the base image rather than through a complete build. CI will confirm end to end.

### Screenshots

N/A
