### PR TITLE
fix(security): remove vim-minimal from ubi9 image

### DIFF
--- a/Dockerfile.ubi9
+++ b/Dockerfile.ubi9
@@ -116,8 +116,11 @@ RUN curl -sSfLo /tmp/node_${NODE_MAJOR_VERSION}.tar.gz "https://nodejs.org/dist/
     mv /tmp/node_${NODE_MAJOR_VERSION}/${NODE_LATEST_VERSION}/bin/node /usr/local/bin && \
     rm -rf /tmp/node_${NODE_MAJOR_VERSION}.tar.gz /tmp/node_${NODE_MAJOR_VERSION}
 
+# vim-minimal ships in the ubi9 base image and carries high-severity advisories
+# with no fixed version available. Nothing in this image uses an editor, so drop it.
 RUN rpm -e --nodeps curl-minimal && \
-    rpm -e --nodeps libcurl-minimal
+    rpm -e --nodeps libcurl-minimal && \
+    rpm -e --nodeps vim-minimal
 
 # The `.config` directory is used by `snyk protect` and we also mount a K8s volume there at runtime.
 # This clashes with OpenShift 3 which mounts things differently and prevents access to the directory.


### PR DESCRIPTION
Unblocks the ubi9 container scan gate, which fails with:

```
✖  SNYK-RHEL9-VIMMINIMAL-17712765
   Reason:   HIGH severity: 31 days since publication exceeds 30-day remediation SLA
   Package:  vim-minimal@2:8.2.2637-26.el9_8.13
   Fixed in: none
```

https://circleci.com/gh/snyk/kubernetes-monitor/39878