### PR TITLE
chore: no-op comment to trigger a control CI run on staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ Error: EROFS: read-only file system, mkdir '/srv/app/.npm/_npx'
 ### Cleaning up
 
 Run `tilt down` to tear down the debugging session.
+
+<!-- CI control (staging): no-op comment to trigger a pipeline run. Safe to revert. -->


### PR DESCRIPTION
**Do not merge. Diagnostic only — close when done.**

Mirror of #1735, which was based on `master` and **passed** `system_tests` (job 39925). This one is based on `staging` with the identical one-line README comment, so the only variable is the base branch.

`staging` is ahead of `master` by exactly two commits:

```
594f645 Merge pull request #1730 from snyk/CN-1555-speed-up-build-image
37109da chore: parallelize and cache the CI image builds
```

`system_tests` is byte-identical between the two branches. What #1730 changed is DLC contention:

| | jobs with `docker_layer_caching` |
|---|---|
| `master` | `system_tests` — 1 |
| `staging` | `build_image_alpine`, `build_image_ubi9`, `system_tests` — 3 |

### How to read the result

| `system_tests` | Conclusion |
|---|---|
| **fails** | Current `staging` is broken. #1734's failure is pre-existing, and the next staging merge will hit it too. |
| **passes** | `staging` is fine and something else explains #1734's two failures. |

Note nothing has run `system_tests` on `staging` since **Jul 29** (pipeline 7260, passed), which is before #1730 merged — so this is the first real test of it.
