### PR TITLE
chore: no-op comment to trigger a control CI run

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ Error: EROFS: read-only file system, mkdir '/srv/app/.npm/_npx'
 ### Cleaning up
 
 Run `tilt down` to tear down the debugging session.
+
+<!-- CI control: no-op comment to trigger a pipeline run. Safe to revert. -->


### PR DESCRIPTION
**Do not merge. Diagnostic only — close when done.**

### Why

`system_tests` is failing on #1734 with the KinD cluster never starting its kubelet:

```
[kubelet-start] WARNING: unable to start the kubelet service: [exit status 1]
```

We can't tell whether that's pre-existing or introduced, because:

- `master` never runs `system_tests` — `MERGE_TO_MASTER` is only `Security Scans → publish → deploy_to_prod`.
- `staging`'s last run was **Jul 29** (pipeline 7260), where `system_tests` **passed**. The failures started **Jul 31**, so there's no run on the far side of whatever changed.

### What this is

One HTML comment appended to `README.md`. Nothing else — the diff is 2 added lines, no code, no config, no Dockerfile.

`PR_TO_STAGING` filters on *branches ignore staging/master*, so this branch triggers the full PR workflow including `system_tests`, against a tree identical to `master`.

### How to read the result

| `system_tests` | Conclusion |
|---|---|
| **fails** | Pre-existing and environmental. Unrelated to #1734, and it will block every PR in this repo. |
| **passes** | The failure is specific to #1734's branch, and my reasoning is wrong somewhere — worth digging further. |

### Known limitation

Either way this won't tell us *why* the kubelet exits 1. `test/system/kind.spec.ts` deletes the cluster in its failure path, so the kubelet's own log is destroyed before anything reads it. Capturing that needs `./kind export logs` before `deleteCluster` plus `store_artifacts`, which is deliberately **not** in this PR.
