### PR TITLE
chore: retag team ownership to sca-scanners [CMPA-724]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
     steps:
       - slack/notify:
           branch_pattern: master,staging
-          channel: team-container-pipeline-info
+          channel: team-sca-scanners-alerts
           event: fail
           #   mentions: '@testenrichers'
           custom: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,7 +445,7 @@ workflows:
           context:
             - snyk-bot-slack
             - prodsec-orb-runtime
-          channel: snyk-vuln-alerts-sca
+          channel: snyk-on-snyk_sca-scanners
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,7 +445,7 @@ workflows:
           context:
             - snyk-bot-slack
             - prodsec-orb-runtime
-          channel: snyk-on-snyk-infrasec_container
+          channel: snyk-vuln-alerts-sca
           filters:
             branches:
               ignore:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/container_container
+* @snyk/engines_sca-scanners

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,8 +4,8 @@ metadata:
   name: kubernetes-monitor
   annotations:
     github.com/project-slug: snyk/kubernetes-monitor
-    github.com/team-slug: snyk/infrasec_container
+    github.com/team-slug: snyk/engines_sca-scanners
 spec:
   type: snyk-deployed-prod
   lifecycle: "-"
-  owner: container
+  owner: sca-scanners


### PR DESCRIPTION
### Prerequisites (done)

The Container team's Event Bus resources take `.spec.owner` from the Polaris owner, which ArgoCD
injects from `catalog-info.yaml`, so retagging makes them present as `sca-scanners`. Every
cross-team grant naming `container` now lists the new name alongside it. All six are merged and
deployed: snyk/enso-agent#454, snyk/apprisk-streams#500, snyk/runtime-entities-service#966,
snyk/workspace-service#2805, snyk/test-service#1652, snyk/event-bus#3661.

### What?

Transfers ownership to `@snyk/engines_sca-scanners`:

- `.github/CODEOWNERS` — container team → `@snyk/engines_sca-scanners`
- `catalog-info.yaml` — `owner` → `sca-scanners`, `github.com/team-slug` → `snyk/engines_sca-scanners`
- `helm/**` — `owner` / `snykowner` / `snyk.io/owner` / `team` → `sca-scanners`, wherever they name the container team (including `helm/values/` overrides and `helm/templates/`, which become pod labels and annotations)
- `.circleci/config.yml` — context → `engines_sca-scanners`, unless the repo needs a Circle PAT
- Slack alert destinations → `@slack-team-sca-scanners-alerts`
- prunes stale `catalog-info` entries (`snyk.io/jira-prefix` and its doc comment, ask-channel links, Notion links, Datadog links naming a retired team, `pagerduty.com/service-id`)

Note the two naming conventions: only **GitHub and CircleCI** carry the `engines_` prefix, so
Polaris and Backstage values are the bare `sca-scanners` — that is the string FireHydrant's CEL
matches on.

### Why?

Per [#tmp-container-oncall-transition](https://snyk.slack.com/archives/C0BQWGAB2CS), Container's
services are transferring to `@snyk/engines_sca-scanners`, with `container-image-collector` going
to Intelligence Engineering instead (that repo is deliberately excluded from this wave).

**Paging is already safe.** The FireHydrant cutover is live: the OS Managed rule matches
`team == 'container' && service != 'container-image-collector'` **and** `team == 'sca-scanners'`,
so alerts land on the same rota before and after this merge.

### Follow-ups

- Drop the `team == 'container'` clause from the OS Managed CEL once nothing reports as `container`.
- Remove `container` from the Event Bus grant lists at the same point.

---

> [!NOTE]
> **Medium Risk**
> Changes this service's team identity. Paging is unaffected (both names route to the OS Managed
> rota) and the Event Bus grants above are already in place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes service team identity and CI alert destinations; runtime behavior is unchanged but ownership, reviews, and who sees failures depend on the new team labels and channels.
> 
> **Overview**
> Transfers **kubernetes-monitor** from Container to **SCA Scanners** in repo metadata and alert routing.
> 
> **CODEOWNERS** now points default review at `@snyk/engines_sca-scanners`. **catalog-info.yaml** updates Backstage/Polaris identity: `spec.owner` is `sca-scanners` and `github.com/team-slug` is `snyk/engines_sca-scanners` (bare `sca-scanners` for Polaris/FireHydrant-style matching).
> 
> **CircleCI** retargets Slack only: pipeline failure notifications go to `team-sca-scanners-alerts` instead of `team-container-pipeline-info`, and the PR secrets-scan job posts to `snyk-on-snyk_sca-scanners` instead of `snyk-on-snyk-infrasec_container`. Workflow **contexts** (e.g. `infrasec_container`) are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f023162b4d67db27fc0f6f2183ed1b6dc1eb020d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->