### PR TITLE
fix: unblock monthly staging → master merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,7 +325,7 @@ master_branch_only_filter:
 orbs:
   aws-cli: circleci/aws-cli@2.0.6
   azure-cli: circleci/azure-cli@1.2.0
-  prodsec: snyk/prodsec-orb@dev:2c981fab5b1c20d52b31daa641e67f959653c86f
+  prodsec: snyk/prodsec-orb@1
   slack: circleci/slack@4.12.5
 
 staging_branch_only_filter:

--- a/.snyk
+++ b/.snyk
@@ -13,4 +13,28 @@ ignore:
           rebuild. See https://access.redhat.com/security/cve/CVE-2026-47162
         expires: 2026-11-03T12:00:00.000Z
         created: 2026-08-03T12:00:00.000Z
+  SNYK-RHEL9-VIMMINIMAL-17790082:
+    - '*':
+        reason: >-
+          CVE-2026-55895 — Arbitrary code injection via a crafted filename
+          containing '|' in vim netrw. Upstream fixed in Vim 9.2.0663 but no
+          fix currently available for the RHEL 9 vim-minimal RPM (base image
+          ubi9:9.8). Exploitation requires interactive vim usage on an
+          attacker-controlled filename; vim is not on any kubernetes-monitor
+          code path. Re-evaluate on next UBI9 base rebuild.
+          See https://access.redhat.com/security/cve/CVE-2026-55895
+        expires: 2026-11-03T12:00:00.000Z
+        created: 2026-08-03T12:00:00.000Z
+  SNYK-RHEL9-VIMMINIMAL-17816811:
+    - '*':
+        reason: >-
+          CVE-2026-57456 — Arbitrary code injection via Python omni-completion
+          docstring breakout in vim. No fix currently available for the RHEL 9
+          vim-minimal RPM (base image ubi9:9.8). Exploitation requires
+          interactive vim usage with attacker-controlled Python source; vim is
+          not on any kubernetes-monitor code path. Re-evaluate on next UBI9
+          base rebuild.
+          See https://access.redhat.com/security/cve/CVE-2026-57456
+        expires: 2026-11-03T12:00:00.000Z
+        created: 2026-08-03T12:00:00.000Z
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,16 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore: {}
+ignore:
+  SNYK-RHEL9-VIMMINIMAL-17712765:
+    - '*':
+        reason: >-
+          CVE-2026-47162 — Vimscript code injection in vim netrw. Upstream
+          fixed in Vim 9.2.0495 but no fix currently available for the RHEL 9
+          vim-minimal RPM (base image ubi9:9.8). Exploitation requires a user
+          to open a crafted directory tree in interactive vim; vim is not on
+          any kubernetes-monitor code path. Re-evaluate on next UBI9 base
+          rebuild. See https://access.redhat.com/security/cve/CVE-2026-47162
+        expires: 2026-11-03T12:00:00.000Z
+        created: 2026-08-03T12:00:00.000Z
 patch: {}

--- a/test/setup/platforms/kind.ts
+++ b/test/setup/platforms/kind.ts
@@ -8,7 +8,7 @@ const clusterName = 'kind';
 
 export async function setupTester(): Promise<void> {
   const osDistro = platform();
-  await download(osDistro, 'v0.11.1');
+  await download(osDistro, 'v0.24.0');
 }
 
 export async function createCluster(version: string): Promise<void> {


### PR DESCRIPTION
- [x] Tests written and linted — same three fixes already validated on PR #1738 (all CI green there before the push flow got stuck).
- [x] Documentation written — no documentation changes.
- [x] Commit history is tidy — four focused commits, one per root cause.

### What this does

Backports the four fixes needed to unblock the monthly `staging → master` promotion (PR #1738) onto `staging` itself, so future monthly merges start from a green base.

1. `chore(snyk): ignore SNYK-RHEL9-VIMMINIMAL-17712765` — CVE-2026-47162, no RHEL 9 fix.
2. `fix(test): bump kind to v0.24.0` — KinD v0.11.1's kubelet doesn't handle cgroups v2, breaking `system_tests` on modern CircleCI machine images.
3. `fix(ci): repin prodsec-orb to @1` — the `@dev:2c981fab...` pin got garbage-collected by CircleCI, causing new pipelines to `errored` with zero workflows. `@1` matches every other Snyk repo.
4. `chore(snyk): ignore two more vim-minimal vulns` — CVE-2026-55895 and CVE-2026-57456, both unfixed in RHEL 9. Both surfaced as blockers alongside `-17712765`.

### Notes for the reviewer

All four changes were already validated on PR #1738 where the full `PR_TO_STAGING` workflow ran green (pipeline 7281) — same commits, cherry-picked here onto staging.

### Screenshots

N/A