### PR TITLE
chore: monthly staging → master merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,7 +325,7 @@ master_branch_only_filter:
 orbs:
   aws-cli: circleci/aws-cli@2.0.6
   azure-cli: circleci/azure-cli@1.2.0
-  prodsec: snyk/prodsec-orb@dev:2c981fab5b1c20d52b31daa641e67f959653c86f
+  prodsec: snyk/prodsec-orb@1
   slack: circleci/slack@4.12.5
 
 staging_branch_only_filter:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,40 +94,69 @@ jobs:
           mode: auto
           release-branch: master
           open-source-additional-arguments: --exclude=test
-  build_image:
-    docker:
-      - image: cimg/base:current
+  # The alpine and ubi9 images share no build stages, so they build, scan and push
+  # as two independent jobs. Both run on a machine executor rather than a docker
+  # executor plus setup_remote_docker: that avoids shipping the build context to a
+  # separate VM, lets docker_layer_caching reuse the gcloud SDK, skopeo, Node and
+  # credential-helper layers between runs, and lets resource_class apply to the build
+  # itself. `system_tests` already uses this executor.
+  build_image_alpine:
+    machine:
+      docker_layer_caching: true
+      image: default
+    resource_class: large
+    environment:
+      DOCKER_BUILDKIT: 1
     steps:
       - checkout
-      - setup_remote_docker
       - run:
           command: |
             IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
             IMAGE_NAME_CANDIDATE=snyk/kubernetes-monitor:${IMAGE_TAG}-${CIRCLE_SHA1}
-            IMAGE_NAME_CANDIDATE_UBI9=snyk/kubernetes-monitor:${IMAGE_TAG}-ubi9-${CIRCLE_SHA1:0:8}
             echo "export IMAGE_NAME_CANDIDATE=$IMAGE_NAME_CANDIDATE" >> $BASH_ENV
-            echo "export IMAGE_NAME_CANDIDATE_UBI9=$IMAGE_NAME_CANDIDATE_UBI9" >> $BASH_ENV
           name: Export environment variables
       - run:
           command: |
             docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASS}
             ./scripts/docker/build-image.sh ${IMAGE_NAME_CANDIDATE}
-            ./scripts/docker/build-image-ubi9.sh ${IMAGE_NAME_CANDIDATE_UBI9}
           name: Build image
       - prodsec/container_scan:
           mode: gate
           docker-image-name: ${IMAGE_NAME_CANDIDATE}
           docker-file: Dockerfile
           project-name: alpine
+      - run:
+          command: docker push ${IMAGE_NAME_CANDIDATE}
+          name: Push image
+      - notify_slack_on_failure
+    working_directory: ~/kubernetes-monitor
+  build_image_ubi9:
+    machine:
+      docker_layer_caching: true
+      image: default
+    resource_class: large
+    environment:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - checkout
+      - run:
+          command: |
+            IMAGE_TAG=$([[ "$CIRCLE_BRANCH" == "staging" ]] && echo "staging-candidate" || echo "discardable")
+            IMAGE_NAME_CANDIDATE_UBI9=snyk/kubernetes-monitor:${IMAGE_TAG}-ubi9-${CIRCLE_SHA1:0:8}
+            echo "export IMAGE_NAME_CANDIDATE_UBI9=$IMAGE_NAME_CANDIDATE_UBI9" >> $BASH_ENV
+          name: Export environment variables
+      - run:
+          command: |
+            docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASS}
+            ./scripts/docker/build-image-ubi9.sh ${IMAGE_NAME_CANDIDATE_UBI9}
+          name: Build image
       - prodsec/container_scan:
           mode: gate
           docker-image-name: ${IMAGE_NAME_CANDIDATE_UBI9}
           docker-file: Dockerfile.ubi9
           project-name: ubi9
       - run:
-          command: |
-            docker push ${IMAGE_NAME_CANDIDATE}
-            docker push ${IMAGE_NAME_CANDIDATE_UBI9}
+          command: docker push ${IMAGE_NAME_CANDIDATE_UBI9}
           name: Push image
       - notify_slack_on_failure
     working_directory: ~/kubernetes-monitor
@@ -344,7 +373,18 @@ workflows:
             - publish
   MERGE_TO_STAGING:
     jobs:
-      - build_image:
+      - build_image_alpine:
+          context:
+            - infrasec_container
+            - go-private-modules
+            - snyk-bot-slack
+            - team-container-integration-docker-hub
+            - prodsec-orb-runtime
+          filters:
+            branches:
+              only:
+                - staging
+      - build_image_ubi9:
           context:
             - infrasec_container
             - go-private-modules
