### PR TITLE
fix(ci): unblock the pipeline — remove vim-minimal and upgrade KinD

### DIFF
--- a/Dockerfile.ubi9
+++ b/Dockerfile.ubi9
@@ -116,8 +116,11 @@ RUN curl -sSfLo /tmp/node_${NODE_MAJOR_VERSION}.tar.gz "https://nodejs.org/dist/
     mv /tmp/node_${NODE_MAJOR_VERSION}/${NODE_LATEST_VERSION}/bin/node /usr/local/bin && \
     rm -rf /tmp/node_${NODE_MAJOR_VERSION}.tar.gz /tmp/node_${NODE_MAJOR_VERSION}
 
+# vim-minimal ships in the ubi9 base image and carries high-severity advisories
+# with no fixed version available. Nothing in this image uses an editor, so drop it.
 RUN rpm -e --nodeps curl-minimal && \
-    rpm -e --nodeps libcurl-minimal
+    rpm -e --nodeps libcurl-minimal && \
+    rpm -e --nodeps vim-minimal
 
 # The `.config` directory is used by `snyk protect` and we also mount a K8s volume there at runtime.
 # This clashes with OpenShift 3 which mounts things differently and prevents access to the directory.

--- a/test/setup/platforms/kind.ts
+++ b/test/setup/platforms/kind.ts
@@ -8,7 +8,13 @@ const clusterName = 'kind';
 
 export async function setupTester(): Promise<void> {
   const osDistro = platform();
-  await download(osDistro, 'v0.11.1');
+  // v0.11.1 (2021) ships kindest/node:v1.21.1, whose kubelet ExecStartPre script
+  // refuses to run on a cgroup v2 host whose root cgroup has processes in it:
+  //   ERROR: this script needs /sys/fs/cgroup/cgroup.procs to be empty
+  //   (for writing the top-level cgroup.subtree_control)
+  // The kubelet then never starts, kubeadm times out waiting for the control plane,
+  // and cluster creation fails. CI runs cgroup v2, so this is no longer viable.
+  await download(osDistro, 'v0.32.0');
 }
 
 export async function createCluster(version: string): Promise<void> {


### PR DESCRIPTION
Fixes the two jobs currently failing on every PR. **Merge this before #1732.**

Two commits, two files, nothing else.

## 1. `build_image_ubi9` — `vim-minimal`

```
✖  SNYK-RHEL9-VIMMINIMAL-17712765
   Reason:   HIGH severity: 31 days since publication exceeds 30-day remediation SLA
   Package:  vim-minimal@2:8.2.2637-26.el9_8.13
   Fixed in: none
```

No fixed version exists, so it can't be upgraded away. `vim-minimal` comes from the `ubi9/ubi:9.8` base image and only provides an editor — the entrypoint is `dumb-init` → `bin/start` → `node`, with no `vi`/`vim`/`EDITOR` references anywhere in the repo. Removed with `rpm -e --nodeps`, matching the existing `curl-minimal` / `libcurl-minimal` lines.

Verified against `registry.access.redhat.com/ubi9/ubi:9.8`: `rpm -q --whatrequires vim-minimal` reports **no package requires it**, so `--nodeps` masks nothing. `build_image_ubi9` has since gone green four times with this change.

Also clears [17790082](https://security.snyk.io/vuln/SNYK-RHEL9-VIMMINIMAL-17790082) and [17816811](https://security.snyk.io/vuln/SNYK-RHEL9-VIMMINIMAL-17816811), which were reported but still inside their SLA window.

## 2. `system_tests` — KinD v0.11.1 → v0.32.0

The KinD cluster never came up. Captured from inside the node:

```
sh[378]: ERROR: this script needs /sys/fs/cgroup/cgroup.procs to be empty
         (for writing the top-level cgroup.subtree_control)
kubelet.service: Control process exited, code=exited, status=1/FAILURE
Failed to start kubelet: The Kubernetes Node Agent.
```

repeated until systemd gave up at restart counter 92. It's the node image's kubelet `ExecStartPre` script failing **before the kubelet binary runs** — `crictl ps -a` showed zero containers ever started, and kubeadm then timed out waiting for the control plane.

`v0.11.1` is from 2021 and pins `kindest/node:v1.21.1`, which predates cgroup v2 nesting support. The node's boot log reports `INFO: detected cgroup v2`, and the script can't write the top-level `subtree_control` while the host's root cgroup has processes in it.

This also explains why it looked non-deterministic: locally `/sys/fs/cgroup/cgroup.procs` is **empty**, so v0.11.1 still builds a cluster fine on a dev machine and only fails in CI.

Verified locally that v0.32.0 creates a cluster from this repo's `cluster-config.yaml` unchanged — `kind.x-k8s.io/v1alpha4` is still supported.

### Reviewer note

The node image moves from Kubernetes **1.21 → 1.36**. The cluster comes up, but that's a large jump and the system tests may need follow-up for removed APIs. The test also downloads kubectl "latest stable" (v1.31.0), so there's now version skew against the cluster. Worth a look if anything downstream misbehaves.

## Evidence it isn't caused by any PR

Two branches containing only a one-line README comment:

| PR | Base | `system_tests` |
|---|---|---|
| #1735 | `master` | passed |
| #1736 | `staging` | failed |

## Not included

An earlier attempt removed `docker_layer_caching` from the build jobs on a DLC-contention theory. That was wrong — `system_tests` failed identically with it — so it isn't here and #1730's caching is untouched.
