### PR TITLE
fix(security): address Snyk vulnerability alerts

### DIFF
--- a/Dockerfile.ubi9
+++ b/Dockerfile.ubi9
@@ -5,11 +5,11 @@ ARG UBI9_VERSION=9.8
 #---------------------------------------------------------------------
 FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset:${UBI9_VERSION} as cred-helpers-build
 
-RUN GOTOOLCHAIN=go1.23.4 go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@bef5bd9384b752e5c645659165746d5af23a098a
+RUN GOTOOLCHAIN=go1.25.12 go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@bef5bd9384b752e5c645659165746d5af23a098a
 RUN --mount=type=secret,id=gh_token,uid=1001,required=true \
     git config --global url."https://$(cat /run/secrets/gh_token):x-oauth-basic@github.com/snyk".insteadOf "https://github.com/snyk" && \
     go env -w GOPRIVATE=github.com/snyk && \
-    GOTOOLCHAIN=go1.23.4 go install github.com/snyk/docker-credential-acr-env@62fbee8398a22171cb0f628400a29b2ebaed7a3a && \
+    GOTOOLCHAIN=go1.25.12 go install github.com/snyk/docker-credential-acr-env@62fbee8398a22171cb0f628400a29b2ebaed7a3a && \
     git config --global --unset url."https://$(cat /run/secrets/gh_token):x-oauth-basic@github.com/snyk".insteadOf
 
 #---------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1940,6 +1940,28 @@
         "openid-client": "^6.1.3"
       }
     },
+    "node_modules/@kubernetes/client-node/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -6770,6 +6792,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
       "tough-cookie": "4.1.3",
       "form-data": "2.5.6",
       "qs": "^6.15.2",
-      "js-yaml": "^4.3.0"
+      "js-yaml": "^4.3.1"
     },
     "cross-spawn": "^7.0.5",
     "minimatch": "^10.2.3",


### PR DESCRIPTION
Two security fixes: one npm override bump and one Go toolchain pin that had gone stale.

### js-yaml

`@kubernetes/client-node` > `js-yaml` goes from ^4.3.0 to ^4.3.1, which is the version that fixes [SNYK-JS-JSYAML-18593780](https://security.snyk.io/vuln/SNYK-JS-JSYAML-18593780), an inefficient algorithmic complexity issue. The override stays scoped under `@kubernetes/client-node` and pinned to major 4, matching the shape of the existing block, so the js-yaml 3.x and 5.x copies elsewhere in the tree keep resolving on their own lines.

`snyk test --severity-threshold=high` reports 1 finding before this change and 0 after.

The `brace-expansion` alert from Aug 4 needs no action. The existing override already holds it at ^5.0.9, which is the fixed version.

### Go toolchain in the UBI9 image

`Dockerfile.ubi9` built `docker-credential-ecr-login` and `docker-credential-acr-env` with `GOTOOLCHAIN=go1.23.4`. The 1.23 line is past upstream support, so every Go stdlib fix released since 1.23.4 was compiled out of both binaries we ship. Nothing in `snyk test` catches this, because the vulnerable code is the compiler's standard library rather than a declared dependency.

The pin now reads `go1.25.12`, the current patch of the 1.25 line. That is the same version line the alpine `Dockerfile` already builds these helpers with through `golang:1.25-alpine3.24`, so both images now agree instead of drifting two minor versions apart.

Nothing else in the repo needs a Go bump. The alpine tag floats to the newest 1.25 patch on rebuild.

### Verification

I regenerated the lockfile with npm 10.9.2, which ships in the `cimg/node:22.15` image CI uses, then validated it with `npm ci` in a clean directory holding only `package.json` and `package-lock.json`. CI covers the UBI9 image build, which is what exercises the new toolchain pin.

### Where these came from

The npm alerts landed in [#snyk-vuln-alerts-container](https://snyk.enterprise.slack.com/archives/C08JELSU78W) on Aug 4 and Aug 8 against [this Snyk project](https://app.snyk.io/org/infrasec_container/project/2aeb7fa3-43de-4fff-92bf-191d732e2395). The js-yaml alert said `Fixable: No`, but 4.3.1 sits inside the declared range on staging, so the flag was stale.