### PR TITLE
fix(deps): update snyk-docker-plugin to 9.20.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "packageurl-js": "^1.2.1",
         "sleep-promise": "^9.1.0",
         "snyk-config": "5.3.0",
-        "snyk-docker-plugin": "^9.20.0",
+        "snyk-docker-plugin": "^9.20.1",
         "source-map-support": "^0.5.21",
         "tunnel": "0.0.6",
         "typescript": "4.9.5",
@@ -8646,9 +8646,9 @@
       }
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.20.0.tgz",
-      "integrity": "sha512-wzvEK7aO7od4/bp1ZXivQzzMJNRYSX9s3DY+sCB5wCw/MVx93R2fNcTqXt3HtObJYPSUtEm5pA8nYVSG77NqYw==",
+      "version": "9.20.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.20.1.tgz",
+      "integrity": "sha512-X65RtGD51TBwaUC9ZYXAfdhWg0q5p+fSwREMmoiJnbTkWhazWhSRi/ru2dH1MllsHO9FrRCIoUXpLkfivFHuvg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
@@ -8670,7 +8670,7 @@
         "packageurl-js": "1.2.0",
         "semver": "^7.7.3",
         "shescape": "^2.1.14",
-        "snyk-nodejs-lockfile-parser": "^2.7.0",
+        "snyk-nodejs-lockfile-parser": "^2.10.3",
         "snyk-poetry-lockfile-parser": "1.9.1",
         "snyk-resolve-deps": "^4.9.1",
         "tar-stream": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "packageurl-js": "^1.2.1",
     "sleep-promise": "^9.1.0",
     "snyk-config": "5.3.0",
-    "snyk-docker-plugin": "^9.20.0",
+    "snyk-docker-plugin": "^9.20.1",
     "source-map-support": "^0.5.21",
     "tunnel": "0.0.6",
     "typescript": "4.9.5",


### PR DESCRIPTION
### What this does

Moves `snyk-docker-plugin` from `^9.20.0` to `^9.20.1`, the current release, and refreshes `package-lock.json` to match.

The declared range already allowed 9.20.1, but the lockfile was pinning 9.20.0, so installs were not picking it up. This makes both the range and the resolved version explicit.

Part of a sweep to get the container team's repos onto one `snyk-docker-plugin` version. No breaking changes, so no application code changes.

### Notes for the reviewer

Only `package.json` and `package-lock.json` change, and the lockfile diff is 5 lines either way. This is the smallest change of the sweep.

Base branch is `staging` rather than `main`, matching this repo's default.

### More information

- Jira ticket: https://snyksec.atlassian.net/browse/CN-1563