@@ -381,7 +421,8 @@ workflows:
               only:
                 - staging
           requires:
-            - build_image
+            - build_image_alpine
+            - build_image_ubi9
             - unit_tests
             - system_tests
       - prepare_to_deploy:
@@ -421,7 +462,22 @@ workflows:
               ignore:
                 - staging
                 - master
-      - build_image:
+      - build_image_alpine:
+          context:
+            - infrasec_container
+            - go-private-modules
+            - snyk-bot-slack
+            - team-container-integration-docker-hub
+            - prodsec-orb-runtime
+          requires:
+            - Scan repository for secrets
+            - Security Scans
+          filters:
+            branches:
+              ignore:
+                - staging
+                - master
+      - build_image_ubi9:
           context:
             - infrasec_container
             - go-private-modules

--- a/.snyk
+++ b/.snyk
@@ -13,4 +13,28 @@ ignore:
           rebuild. See https://access.redhat.com/security/cve/CVE-2026-47162
         expires: 2026-11-03T12:00:00.000Z
         created: 2026-08-03T12:00:00.000Z
+  SNYK-RHEL9-VIMMINIMAL-17790082:
+    - '*':
+        reason: >-
+          CVE-2026-55895 — Arbitrary code injection via a crafted filename
+          containing '|' in vim netrw. Upstream fixed in Vim 9.2.0663 but no
+          fix currently available for the RHEL 9 vim-minimal RPM (base image
+          ubi9:9.8). Exploitation requires interactive vim usage on an
+          attacker-controlled filename; vim is not on any kubernetes-monitor
+          code path. Re-evaluate on next UBI9 base rebuild.
+          See https://access.redhat.com/security/cve/CVE-2026-55895
+        expires: 2026-11-03T12:00:00.000Z
+        created: 2026-08-03T12:00:00.000Z
+  SNYK-RHEL9-VIMMINIMAL-17816811:
+    - '*':
+        reason: >-
+          CVE-2026-57456 — Arbitrary code injection via Python omni-completion
+          docstring breakout in vim. No fix currently available for the RHEL 9
+          vim-minimal RPM (base image ubi9:9.8). Exploitation requires
+          interactive vim usage with attacker-controlled Python source; vim is
+          not on any kubernetes-monitor code path. Re-evaluate on next UBI9
+          base rebuild.
+          See https://access.redhat.com/security/cve/CVE-2026-57456
+        expires: 2026-11-03T12:00:00.000Z
+        created: 2026-08-03T12:00:00.000Z
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,16 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore: {}
+ignore:
+  SNYK-RHEL9-VIMMINIMAL-17712765:
+    - '*':
+        reason: >-
+          CVE-2026-47162 — Vimscript code injection in vim netrw. Upstream
+          fixed in Vim 9.2.0495 but no fix currently available for the RHEL 9
+          vim-minimal RPM (base image ubi9:9.8). Exploitation requires a user
+          to open a crafted directory tree in interactive vim; vim is not on
+          any kubernetes-monitor code path. Re-evaluate on next UBI9 base
+          rebuild. See https://access.redhat.com/security/cve/CVE-2026-47162
+        expires: 2026-11-03T12:00:00.000Z
+        created: 2026-08-03T12:00:00.000Z
 patch: {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,9 +82,14 @@ RUN mkdir -p .config
 
 # --include=dev is required despite NODE_ENV=production above: tsc and @types/* are
 # devDependencies and `npm run build` below needs them. They are pruned again after the build.
+# The cache mount keeps the npm tarball cache across builds so a package-lock.json change
+# re-resolves from local disk instead of re-downloading the whole tree. It is a BuildKit cache
+# mount, so it is never part of the resulting image. uid/gid match the snyk user, which is who
+# runs npm here.
 RUN --mount=type=secret,id=npm_token,uid=10001 \
+    --mount=type=cache,target=/tmp/npm-cache,uid=10001,gid=10001 \
     echo "//registry.npmjs.org/:_authToken=$(cat /run/secrets/npm_token)" > ~/.npmrc && \
-    npm ci --include=dev && \
+    npm ci --include=dev --cache /tmp/npm-cache && \
     rm -f ~/.npmrc
 
 # add the rest of the app files

--- a/Dockerfile.ubi9
+++ b/Dockerfile.ubi9
@@ -24,9 +24,14 @@ COPY --chown=1001:1001 package.json package-lock.json ./
 
 # --include=dev is required despite NODE_ENV=production above: tsc and @types/* are
 # devDependencies and `npm run build` below needs them. They are pruned again after the build.
+# The cache mount keeps the npm tarball cache across builds so a package-lock.json change
+# re-resolves from local disk instead of re-downloading the whole tree. It is a BuildKit cache
+# mount, so it is never part of the resulting image. uid/gid match the default user of the
+# ubi9/nodejs-22 image, which is who runs npm here.
 RUN --mount=type=secret,id=npm_token,uid=1001 \
+    --mount=type=cache,target=/tmp/npm-cache,uid=1001,gid=0 \
     echo "//registry.npmjs.org/:_authToken=$(cat /run/secrets/npm_token)" > ~/.npmrc && \
-    npm ci --include=dev && \
+    npm ci --include=dev --cache /tmp/npm-cache && \
     rm -f ~/.npmrc
 
 # add the rest of the app files

--- a/scripts/docker/build-image-ubi9.sh
+++ b/scripts/docker/build-image-ubi9.sh
@@ -14,9 +14,10 @@ NAME_AND_TAG=${1:-$LOCAL_DISCARDABLE_IMAGE}
 # This step gets the latest version of node 22 from node.js. It removes the .tar.gz extension and then returns the result.
 # It is used when buidling the ubi image in order to download the latest node 22 version and copy its binary.
 NODE_MAJOR_VERSION=22
-NODE_LATEST_VERSION_TAR_GZ_FILE=$(curl -L --fail --silent https://nodejs.org/dist/latest-v${NODE_MAJOR_VERSION}.x/SHASUMS256.txt | grep linux-x64.tar.gz | awk '{ print $2 }')
+NODE_SHASUMS_LINE=$(curl -L --fail --silent https://nodejs.org/dist/latest-v${NODE_MAJOR_VERSION}.x/SHASUMS256.txt | grep linux-x64.tar.gz)
+NODE_LATEST_VERSION_TAR_GZ_FILE=$(echo "${NODE_SHASUMS_LINE}" | awk '{ print $2 }')
 NODE_LATEST_VERSION="${NODE_LATEST_VERSION_TAR_GZ_FILE%%.tar.gz}"
-NODE_LATEST_VERSION_TAR_GZ_FILE_SHASUM256=$(curl -L --fail --silent https://nodejs.org/dist/latest-v${NODE_MAJOR_VERSION}.x/SHASUMS256.txt | grep linux-x64.tar.gz | awk '{ print $1 }')
+NODE_LATEST_VERSION_TAR_GZ_FILE_SHASUM256=$(echo "${NODE_SHASUMS_LINE}" | awk '{ print $1 }')
 
 docker build \
   --build-arg NODE_LATEST_VERSION="${NODE_LATEST_VERSION}" \

--- a/test/setup/platforms/kind.ts
+++ b/test/setup/platforms/kind.ts
@@ -8,7 +8,7 @@ const clusterName = 'kind';
 
 export async function setupTester(): Promise<void> {
   const osDistro = platform();
-  await download(osDistro, 'v0.11.1');
+  await download(osDistro, 'v0.24.0');
 }
 
 export async function createCluster(version: string): Promise<void> {


### PR DESCRIPTION
- [x] Tests written and linted — full `PR_TO_STAGING` workflow already ran green on PR #1739 (same tree).
- [x] Documentation written — no documentation changes; this is the monthly promotion.
- [x] Commit history is tidy — replays `staging` as-is.

### What this does

Monthly promotion PR to merge `staging` into `master` for `snyk/kubernetes-monitor`.

Flow docs: https://snyksec.atlassian.net/wiki/spaces/CONTAINER/pages/3839426717/

Includes four blocker fixes landed on `staging` via PR #1739 that the earlier attempt at this promotion (PR #1738) needed:
- `.snyk` ignores for three unfixed RHEL 9 vim-minimal CVEs (CVE-2026-47162 / -55895 / -57456).
- KinD test bump `v0.11.1 → v0.24.0` so `system_tests` runs on cgroups-v2 hosts.
- Prodsec-orb repin from a garbage-collected `@dev:` SHA back to `@1` (matching the rest of the org).

### Notes for the reviewer

Please merge with a regular merge commit (not squash and not rebase) so the semantic-release tag commit from `staging` lands as-is and the production publish flow can resolve the version from the tag.

Supersedes PR #1738.

### Screenshots

N/A